### PR TITLE
Update CONTRIBUTING.md with licensing information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,12 @@ Translators should only translate the `title:` field, and change the language co
 Notice the remaining fields are left untranslated, however in Transifiex, you must copy these fields as translations (without actually translating them).
 
 Please note that [translations.yml](https://github.com/bitcoin-core/website/blob/gh-pages/_data/translations.yml) and [navigation.yml](https://github.com/bitcoin-core/website/blob/gh-pages/_data/navigation.yml) should be translated and submitted as normal pull-requests because they are not compatible with Transifex at this time.
+
+## License
+
+The code and documentation of this website are licensed under [MIT license][MIT] and all contributors agree to irrevocably license their contributions under the same license.
+
+Unless specified in the header of the file, the website content in `_posts/` of this website is licensed under the Creative Commons Attribution-ShareAlike 4.0 International License: [CC-BY-SA] and all contributors agree to irrevocably license their content under the same license.
+
+[MIT]: https://github.com/bitcoin-core/website/blob/gh-pages/LICENSE
+[CC-BY-SA]: http://creativecommons.org/licenses/by-sa/4.0/


### PR DESCRIPTION
Code and documentation that make this website are licensed under MIT
Content published on the website suggested [CC-by-SA](http://creativecommons.org/licenses/by-sa/4.0/) which is the most permissive version.

#8