### PR TITLE
Use full width (reduce right margin to 12/0.5)

### DIFF
--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -239,12 +239,12 @@ $button-size: 1.5rem;
 		@include suffix(12,1);
 		margin-bottom: 2em;
 		@media #{$small} {
-			@include grid(12,6);
+			@include grid(12,8.5);
 			@include prefix(12,0);
-			@include suffix(12,0);
+			@include suffix(12,0.5);
 		}
 		@media #{$x-large} {
-			@include grid(12,4.5);
+			@include grid(12,7);
 		}
 	}
 }
@@ -257,9 +257,9 @@ $button-size: 1.5rem;
 	@include suffix(12,1);
 	margin-bottom: 2em;
 	@media #{$small} {
-		@include grid(12,6);
+		@include grid(12,8.5);
 		@include prefix(12,0);
-		@include suffix(12,0);
+		@include suffix(12,0.5);
 	}
 	@media #{$x-large} {
 		@include grid(12,4.5);
@@ -658,9 +658,9 @@ $button-size: 1.5rem;
 		@include prefix(12,1);
 		@include suffix(12,1);
 		@media #{$small} {
-			@include grid(12,6);
+			@include grid(12,8.5);
 			@include prefix(12,3);
-			@include suffix(12,3);
+			@include suffix(12,0.5);
 		}
 		@media #{$x-large} {
 			@include grid(12,4.5);


### PR DESCRIPTION
IMO using the full page with makes things more readable.

Before:
![bildschirmfoto 2016-01-13 um 21 55 45](https://cloud.githubusercontent.com/assets/178464/12307584/7efa0072-ba40-11e5-889d-74ee48775da9.png)

After:
![bildschirmfoto 2016-01-13 um 21 56 01](https://cloud.githubusercontent.com/assets/178464/12307588/81e55d2c-ba40-11e5-99d2-a4fba97c908a.png)
