### PR TITLE
[WIP] Add supporters structure in footer and as a separated page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,6 +6,9 @@ en:
   about:
     title: "About"
     url:   "/en/about/"
+  supporters:
+    title: "Supporters"
+    url:   "/en/supporters/"
   blog:
     title: "blog"
     url:   "/en/blog/"

--- a/_includes/_supporters_full.html
+++ b/_includes/_supporters_full.html
@@ -1,0 +1,31 @@
+<div class="show-your-support">
+  <h3>Show your support</h3>
+  <p>
+      <a href="https://github.com/bitcoin-core/website/issues/50" target="_blank" class=""><i class="fa fa-fw fa-github"></i>Github</a>
+      <a href="http://twitter.com/home?status=I support %23bitcoincore - Find out more at https://bitcoincore.org" target="_blank" class=""><i class="fa fa-fw fa-twitter"></i>Twitter</a>
+  </p>
+  <div>
+      <h3>Developers</h3>
+      <ul>
+          <li>Jonas Schnelli</li>
+      </ul>
+  </div>
+  <div>
+      <h3>Companies</h3>
+      <ul>
+          <li>A Company</li>
+      </ul>
+  </div>
+  <div>
+      <h3>Miners</h3>
+      <ul>
+          <li>Some Miners</li>
+      </ul>
+  </div>
+  <div>
+      <h3>Users</h3>
+      <ul>
+          <li>Some Users</li>
+      </ul>
+  </div>
+</div>

--- a/_includes/_supporters_short.html
+++ b/_includes/_supporters_short.html
@@ -1,0 +1,33 @@
+<div class="show-your-support show-your-support-small">
+  <h3>Show your support</h3>
+  <p>
+      <a href="https://github.com/bitcoin-core/website/issues/50" target="_blank" class=""><i class="fa fa-fw fa-github"></i>Github</a>
+      <a href="http://twitter.com/home?status=I support %23bitcoincore - Find out more at https://bitcoincore.org" target="_blank" class=""><i class="fa fa-fw fa-twitter"></i>Twitter</a>
+  </p>
+  <div>
+      <h4>Developers</h4>
+      <ul>
+          <li>Jonas Schnelli</li>
+          <li>Jonas Schnelli</li>
+      </ul>
+  </div>
+  <div>
+      <h4>Companies</h4>
+      <ul>
+          <li>A Company</li>
+      </ul>
+  </div>
+  <div>
+      <h4>Miners</h4>
+      <ul>
+          <li>Some Miners</li>
+      </ul>
+  </div>
+  <div>
+      <h4>Users</h4>
+      <ul>
+          <li>Some Users</li>
+          <li>Some Users</li>
+      </ul>
+  </div>
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -56,6 +56,7 @@
   <footer>
     {% include _footer.html %}
   </footer>
+  {% include _supporters_short.html %}
 </div><!-- /.footer-wrap -->
 
 {% include _scripts.html %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -46,6 +46,9 @@
   <footer>
     {% include _footer.html %}
   </footer>
+  {% if page.footer_show_supporters != false %}
+      {% include _supporters_short.html %}
+  {% endif %}
 </div><!-- /.footer-wrap -->
 
 {% include _scripts.html %}

--- a/_layouts/pagecopy.html
+++ b/_layouts/pagecopy.html
@@ -45,6 +45,9 @@
   <footer>
     {% include _footer.html %}
   </footer>
+  {% if page.footer_show_supporters != false %}
+      {% include _supporters_short.html %}
+  {% endif %}
 </div><!-- /.footer-wrap -->
 
 {% include _scripts.html %}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -60,6 +60,9 @@
   <footer>
     {% include _footer.html %}
   </footer>
+    {% if page.footer_show_supporters != false %}
+      {% include _supporters_short.html %}
+    {% endif %}
 </div><!-- /.footer-wrap -->
 
 {% include _scripts.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -56,6 +56,9 @@
   <footer>
     {% include _footer.html %}
   </footer>
+  {% if page.footer_show_supporters != false %}
+      {% include _supporters_short.html %}
+  {% endif %}
 </div><!-- /.footer-wrap -->
 
 {% include _scripts.html %}

--- a/_layouts/postcopy.html
+++ b/_layouts/postcopy.html
@@ -68,6 +68,9 @@
   <footer>
     {% include _footer.html %}
   </footer>
+  {% if page.footer_show_supporters != false %}
+      {% include _supporters_short.html %}
+  {% endif %}
 </div><!-- /.footer-wrap -->
 
 {% include _scripts.html %}

--- a/_posts/en/pages/2016-01-18-supporters.md
+++ b/_posts/en/pages/2016-01-18-supporters.md
@@ -1,0 +1,11 @@
+---
+title: Bitcoin Core Supporters
+name: supporters
+type: page
+permalink: /en/supporters
+share: false
+version: 1
+footer_show_supporters: false
+---
+
+{% include _supporters_full.html %}

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -765,7 +765,7 @@ li.lang:hover {
 	@include container;
 	@include clearfix;
 	clear: both;
-	padding-bottom: 3em;
+	padding-bottom: 1.5em;
 	a,
 	a:active,
 	a:visited,
@@ -904,4 +904,40 @@ li.lang:hover {
 }
 #goog-wm-sb {
 	@extend .btn;
+}
+
+
+/*
+Show your support page
+========================================================================== */
+.show-your-support,
+{
+	@include grid(12,10);
+	@include prefix(12,1);
+	@include suffix(12,1);
+	@include clearfix;
+	margin-bottom: 1em;
+	h2, h3, h4 {
+		margin-bottom: 0.3em;
+	}
+	text-align: center;
+  .fa {
+		margin-right: 5px;
+	}
+	div {
+		@media #{$small} {
+			@include grid(12,3);
+		}
+	}
+	ul {
+		margin: 0;
+		padding: 0;
+		clear: both;
+		list-style-type: none;
+	}
+}
+
+.show-your-support-small {
+	margin-top: 2em;
+	margin-bottom: 0em;
 }


### PR DESCRIPTION
Groundwork for supporters in footer and as a separated page.
Maybe needs to include some .md files to remove the actual content from the .html template.

@btcdrak interested to continue this?

<img width="1350" alt="bildschirmfoto 2016-01-18 um 11 27 51" src="https://cloud.githubusercontent.com/assets/178464/12389015/88ff8076-bdd6-11e5-8eba-c534d68b9bdb.png">