### PR TITLE
add rough date Q1 2017 to increase MAX_BLOCK_SIZE

### DIFF
--- a/_posts/en/posts/2015-12-23-capacity-increases-faq.md
+++ b/_posts/en/posts/2015-12-23-capacity-increases-faq.md
@@ -20,6 +20,7 @@ specific improvements described in the [roadmap][].
 | Mar 2016\* | 0.12.x | Deploy OP_CHECKSEQUENCEVERIFY (BIPs [68][BIP68] & [112][BIP112]) + [BIP113][] as first [BIP9][] versionbits soft fork |
 | April 2016\* |  0.12.x |  Deploy segregated witness |
 | 2016 | | Weak blocks, IBLTs, or both |
+| Q1 2017 | | Hardfork to increase MAX_BLOCK_SIZE (specific BIP TBD) |
 
 \* Dates with an asterisk are when we expect to release soft fork-ready code. The code will not be released until it has been well reviewed, and the actual fork will take time to activate ([BIP66][] activated in July 2015 after a few months; [BIP65][] activated in Dec 2015 after only 5 weeks).
 
@@ -56,6 +57,12 @@ specific improvements described in the [roadmap][].
   improvement is accomplished by spreading bandwidth usage out over time
   for full nodes, which means IBLT and weak blocks may allow for safer
   future increases to the max block size.
+
+- **Hardfork to increase MAX_BLOCK_SIZE:** at some point the capacity
+  increases from the above may not be enough. Delivery on relay improvements,
+  segwit fraud proofs, dynamic block size controls, and other advances in 
+  technology will reduce the risk and therefore controversy around moderate 
+  block size increase proposals (such as 2/4/8 rescaled to respect segwit's increase).
 
 ## Is the segregated witness soft fork equivalent to a 4MB block size increase, a 2MB increase, a 1.75MB increase, or what? I keep hearing different numbers.  {#segwit-size}
 

--- a/_posts/en/posts/2015-12-23-capacity-increases-faq.md
+++ b/_posts/en/posts/2015-12-23-capacity-increases-faq.md
@@ -20,7 +20,7 @@ specific improvements described in the [roadmap][].
 | Mar 2016\* | 0.12.x | Deploy OP_CHECKSEQUENCEVERIFY (BIPs [68][BIP68] & [112][BIP112]) + [BIP113][] as first [BIP9][] versionbits soft fork |
 | April 2016\* |  0.12.x |  Deploy segregated witness |
 | 2016 | | Weak blocks, IBLTs, or both |
-| Q1 2017 | | Hardfork to increase MAX_BLOCK_SIZE (specific BIP TBD) |
+| 2017 | | Hardfork to increase MAX_BLOCK_SIZE (specific BIP TBD) |
 
 \* Dates with an asterisk are when we expect to release soft fork-ready code. The code will not be released until it has been well reviewed, and the actual fork will take time to activate ([BIP66][] activated in July 2015 after a few months; [BIP65][] activated in Dec 2015 after only 5 weeks).
 


### PR DESCRIPTION
Hello,

I think it was a mistake to not add a date for the hardfork to the scaling roadmap. In my opinion
this is what most people are not happy about, because it could mean 2017, 2020 or 2035,
which is what caused the current situation that divides the bitcoin community.

The text I added is from the  "Capacity increases for the Bitcoin system" email:
https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-December/011865.html

From what I read most people want more or less the same, but they have different
timeframes for it. The classic guys want it right now, but core-devs want more time to deploy a HF.
It would send a sign that everyone is willing to work together and compromise to move bitcoin forward.
Downside is everyone has to re-ACK and translations have to be updated. Consider this a bugfix :)
