### PR TITLE
Add announcement list

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -54,6 +54,16 @@ en:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 de:
   home:
     title: "Bitcoin Core"
@@ -109,6 +119,16 @@ de:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 es:
   home:
     title: "Bitcoin Core"
@@ -164,6 +184,16 @@ es:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 fr:
   home:
     title: "Bitcoin Core"
@@ -219,6 +249,16 @@ fr:
       eol:
         title: "Cycle de vie"
         url:   "/fr/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 it:
   home:
     title: "Bitcoin Core"
@@ -274,6 +314,16 @@ it:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 ru:
   home:
     title: "Bitcoin Core"
@@ -329,6 +379,16 @@ ru:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 zh_CN:
   home:
     title: "Bitcoin Core"
@@ -384,6 +444,16 @@ zh_CN:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"
 zh_TW:
   home:
     title: "Bitcoin Core"
@@ -439,3 +509,13 @@ zh_TW:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"

--- a/_data/source_navigation.txt
+++ b/_data/source_navigation.txt
@@ -39,6 +39,9 @@ en:
       contribute:
         title: "contribute"
         url:   "/en/contribute"
+      contribute-code:
+        title: "contributing code"
+        url:   "/en/faq/contributing-code"
       segwit:
         title: "SegWit Adoption"
         url:   "/en/segwit_adoption"
@@ -51,3 +54,13 @@ en:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
+  contact:
+      title: "Contact"
+      submenu: true
+      tree:
+        contact_us:
+          title: "Contact Us"
+          url: "/en/contact"
+        announcements:
+          title: "Announcements"
+          url: "/en/list/announcements/join"

--- a/_includes/_references.md
+++ b/_includes/_references.md
@@ -37,3 +37,6 @@
 [BIP125]: https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki
 [BIP130]: https://github.com/bitcoin/bips/blob/master/bip-0130.mediawiki
 [BIP133]: https://github.com/bitcoin/bips/blob/master/bip-0133.mediawiki
+
+[@bitcoincoreorg]: https://twitter.com/bitcoincoreorg
+[Slack]: https://slack.bitcoincore.org/

--- a/_includes/_references.md
+++ b/_includes/_references.md
@@ -39,4 +39,10 @@
 [BIP133]: https://github.com/bitcoin/bips/blob/master/bip-0133.mediawiki
 
 [@bitcoincoreorg]: https://twitter.com/bitcoincoreorg
-[Slack]: https://slack.bitcoincore.org/
+[#bitcoin-core-dev]: https://webchat.freenode.net?channels=%23bitcoin-core-dev&uio=MTY9dHJ1ZSYxMT0yMTU87
+[issues]: https://github.com/bitcoin/bitcoin/issues
+[pulls]: https://github.com/bitcoin/bitcoin/pulls
+[bitcoin-discuss]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-discuss
+[bitcoin-dev]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev
+[Slack]: https://bitcoincore.slack.com/
+[slack-invite]: https://slack.bitcoincore.org/

--- a/_includes/pages/list/announcement.html
+++ b/_includes/pages/list/announcement.html
@@ -1,0 +1,7 @@
+<form action="https://sendy.bitcoincore.org/subscribe" method="POST" accept-charset="utf-8">
+    <label for="email">Email</label><br/>
+    <input type="text" name="email" id="email"/>
+    <br/>
+    <input type="hidden" name="list" value="NkAKeRXqqhq763VNq4wM8921SA"/>
+    <input type="submit" name="submit" id="submit"/>
+</form>

--- a/_includes/pages/list/announcement.html
+++ b/_includes/pages/list/announcement.html
@@ -1,7 +1,6 @@
-<form action="https://sendy.bitcoincore.org/subscribe" method="POST" accept-charset="utf-8">
-    <label for="email">Email</label><br/>
-    <input type="text" name="email" id="email"/>
-    <br/>
+<form action="https://sendy.bitcoincore.org/subscribe" method="POST" accept-charset="utf-8" id="mailregform">
     <input type="hidden" name="list" value="NkAKeRXqqhq763VNq4wM8921SA"/>
+
+    <input type="text" placeholder="Your email address" name="email" id="email"/>
     <input type="submit" name="submit" id="submit"/>
 </form>

--- a/_posts/en/pages/2016-03-12-contact.md
+++ b/_posts/en/pages/2016-03-12-contact.md
@@ -1,0 +1,15 @@
+---
+title: Contact Us
+name: contact
+permalink: /en/contact/
+type: pages
+layout: page
+lang: en
+share: false
+version: 1
+---
+You can find Bitcoin Core developers on [Slack][slack-invite] and [IRC][#bitcoin-core-dev].
+
+You can report bugs in our software using the [issue tracker][issues].
+
+{% include _references.md %}

--- a/_posts/en/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/en/pages/list/2016-03-10-announcements-join.md
@@ -12,12 +12,6 @@ Receive notification of important security announcements and releases for Bitcoi
 
 Enter your email address below:
 
-<form action="https://sendy.bitcoincore.org/subscribe" method="POST" accept-charset="utf-8">
-	<label for="email">Email</label><br/>
-	<input type="text" name="email" id="email"/>
-	<br/>
-	<input type="hidden" name="list" value="NkAKeRXqqhq763VNq4wM8921SA"/>
-	<input type="submit" name="submit" id="submit"/>
-</form>
+{% include pages/list/announcement.html %}
     
 Low traffic for announcements only.

--- a/_posts/en/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/en/pages/list/2016-03-10-announcements-join.md
@@ -1,7 +1,7 @@
 ---
 title: Subscribe to Bitcoin Core announcements
 name: announcements
-permalink: /en/list/announcements/join
+permalink: /en/list/announcements/join/
 type: pages
 layout: page
 lang: en

--- a/_posts/en/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/en/pages/list/2016-03-10-announcements-join.md
@@ -1,0 +1,23 @@
+---
+title: Subscribe to Bitcoin Core announcements
+name: announcements
+permalink: /en/list/announcements/join
+type: pages
+layout: page
+lang: en
+share: false
+version: 1
+---
+Receive notification of important security announcements and releases for Bitcoin Core.
+
+Enter your email address below:
+
+<form action="https://sendy.bitcoincore.org/subscribe" method="POST" accept-charset="utf-8">
+	<label for="email">Email</label><br/>
+	<input type="text" name="email" id="email"/>
+	<br/>
+	<input type="hidden" name="list" value="NkAKeRXqqhq763VNq4wM8921SA"/>
+	<input type="submit" name="submit" id="submit"/>
+</form>
+    
+Low traffic for announcements only.

--- a/_posts/en/posts/2016-03-12-announcelist.md
+++ b/_posts/en/posts/2016-03-12-announcelist.md
@@ -1,0 +1,17 @@
+---
+title: Keep updated!
+permalink: /en/2016/03/12/announcement-list/
+lang: en
+id: en-announce-list
+name: announce-list
+tags: [bitcoin, bitcoin core, announcement list, updates]
+version: 1
+---
+In an effort to increase communications, we are launching an opt-in, _announcement-only_ mailing-list for users of Bitcoin Core to receive notifications of security issues and new releases.
+
+While the Bitcoin Core project has a variety of communication channels, this website, Twitter [@bitcoincoreorg][], [Slack][] there have been a number of requests for this an [announcement mailing list](/en/list/announcements/join). It is intended to be extremely low volume, focused on critical notifications as well as to announce new releases.
+
+To subscribe, enter your email address below:
+
+{% include pages/list/announcement.html %}
+{% include _references.md %}

--- a/_posts/en/posts/2016-03-12-announcelist.md
+++ b/_posts/en/posts/2016-03-12-announcelist.md
@@ -9,7 +9,7 @@ version: 1
 ---
 In an effort to increase communications, we are launching an opt-in, _announcement-only_ mailing-list for users of Bitcoin Core to receive notifications of security issues and new releases.
 
-While the Bitcoin Core project has a variety of communication channels, this website, Twitter [@bitcoincoreorg][], [Slack][] there have been a number of requests for this an [announcement mailing list](/en/list/announcements/join). It is intended to be extremely low volume, focused on critical notifications as well as to announce new releases.
+While the Bitcoin Core project has a variety of communication channels, this website, Twitter [@bitcoincoreorg][], [Slack][] there have been a number of requests for an [announcement mailing list](/en/list/announcements/join). It is intended to be extremely low volume, focused on critical notifications as well as to announce new releases.
 
 To subscribe, enter your email address below:
 

--- a/_posts/en/posts/2016-03-15-announcelist.md
+++ b/_posts/en/posts/2016-03-15-announcelist.md
@@ -1,6 +1,6 @@
 ---
 title: Keep updated!
-permalink: /en/2016/03/12/announcement-list/
+permalink: /en/2016/03/15/announcement-list/
 lang: en
 id: en-announce-list
 name: announce-list

--- a/_posts/misc/list/announcements/2016-03-10-check.md
+++ b/_posts/misc/list/announcements/2016-03-10-check.md
@@ -1,0 +1,11 @@
+---
+title: Please check your email
+permalink: /list/announcements/check
+type:
+layout: page
+lang: en
+share: false
+robots_exclude: true
+sitemap_exlude: true
+---
+We have sent you an email to confirm your subscription to the Bitcoin Core announcements list.

--- a/_posts/misc/list/announcements/2016-03-10-confirmed.md
+++ b/_posts/misc/list/announcements/2016-03-10-confirmed.md
@@ -1,0 +1,13 @@
+---
+title: Confirmation Success
+permalink: /list/announcements/confirmed
+type:
+layout: page
+lang: en
+share: false
+robots_exclude: true
+sitemap_exlude: true
+---
+You have successfully subscribed to the Bitcoin Core announcement list.
+
+You will only receive security and new release announcements.

--- a/_posts/misc/list/announcements/2016-03-10-unsub.md
+++ b/_posts/misc/list/announcements/2016-03-10-unsub.md
@@ -1,0 +1,11 @@
+---
+title: Unsubscribed
+permalink: /list/announcements/unsub
+type:
+layout: page
+lang: en
+share: false
+robots_exclude: true
+sitemap_exlude: true
+---
+You have been unsubscribed from the Bitcoin Core announcements list.

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -976,3 +976,34 @@ Show your support page
 .show-your-support-small {
 	margin-top: 2em;
 }
+
+#mailregform
+{
+	@include clearfix;
+	
+	input {
+		padding: 0.5em 0.5em;
+		float: left;
+		border-color: lighten($black,70);
+	}
+	#email {
+		@include border-radius(0px, 0px, 5px, 5px);
+		width: 60%;
+		@media #{$small} {
+			width: 250px;
+		}
+	}
+	#submit {
+		width: 25%;
+		@media #{$small} {
+			width: 90px;
+		}
+		border-left:0px;
+		@include border-radius(5px, 5px, 0px, 0px);
+		background-color: darken($white, 2);
+		&:hover {
+			background-color: darken($white, 20);
+			border-color: lighten($black,70);
+		}
+	}
+}


### PR DESCRIPTION
Improve communications by providing an opt-in email list for security and release notifications. Requested by many people who don't have time to follow social media or other noisier channels. This list is only for Bitcoin Core security/release announcements.

![screenshot-localhost 4000 2016-03-14 10-44-03](https://cloud.githubusercontent.com/assets/7275704/13742078/bd6aeb30-e9d1-11e5-993a-8f2efa89d3cb.png)
