### PR TITLE
Fix typo in segwit dev guide

### DIFF
--- a/_posts/en/pages/2016-01-18-segwit-wallet-dev.md
+++ b/_posts/en/pages/2016-01-18-segwit-wallet-dev.md
@@ -104,7 +104,7 @@ To spend a P2WSH output, the <code>scriptSig</code> MUST be empty, and the witne
 
 <pre><code>witness: <...> <...> <...> < witnessScript ></code></pre>
 
-where the <code>RIPEMD160(SHA256(witnessScript))</code> is equal to the <code>32-byte-script-hash</code> in scriptPubKey. The <code>witnessScript</code> is deserialized and evaluated with the remaining data in the <code>witness</code>.
+where the <code>SHA256(witnessScript)</code> is equal to the <code>32-byte-script-hash</code> in scriptPubKey. The <code>witnessScript</code> is deserialized and evaluated with the remaining data in the <code>witness</code>.
 
 
 #### P2WSH in P2SH (P2SH-P2WSH)


### PR DESCRIPTION
Fixed a typo in the segwit wallet dev guide where it said that p2wsh outputs used ripemd160(sha256(witnessScript)) instead of the actual sha256(witnessScript)