### PR TITLE
contact: security alias is not for support

### DIFF
--- a/_posts/en/pages/2016-03-12-contact.md
+++ b/_posts/en/pages/2016-03-12-contact.md
@@ -10,7 +10,7 @@ version: 2
 ---
 For general enquiries and press: <i class="fa fa-fw fa-envelope"></i> contact<span style="display:none"></span>@bitcoincore.org (not for support).
 
-To report security issues: <i class="fa fa-fw fa-envelope"></i> security<span style="display:none"></span>@bitcoincore.org
+To report security issues: <i class="fa fa-fw fa-envelope"></i> security<span style="display:none"></span>@bitcoincore.org (not for support).
 
 <i class="fa fa-fw fa-twitter"></i> Twitter: <a href="https://twitter.com/bitcoincoreorg/">@bitcoincoreorg</a>
 


### PR DESCRIPTION
We get too many support queries. I thought this was already mentioned on the site but it wasn't.