### PR TITLE
Update lifecycle page

### DIFF
--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -58,14 +58,12 @@ _TBA: to be announced_
 The description above only describes Bitcoin Core software releases. Many other parts of the Bitcoin system contain their own versions.  A few examples:
 
 - Every **transaction** contains a version number.
-- Every **block** allows miners to signal their readiness to enforce new
-  versions of the consensus rules.
 - The **P2P network protocol** uses version numbers to allow nodes to announce what features they support.
 - Bitcoin Core's **built-in wallet** has its own internal version number.
 
 These versions numbers are deliberately decoupled from Bitcoin Core's version number as the Bitcoin Core project either has no direct control over them (as is the case with blocks and transactions), or tries to maintain compatibility with other projects (as is the case with the network protocol), or allows for the possibility that no major changes will be made in some releases (as is sometimes the case with the built-in wallet).
 
-The consensus protocol itself doesn't have a version number, although it has gone through about a dozen different versions since the release of Bitcoin 0.1 in January 2009.
+The consensus protocol itself doesn't have a version number.
 
 ## Relationship to SemVer
 

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -55,20 +55,13 @@ _TBA: to be announced_
 
 ## Protocol versioning
 
-The description above only describes Bitcoin Core releases.  Many other
-parts of the Bitcoin system contain their own versions.  A few examples:
+The description above only describes Bitcoin Core software releases. Many other parts of the Bitcoin system contain their own versions.  A few examples:
 
 - Every **block** and **transaction** contains a version number.
-- The **P2P network protocol** uses version numbers to allow nodes to
-  announce what features they support.
+- The **P2P network protocol** uses version numbers to allow nodes to announce what features they support.
 - Bitcoin Core's **built-in wallet** has its own internal version number.
 
-These versions numbers are deliberately decoupled from Bitcoin Core's version
-number as the Bitcoin Core project either has no direct control over them (as is
-the case with blocks and transactions), or tries to maintain compatibility with
-other projects (as is the case with the network protocol), or
-allows for the possibility that no major changes will be made in some
-releases (as is sometimes the case with the built-in wallet).
+These versions numbers are deliberately decoupled from Bitcoin Core's version number as the Bitcoin Core project either has no direct control over them (as is the case with blocks and transactions), or tries to maintain compatibility with other projects (as is the case with the network protocol), or allows for the possibility that no major changes will be made in some releases (as is sometimes the case with the built-in wallet).
 
 ## Relationship to SemVer
 
@@ -76,7 +69,7 @@ Bitcoin Core software versioning does not follow the [SemVer][] optional version
 
 Parts of Bitcoin, most notably the consensus rules, don't work that way.  In order for a new consensus rule to go into effect, it must be enforced by some number of miners, full nodes, or both; and once it has gone into effect, software that doesn't know about the new rule may generate or accept invalid transactions (although upgrades are designed to prevent this from happening when possible).
 
-For this reason, Bitcoin Core deviates from SemVer for changes to consensus rules and other updates where network-wide adoption is necessary or desirable.  The deviation is slight: Bitcoin Core releases these changes as minor releases (`0.x.y`) instead of as major releases(`0.x.0`); this minimizes the size of the patch in order to make it easy for as many people as possible to inspect it, test it, and deploy it.  It also makes it possible to backport the same patch to multiple previous major releases, further increasing the number of users who can easily upgrade, although there are not always enough volunteers to manage this.
+For this reason, Bitcoin Core deviates from SemVer for changes to consensus rules and other updates where network-wide adoption is necessary or desirable.  Bitcoin Core releases these changes as maintenance releases (`0.x.y`) instead of as major releases(`0.x.0`); this minimizes the size of the patch in order to make it easy for as many people as possible to inspect it, test it, and deploy it.  It also makes it possible to backport the same patch to multiple previous major releases, further increasing the number of users who can easily upgrade, although there are not always enough volunteers to manage this.
 
 [SemVer]: https://semver.org/
 [bitcoin-transifex-link]: https://www.transifex.com/bitcoin/bitcoin/

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -57,11 +57,15 @@ _TBA: to be announced_
 
 The description above only describes Bitcoin Core software releases. Many other parts of the Bitcoin system contain their own versions.  A few examples:
 
-- Every **block** and **transaction** contains a version number.
+- Every **transaction** contains a version number.
+- Every **block** allows miners to signal their readiness to enforce new
+  versions of the consensus rules.
 - The **P2P network protocol** uses version numbers to allow nodes to announce what features they support.
 - Bitcoin Core's **built-in wallet** has its own internal version number.
 
 These versions numbers are deliberately decoupled from Bitcoin Core's version number as the Bitcoin Core project either has no direct control over them (as is the case with blocks and transactions), or tries to maintain compatibility with other projects (as is the case with the network protocol), or allows for the possibility that no major changes will be made in some releases (as is sometimes the case with the built-in wallet).
+
+The consensus protocol itself doesn't have a version number, although it has gone through about a dozen different versions since the release of Bitcoin 0.1 in January 2009.
 
 ## Relationship to SemVer
 

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -31,7 +31,7 @@ Minor releases will be numbered 0.11.1, 0.11.2, 0.12.1, 0.12.2 etc.
 
 ## Consensus rules
 
-Proposals to change consensus rules are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This make it easier for enterprise users to assess and test the proposal because of its smaller changeset compared to a major release. It also allows users who follow a more conservative upgrade path to adopt consensus rule changes in a more timely manner.
+Proposals to change consensus rules are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This makes it easier for enterprise users to assess and test the proposal because of its smaller changeset compared to a major release. It also allows users who follow a more conservative upgrade path to adopt consensus rule changes in a more timely manner.
 
 ## Maintenance period
 

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -7,19 +7,41 @@ layout: page
 type: pages
 lang: en
 share: false
-version: 1
+version: 2
 ---
+{% include _toc.html %}
+
 This document describes the life-cycle of the Bitcoin Core software package released by the Bitcoin Core project. It is in line with standard maintenance policy across commercial software.  
 
-We aim to make a major release every 6-7 months, These will be numbered 0.11, 0.12 etc.
+## Versioning
 
-We will provide maintenance "minor releases" that fix bugs within the major releases. We may add minor features to point releases where necessary, for example when back-porting consensus rule changes such as soft forks. Minor releases will be numbered 0.11.1, 0.11.2, 0.12.1, 0.12.2 etc.
+Bitcoin Core versions releases as follows 0.MAJOR.MINOR. Release candidates are suffixed with rc1, rc2 etc.
+
+## Major releases
+
+We aim to make a major release every 6-7 months.
+
+These will be numbered 0.11.0, 0.12.0 etc.
+
+## Maintenance releases
+
+We will provide maintenance "minor releases" that fix bugs within the major releases. As a general rule we do not introduce major new features in a maintenance release (consensus rule are exempt from this rule). However, we may add minor features where necessary, and we will back-port consensus rule changes such as soft forks.
+
+Minor releases will be numbered 0.11.1, 0.11.2, 0.12.1, 0.12.2 etc.
+
+## Soft forks
+
+Soft fork consensus rule proposals are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This make it easier for enterprise users to assess and test the proposal due to smaller changeset than in a major release. 
+
+## Maintenance period
 
 We maintain the major versions until their "Maintenance End". We generally maintain the current and previous major release. So if the current release is 0.12, then 0.11 is also considered maintained. Once 0.13 is released, then 0.11 would be considered at it's "Maintenance End". The older the major release, the more critical issues have to be to get backported to it, and the more to warrant a new minor release. Once software has reached the "Maintenance End" period it will only receive critical security fixes until the EOL date. After EOL, users must upgrade to a later version to receive security updates.
 
 Please note that minor versions get bugfixes, translation updates, and soft forks. Translation on [Transifex][bitcoin-transifex-link] is only open for the last two major releases.
 
 For example, major version 0.9 was released on 2014-03-19 and we provided maintenance fixes (point releases) until 2015-02-16. Critical security issues would still be continue to be fixed until the End-Of-Life "EOL" date of 2016-02-31. However, to take advantage of bug fixes, you would have to upgrade to a later major version.
+
+## Schedule
 
 Once EOL is reached, you will need to upgrade to a newer version.
 

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -15,7 +15,7 @@ This document describes the life-cycle of the Bitcoin Core software package rele
 
 ## Versioning
 
-Bitcoin Core versions releases as follows 0.MAJOR.MINOR. Release candidates are suffixed with rc1, rc2 etc.
+Bitcoin Core releases are versioned as follow: 0.MAJOR.MINOR, and release candidates are suffixed with rc1, rc2 etc.
 
 ## Major releases
 
@@ -25,13 +25,13 @@ These will be numbered 0.11.0, 0.12.0 etc.
 
 ## Maintenance releases
 
-We will provide maintenance "minor releases" that fix bugs within the major releases. As a general rule we do not introduce major new features in a maintenance release (consensus rule are exempt from this rule). However, we may add minor features where necessary, and we will back-port consensus rule changes such as soft forks.
+We will provide maintenance "minor releases" that fix bugs within the major releases. As a general rule we do not introduce major new features in a maintenance release (consensus rules are exempt). However, we may add minor features where necessary, and we will back-port consensus rule changes such as soft forks.
 
 Minor releases will be numbered 0.11.1, 0.11.2, 0.12.1, 0.12.2 etc.
 
-## Soft forks
+## Consensus rules
 
-Soft fork consensus rule proposals are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This make it easier for enterprise users to assess and test the proposal due to smaller changeset than in a major release. 
+Proposals to change consensus rules are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This make it easier for enterprise users to assess and test the proposal due to smaller changeset than in a major release. It also allows users who follow a more conservative upgrade path to adopt consensus rule changes in a more timely manner.
 
 ## Maintenance period
 
@@ -53,4 +53,9 @@ Once EOL is reached, you will need to upgrade to a newer version.
 
 _TBA: to be announced_
 
+## Foot notes
+
+Bitcoin Core software versioning is similar, but not identical to [SemVer][]. Bitcoin Core implements a full stack of wallet, full node, networking and consensus rule validation. However, versioning of the Bitcoin system is much more complex; there are block versions, transaction versions, p2p versions, and consensus rules are all versioned separately, and the consensus rule. [SemVer][] is not designed to handle this complexity and while Bitcoin Core adheres in the most part to the spirit of [SemVer][], there are notable exceptions, especially for consensus rules proposals.
+
+[SemVer]: https://semver.org/
 [bitcoin-transifex-link]: https://www.transifex.com/bitcoin/bitcoin/

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -53,13 +53,30 @@ Once EOL is reached, you will need to upgrade to a newer version.
 
 _TBA: to be announced_
 
+## Protocol versioning
+
+The description above only describes Bitcoin Core releases.  Many other
+parts of the Bitcoin system contain their own versions.  A few examples:
+
+- Every **block** and **transaction** contains a version number.
+- The **P2P network protocol** uses version numbers to allow nodes to
+  announce what features they support.
+- Bitcoin Core's **built-in wallet** has its own internal version number.
+
+These versions numbers are deliberately decoupled from Bitcoin Core's version
+number as the Bitcoin Core project either has no direct control over them (as is
+the case with blocks and transactions), or tries to maintain compatibility with
+other projects (as is the case with the network protocol), or
+allows for the possibility that no major changes will be made in some
+releases (as is sometimes the case with the built-in wallet).
+
 ## Relationship to SemVer
 
-Bitcoin Core software versioning is similar to the [SemVer][] optional versioning standard for regular feature releases.  However, SemVer was designed for use in normal software libraries where individuals can choose to upgrade the library at their own pace, or even stay behind if they don't like the changes.
+Bitcoin Core software versioning does not follow the [SemVer][] optional versioning standard, but its release versioning is superficially similar.  SemVer was designed for use in normal software libraries where individuals can choose to upgrade the library at their own pace, or even stay behind on an older release if they don't like the changes.
 
-Parts of Bitcoin, most notably the consensus rules, don't work that way.  In order for a new consensus rule to go into effect, it must be enforced by some number of miners, full nodes, or both; and once it has gone into effect, software that doesn't know about the new rule may generate or accept invalid transactions.
+Parts of Bitcoin, most notably the consensus rules, don't work that way.  In order for a new consensus rule to go into effect, it must be enforced by some number of miners, full nodes, or both; and once it has gone into effect, software that doesn't know about the new rule may generate or accept invalid transactions (although upgrades are designed to prevent this from happening when possible).
 
-For this reason, Bitcoin Core deviates from SemVer for changes to consensus rules and other updates where network-wide adoption is necessary or desirable.  The deviation is slight: Bitcoin Core releases these changes as minor releases (`x.y`) instead of as major releases(`x.0`); this minimizes the size of the patch in order to make it easy for as many people as possible to inspect it, test it, and deploy it.  It also makes it possible to backport the same patch to multiple previous major releases, further increasing the number of users who can easily upgrade, although there are not always enough volunteers to manage this.
+For this reason, Bitcoin Core deviates from SemVer for changes to consensus rules and other updates where network-wide adoption is necessary or desirable.  The deviation is slight: Bitcoin Core releases these changes as minor releases (`0.x.y`) instead of as major releases(`0.x.0`); this minimizes the size of the patch in order to make it easy for as many people as possible to inspect it, test it, and deploy it.  It also makes it possible to backport the same patch to multiple previous major releases, further increasing the number of users who can easily upgrade, although there are not always enough volunteers to manage this.
 
 [SemVer]: https://semver.org/
 [bitcoin-transifex-link]: https://www.transifex.com/bitcoin/bitcoin/

--- a/_posts/en/pages/2016-01-15-lifecycle.md
+++ b/_posts/en/pages/2016-01-15-lifecycle.md
@@ -15,7 +15,7 @@ This document describes the life-cycle of the Bitcoin Core software package rele
 
 ## Versioning
 
-Bitcoin Core releases are versioned as follow: 0.MAJOR.MINOR, and release candidates are suffixed with rc1, rc2 etc.
+Bitcoin Core releases are versioned as follows: 0.MAJOR.MINOR, and release candidates are suffixed with rc1, rc2 etc.
 
 ## Major releases
 
@@ -25,13 +25,13 @@ These will be numbered 0.11.0, 0.12.0 etc.
 
 ## Maintenance releases
 
-We will provide maintenance "minor releases" that fix bugs within the major releases. As a general rule we do not introduce major new features in a maintenance release (consensus rules are exempt). However, we may add minor features where necessary, and we will back-port consensus rule changes such as soft forks.
+We will provide maintenance "minor releases" that fix bugs within the major releases. As a general rule we do not introduce major new features in a maintenance release (except for consensus rules). However, we may add minor features where necessary, and we will back-port consensus rule changes such as soft forks.
 
 Minor releases will be numbered 0.11.1, 0.11.2, 0.12.1, 0.12.2 etc.
 
 ## Consensus rules
 
-Proposals to change consensus rules are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This make it easier for enterprise users to assess and test the proposal due to smaller changeset than in a major release. It also allows users who follow a more conservative upgrade path to adopt consensus rule changes in a more timely manner.
+Proposals to change consensus rules are always shipped first in maintenance versions such as 0.11.2, 0.12.1 etc. This make it easier for enterprise users to assess and test the proposal because of its smaller changeset compared to a major release. It also allows users who follow a more conservative upgrade path to adopt consensus rule changes in a more timely manner.
 
 ## Maintenance period
 
@@ -53,9 +53,13 @@ Once EOL is reached, you will need to upgrade to a newer version.
 
 _TBA: to be announced_
 
-## Foot notes
+## Relationship to SemVer
 
-Bitcoin Core software versioning is similar, but not identical to [SemVer][]. Bitcoin Core implements a full stack of wallet, full node, networking and consensus rule validation. However, versioning of the Bitcoin system is much more complex; there are block versions, transaction versions, p2p versions, and consensus rules are all versioned separately, and the consensus rule. [SemVer][] is not designed to handle this complexity and while Bitcoin Core adheres in the most part to the spirit of [SemVer][], there are notable exceptions, especially for consensus rules proposals.
+Bitcoin Core software versioning is similar to the [SemVer][] optional versioning standard for regular feature releases.  However, SemVer was designed for use in normal software libraries where individuals can choose to upgrade the library at their own pace, or even stay behind if they don't like the changes.
+
+Parts of Bitcoin, most notably the consensus rules, don't work that way.  In order for a new consensus rule to go into effect, it must be enforced by some number of miners, full nodes, or both; and once it has gone into effect, software that doesn't know about the new rule may generate or accept invalid transactions.
+
+For this reason, Bitcoin Core deviates from SemVer for changes to consensus rules and other updates where network-wide adoption is necessary or desirable.  The deviation is slight: Bitcoin Core releases these changes as minor releases (`x.y`) instead of as major releases(`x.0`); this minimizes the size of the patch in order to make it easy for as many people as possible to inspect it, test it, and deploy it.  It also makes it possible to backport the same patch to multiple previous major releases, further increasing the number of users who can easily upgrade, although there are not always enough volunteers to manage this.
 
 [SemVer]: https://semver.org/
 [bitcoin-transifex-link]: https://www.transifex.com/bitcoin/bitcoin/


### PR DESCRIPTION
There has been repeated confusion about Bitcoin Core's release versioning compared with SemVer 2.0.0.

While Bitcoin Core does indeed follow the spirit of SemVer regarding major and minor releases, where minor releases focus on bug fix maintenance; Bitcoin Core software releases are decoupled network versioning and consensus rule changes. As such, the exceptions need to be explained explicitly.