### PR TITLE
Colourise segwit adoption table

### DIFF
--- a/_data/segwitsupport.csv
+++ b/_data/segwitsupport.csv
@@ -1,0 +1,48 @@
+name,url,planned,ready,notes,depends
+AirBitz,https://airbitz.co/,yes,no,wallet,
+Armory,https://github.com/goatpig/BitcoinArmory/tree/SegWit/,yes,wip,wallet,bitcoin core
+Bcoin,https://github.com/bcoin-org/bcoin,yes,yes,library,
+Bitcoin India,https://bitcoin-india.org/,yes,wip,exchange,
+Bitcoin LJR,http://luke.dashjr.org/programs/bitcoin-ljr/,yes,no,,n/a
+BitcoinJ,https://bitcoinj.github.io/,yes,wip,library,n/a
+bitcoin-lib,https://github.com/ACINQ/bitcoin-lib,yes,wip,library,n/a
+Bitcoinjs,http://bitcoinjs.org/,yes,wip,library,n/a
+bitcore-lib,https://bitcore.io/,yes,wip,library,n/a
+BitGo*,https://www.bitgo.com/,yes,no,wallet,"bitcoinj, bitcoinjs"
+Bither Wallet,https://bither.net/,yes,no,wallet,
+BitmainWarranty,https://bitmainwarranty.com/,yes,yes,miner,
+Bitrated,https://www.bitrated.com/,yes,no,wallet,
+BitWasp,https://github.com/Bit-Wasp/bitcoin-php,yes,yes,library,
+Blockchain.info,https://blockchain.info/,yes,no,"wallet, block explorer",
+Blocktrail,https://www.blocktrail.com/,yes,no,"wallet, block explorer",
+BreadWallet,http://breadwallet.com/,yes,no,wallet,
+BTC.com,https://btc.com/,yes,wip,"block explorer, wallet",
+cgminer,https://www.blocktrail.com/,yes,wip,mining software,
+ckpool,https://bitbucket.org/ckolivas/ckpool,yes,yes,mining software,
+Coinfloor,https://www.coinfloor.co.uk/,yes,wip,exchange,
+Coinomi,https://coinomi.com/,yes,no,wallet,
+CoPay,https://copay.io/,yes,no,wallet,bitcore-lib
+Digitalbitbox,https://digitalbitbox.com/,yes,wip,hardware wallet,
+EI8HT,http://ei8.ht/,yes,no,wallet,"bitcoin core, bitcoinjs"
+Electrum,https://electrum.org/,yes,no,wallet,
+Eloipool,https://github.com/luke-jr/eloipool,yes,wip,pool software,n/a
+GreenAddress*,https://greenaddress.it/,yes,wip,wallet,"pycoin, bitcoinjs"
+GreenBits,https://www.greenbits.com/,yes,wip,wallet,bitcoinj
+Kaiko,https://www.kaiko.com/,yes,no,explorer,
+Ledger Wallet,https://www.ledgerwallet.com/,yes,yes,hardware wallet,
+libbtc,https://github.com/libbtc,yes,no,library,
+libbitcoin,http://libbitcoin.dyne.org/,yes,no,library,
+libblkmaker,https://github.com/bitcoin/libblkmaker,yes,yes,mining library,n/a
+mSIGNA,https://ciphrex.com/,yes,yes,wallet,
+Multibit HD,https://multibit.org/,yes,no,wallet,bitcoinj
+Mycelium,https://mycelium.com/,yes,wip,wallet,
+NBitcoin,https://github.com/MetacoSA/NBitcoin,yes,yes,library,n/a
+OKLink,https://www.oklink.com/,yes,wip,"wallet, block explorer",
+OmniCore,https://github.com/OmniLayer/omnicore,yes,no,wallet,
+python-bitcoinlib,https://github.com/petertodd/python-bitcoinlib,yes,no,library,
+pycoin,https://github.com/richardkiss/pycoin,yes,no,library,n/a
+Samourai Wallet,http://samouraiwallet.com/,yes,wip,wallet,bitcoinj
+Smartbit,https://www.smartbit.com.au/,yes,wip,explorer,
+Trezor,http://satoshilabs.com/trezor/,yes,wip,hardware wallet,
+Vaultoro,https://www.vaultoro.com/,yes,no,,
+WageCan,https://www.wagecan.com/,yes,wip,exchange,

--- a/_includes/pages/segwit_support.md
+++ b/_includes/pages/segwit_support.md
@@ -1,47 +1,32 @@
-|[AirBitz](https://airbitz.co/)|yes|no|wallet||
-|[Armory](https://github.com/goatpig/BitcoinArmory/tree/SegWit/)|yes|wip|wallet|bitcoin core|
-|[Bcoin](https://github.com/bcoin-org/bcoin)|yes|yes|library||
-|[Bitcoin India](https://bitcoin-india.org/)|yes|wip|exchange||
-|[Bitcoin LJR](http://luke.dashjr.org/programs/bitcoin-ljr/)|yes|no||n/a|
-|[BitcoinJ](https://bitcoinj.github.io/)|yes|wip|library|n/a|
-|[bitcoin-lib](https://github.com/ACINQ/bitcoin-lib)|yes|wip|library|n/a|
-|[Bitcoinjs](http://bitcoinjs.org/)|yes|wip|library|n/a|
-|[bitcore-lib](https://bitcore.io/)|yes|wip|library|n/a|
-|[BitGo](https://www.bitgo.com/)*|yes|no|wallet|bitcoinj, bitcoinjs|
-|[Bither Wallet](https://bither.net/)|yes|no|wallet||
-|[BitmainWarranty](https://bitmainwarranty.com/)|yes|yes|miner||
-|[Bitrated](https://www.bitrated.com/)|yes|no|wallet||
-|[BitWasp](https://github.com/Bit-Wasp/bitcoin-php)|yes|yes|library||
-|[Blockchain.info](https://blockchain.info/)|yes|no|wallet, block explorer||
-|[Blocktrail](https://www.blocktrail.com/)|yes|no|wallet, block explorer||
-|[BreadWallet](http://breadwallet.com/)|yes|no|wallet||
-|[BTC.com](https://btc.com/)|yes|wip|block explorer, wallet||
-|[cgminer](https://www.blocktrail.com/)|yes|wip|mining software||
-|[ckpool](https://bitbucket.org/ckolivas/ckpool)|yes|yes|mining software||
-|[Coinfloor](https://www.coinfloor.co.uk/)|yes|wip|exchange||
-|[Coinomi](https://coinomi.com/)|yes|no|wallet||
-|[CoPay](https://copay.io/)|yes|no|wallet|bitcore-lib|
-|[Digitalbitbox](https://digitalbitbox.com/)|yes|wip|hardware wallet||
-|[EI8HT](http://ei8.ht/)|yes|no|wallet|bitcoin core, bitcoinjs|
-|[Electrum](https://electrum.org/)|yes|no|wallet||
-|[Eloipool](https://github.com/luke-jr/eloipool)|yes|wip|pool software|n/a|
-|[GreenAddress](https://greenaddress.it/)*|yes|wip|wallet|pycoin, bitcoinjs|
-|[GreenBits](https://www.greenbits.com/)|yes|wip|wallet|bitcoinj|
-|[Kaiko](https://www.kaiko.com/)|yes|no|explorer||
-|[Ledger Wallet](https://www.ledgerwallet.com/)|yes|yes|hardware wallet||
-|[libbtc](https://github.com/libbtc)|yes|no|library||
-|[libbitcoin](http://libbitcoin.dyne.org/)|yes|no|library||
-|[libblkmaker](https://github.com/bitcoin/libblkmaker)|yes|yes|mining library|n/a|
-|[mSIGNA](https://ciphrex.com/)|yes|yes|wallet||
-|[Multibit HD](https://multibit.org/)|yes|no|wallet|bitcoinj|
-|[Mycelium](https://mycelium.com/)|yes|wip|wallet||
-|NBitcoin|yes|yes|library|n/a|
-|[OKLink](https://www.oklink.com/)|yes|wip|wallet, block explorer||
-|[OmniCore](https://github.com/OmniLayer/omnicore)|yes|no|wallet||
-|[python-bitcoinlib](https://github.com/petertodd/python-bitcoinlib)|yes|no|library||
-|[pycoin](https://github.com/richardkiss/pycoin)|yes|no|library|n/a|
-|[Samourai Wallet](http://samouraiwallet.com/)|yes|wip|wallet|bitcoinj|
-|[Smartbit](https://www.smartbit.com.au/)|yes|wip|explorer||
-|[Trezor](http://satoshilabs.com/trezor/)|yes|wip|hardware wallet||
-|[Vaultoro](https://www.vaultoro.com/)|yes|no|||
-|[WageCan](https://www.wagecan.com/)|yes|wip|exchange||
+{% unless segwitsupportheaders %}
+{% comment %}
+  to translate the table headers, copy and replace the above line prior
+  to including this file
+{% endcomment %}
+{% assign segwitsupportheaders = "Name,Planned,Ready,Notes,Depends" %}
+{% endunless %}
+{% assign segwitsupportheaders = segwitsupportheaders | split: ',' %}
+
+<table>
+
+<thead>
+<tr>
+{% for h in segwitsupportheaders %}
+<th>{{ h }}</th>
+{% endfor %}
+</tr>
+</thead>
+
+<tbody>
+{% for sws in site.data.segwitsupport %}
+<tr>
+<td><a href="{{ sws.url }}">{{ sws.name }}</a></td>
+<td {% if sws.planned == "yes" %} class="good" {% elsif sws.planned == "no" %} class="bad" {% endif %}>{{ sws.planned }}</td>
+<td {% if sws.ready == "yes" %} class="good" {% elsif sws.ready == "no" %} class="bad" {% endif %}>{{ sws.ready }}</td>
+<td>{{ sws.notes }}</td>
+<td>{{ sws.depends }}</td>
+</tr>
+{% endfor %}
+</tbody>
+</table>
+

--- a/_posts/en/pages/2016-01-13-segwit-support.md
+++ b/_posts/en/pages/2016-01-13-segwit-support.md
@@ -13,8 +13,6 @@ The following is a list of companies and projects which have stated they will su
 To add your company or service, please ACK ticket <a href="https://github.com/bitcoin-core/bitcoincore.org/pull/30">[#30]
 </a> with company/service name.
 
-|Name|Planned|Ready|Notes|Depends|
-|----|-------|-----|-----|-------|
 {% include pages/segwit_support.md %}
 
 \* BitGo provides wallet services to exchanges such as Bitstamp and Kraken.

--- a/_posts/zh_CN/pages/2016-01-13-segwit-support.md
+++ b/_posts/zh_CN/pages/2016-01-13-segwit-support.md
@@ -14,8 +14,6 @@ share: false
 
 最新! (隔离见证比特币测试网服务):
 
-|Name|Planned|Ready|Notes|Depends|
-|----|-------|-----|-----|-------|
 {% include pages/segwit_support.md %} 
 
 添加公司或服务, 请使用 ACK ticket [#30] 加公司／服务名称。

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -1087,3 +1087,12 @@ ul.team {
 div.maintainers {
 	margin-bottom: 1.5em;
 }
+
+.good {
+	background-color: $good;
+}
+
+.bad {
+	background-color: $bad;
+}
+

--- a/_sass/variables.scss
+++ b/_sass/variables.scss
@@ -30,6 +30,9 @@ $white          : #fff;
 $black          : #111;
 $accentcolor    : $black;
 
+$good           : #ffb;
+$bad            : #9df;
+
 /* buttons */
 $primary			: $black;
 $success			: #5cb85c;


### PR DESCRIPTION
Here's a patch to add background colours to the segwit adoption table -- makes it a bit easier to spot which ones aren't done yet. Not sure if there's a meaningful difference between "wip" and "no"; I left "wip" as normal background but maybe it should be coloured "bad" too.

I couldn't get kramdown markup to add an attribute to cells, so switched to using liquid to generate HTML directly based on a CSV file, which seems fine. I chose yellow and blue because it seems to work for colour blind (unlike green and red), doesn't suffer from red is bad in the West and good in the East confusion, and because "golden" sounds positive and "blue" is sad, but whatever.

Also added a URL for NBitcoin since it was the only one missing a URL and it saved special casing it.