### PR TITLE
Fix name: header for zh-CN translations

### DIFF
--- a/_posts/zh_CN/pages/2016-01-01-contribute.md
+++ b/_posts/zh_CN/pages/2016-01-01-contribute.md
@@ -2,7 +2,7 @@
 type: pages
 layout: page
 lang: zh_CN
-name: 2016-01-01-contribute
+name: contribute
 id: zh_cn-2016-01-01-contribute.md
 title: 我如何做出贡献?
 permalink: /zh_CN/contribute/

--- a/_posts/zh_CN/pages/2016-01-13-segwit-support.md
+++ b/_posts/zh_CN/pages/2016-01-13-segwit-support.md
@@ -2,7 +2,7 @@
 type: pages
 layout: page
 lang: zh_CN
-name: 2016-01-13-segwit-support
+name: segwit-support
 id: zh_cn-2016-01-13-segwit-support
 title: 隔离见证支持
 permalink: /zh_CN/segwit_adoption/


### PR DESCRIPTION
A couple of the zh-CN translations have name: fields that include a date and thus don't match the english header, so the language drop down doesn't work right.