### PR TITLE
Add release blog post for 0.13.1

### DIFF
--- a/_posts/en/posts/2016-10-31-release-0.13.1.md
+++ b/_posts/en/posts/2016-10-31-release-0.13.1.md
@@ -9,9 +9,7 @@ layout: post
 share: true
 version: 1
 
-excerpt: >
-  The first release of Bitcoin Core that supports activation of
-  segregated witness is now available.
+excerpt: The first release of Bitcoin Core that supports activation of segregated witness is now available.
 ---
 {% include _toc.html %}
 {% include _references.md %}
@@ -153,7 +151,7 @@ These are the SHA-256 hashes of the released files:
     FIXME
 
 
-[segwit upgrade guide]: /en/segwit-upgrade-guide/
+[segwit upgrade guide]: /en/2016/10/27/segwit-upgrade-guide/
 [Elimination of unwanted transaction malleability]: #eliminate-malleability
 [Capacity increase]: #capacity-increase
 [Weighting data based on how it affects node performance]: #weight-data-by-performance

--- a/_posts/en/posts/2016-10-31-release-0.13.1.md
+++ b/_posts/en/posts/2016-10-31-release-0.13.1.md
@@ -1,0 +1,171 @@
+---
+title: Bitcoin Core 0.13.1 Released with Segregated Witness
+name: blog-release-0.13.1
+id: en-blog-release-0.13.1
+lang: en
+permalink: /en/2016/10/31/release-0.13.1/
+type: posts
+layout: post
+share: true
+version: 1
+
+excerpt: >
+  The first release of Bitcoin Core that supports activation of
+  segregated witness is now available.
+---
+{% include _toc.html %}
+{% include _references.md %}
+
+[release notes]: /FIXME
+
+We are pleased to [release][release notes] Bitcoin Core 0.13.1, which contains code miners can use to signal support for the segregated witness (segwit) soft fork and which nodes can use to validate segwit transactions if the soft fork is activated.
+
+The segwit soft fork is fully backwards compatible with all Bitcoin wallets, so you will continue to be able to safely send and receive bitcoins whether or not segwit is activated.  If you are a miner, you may need to take action if it appears that segwit will activate; for all other Bitcoin users, there is no action you need to take related to segwit now or in the future.  However, if you want to support segwit or if you want more details about the changes you may see if segwit activates, please see our [segwit upgrade guide][].
+
+Segwit timeline:
+
+- [#](#signal){:#signal} Miners will be able to signal that they are willing and able to enforce segwit starting at the beginning of the first 2,016-block retarget period on or after 15 November 2016 (UTC). 
+
+- [#](#lock-in){:#lock-in} If 95% of blocks within any retarget period signal support for segwit, it locks-in.
+
+- [#](#activate){:#activate} After another 2,016-block (roughly two week) retarget period, segwit will activate, allowing miners to produce blocks containing segwit transactions on Bitcoin’s mainnet.
+
+- [#](#fail){:#fail} If segwit has not activated by the end of one retarget period after 15 November 2017, segwit will cease to be eligible for activation.
+
+If segwit is activated, transaction-producing software will be able to separate (segregate) transaction signatures (witnesses) from the part of the data in a transaction that is covered by the txid. This provides several immediate benefits:
+
+1. **[Elimination of unwanted transaction malleability][]** for transactions that use segregated witnesses, making it easier to write Bitcoin wallet software and simplifying the design of smart contracts for Bitcoin.
+
+2. **[Capacity increase][]** allowing blocks to hold more transactions than before.
+
+3. **[Weighting data based on how it affects node performance][]** so that miners are allowed to include more data in the parts of the block that don’t reduce node performance long-term.
+
+4. **[Signature covers value][]** to reduce the number of steps secure signature generators (such as hardware wallets) need to perform to create a secure signature.  This makes it easier to develop hardware wallets and may significantly improve the speed of existing hardware wallets.
+
+5. **[Linear scaling of sighash operations][]** to ensure that transactions using segwit can’t trigger the problem that caused a block in 2015 to take 25 seconds to validate.
+
+6. **[Increased security for multisig][]** so security goes from about 80 bits with P2SH to about 128 bits with segwit---which is about 281 trillion times more security against certain attacks.
+
+7. **[More efficient almost-full-node security][]** to allow newly-started nodes who are willing to give up some security guarantees to build an accurate copy of the Bitcoin ledger without having to download all the data from every block.  (This is a feature made possible by segwit; it is not included in Bitcoin Core 0.13.1.)
+
+8. **[Script versioning][]** to allow users to individually opt-in to future soft fork changes made to Bitcoin’s scripting language.
+
+For more information about each of the benefits above, please see the [detailed segwit benefits][] section below or the longer and more detailed [segwit benefits FAQ][] page on this website.
+
+For more information about upgrading for segwit, please see the [segwit upgrade guide][].
+
+
+## Detailed segwit benefits
+
+The following subsections describe in more detail the features that were summarized above.
+
+### 1. Elimination of unwanted transaction malleability {#eliminate-malleability}
+
+Segregating the witness allows both existing and upgraded software to calculate the transaction identifier (txid) of transactions without referencing the witness, which can sometimes be changed by third-parties (such as miners) or by co-signers in a multisig spend. This solves all known cases of unwanted transaction malleability, which is a problem that makes programming Bitcoin wallet software more difficult and which seriously complicates the design of smart contracts for Bitcoin.
+
+### 2. Capacity increase {#capacity-increase}
+
+Segwit transactions contain new fields that are not part of the data currently used to calculate the size of a block, which allows a block containing segwit transactions to hold more data than allowed by the current maximum block size.
+
+Estimates based on the transactions currently found in blocks indicate that if all wallets switch to using segwit, the network will be able to support about 70% more transactions.  The network will also be able to support more of the advanced-style payments (such as multisig) than it can support now because of the different weighting given to different parts of a transaction after segwit activates (see the following section for details).
+
+### 3. Weighting data based on how it affects node performance {#weight-data-by-performance}
+
+Some parts of each Bitcoin block need to be stored by nodes in order to validate future blocks; other parts of a block can be immediately forgotten (pruned) or used only for helping other nodes sync their copy of the block chain.
+
+One large part of the immediately prunable data are transaction signatures (witnesses), and segwit makes it possible to give a different “weight” to segregated witnesses to correspond with the lower demands they place on node resources.  Specifically, each byte of a segregated witness is given a weight of 1, each other byte in a block is given a weight of 4, and the maximum allowed weight of a block is 4 million.  Weighting the data this way better aligns the most profitable strategy for creating blocks with the long-term costs of block validation.
+
+### 4. Signature covers value {#signature-covers-value}
+
+A simple improvement in the way signatures are generated in segwit simplifies the design of secure signature generators (such as hardware wallets), reduces the amount of data the signature generator needs to download, and allows the signature generator to operate more quickly.  This is made possible by having the generator sign the amount of bitcoins they think they are spending, and by having full nodes refuse to accept those signatures unless the amount of bitcoins being spent is exactly the same as was signed.
+
+For non-segwit transactions, wallets instead had to download the complete previous transactions being spent for every payment they made, which could be a slow operation on hardware wallets and in other situations where bandwidth or computation speed was constrained.
+
+### 5. Linear scaling of sighash operations {#linear-scaling-of-sighash-operations}
+
+In 2015 a block was produced that required about 25 seconds to validate on modern hardware because of the way transaction signature hashes are performed.  Other similar blocks, or blocks that could take even longer to validate, can still be produced today.  The problem that caused this can’t be fixed in a soft fork without unwanted side-effects, but transactions that opt-in to using segwit will now use a different signature hashing method that doesn’t suffer from this problem and doesn’t have any unwanted side-effects.
+
+### 6. Increased security for multisig {#increased-security-for-multisig}
+
+Bitcoin addresses (both P2PKH addresses that start with a ‘1’ and P2SH addresses that start with a ‘3’) use a hash function known as RIPEMD-160.  For P2PKH addresses, this provides about 160 bits of security---which is beyond what cryptographers believe can be broken today.  But because P2SH is more flexible, only about 80 bits of security is provided per address.
+
+Although 80 bits is very strong security, it is within the realm of possibility that it can be broken by a powerful adversary.  Segwit allows advanced transactions to use the SHA256 hash function instead, which provides about 128 bits of security  (that is 281 trillion times as much security as 80 bits and is equivalent to the maximum bits of security believed to be provided by Bitcoin’s choice of parameters for its Elliptic Curve Digital Security Algorithm [ECDSA].)
+
+### 7. More efficient almost-full-node security {#more-efficient-security}
+
+Satoshi Nakamoto’s [original Bitcoin paper][] describes a method for allowing newly-started full nodes to skip downloading and validating some data from historic blocks that are protected by large amounts of proof of work.  Unfortunately, Nakamoto’s method can’t guarantee that a newly-started node using this method will produce an accurate copy of Bitcoin’s current ledger (called the UTXO set), making the node vulnerable to falling out of consensus with other nodes.
+
+Although the problems with Nakamoto’s method can’t be fixed in a soft fork, segwit accomplishes something similar to his original proposal: it makes it possible for a node to optionally skip downloading some blockchain data (specifically, the segregated witnesses) while still ensuring that the node can build an accurate copy of the UTXO set for the block chain with the most proof of work.  Segwit enables this capability at the consensus layer, but note that Bitcoin Core does not provide an option to use this capability as of this 0.13.1 release.
+
+### 8. Script versioning {#script-versioning}
+
+Segwit makes it easy for future soft forks to allow Bitcoin users to individually opt-in to almost any change in the Bitcoin Script language when those users receive new transactions.  Features currently being researched by Bitcoin Core contributors that may use this capability include support for Schnorr signatures, which can improve the privacy and efficiency of multisig transactions (or transactions with multiple inputs), and Merkelized Abstract Syntax Trees (MAST), which can improve the privacy and efficiency of scripts with two or more conditions.  Other Bitcoin community members are studying several other improvements that can be made using script versioning.
+
+## How segwit was tested {#segwit-testing}
+
+Developers from Bitcoin Core and a number of other Bitcoin projects have been testing and using one version of segwit or another since June 2015---and have been testing the final version of segwit implementation since April 2016.  A few of the development and testing milestones are described below:
+
+- **June 2015** saw the release of the [Elements Project sidechain][], which included a version of segwit described as being “from scratch” because it wasn’t intended to be compatible with previous Bitcoin software as it wasn't known how to do that at the time. This version of segwit continued to be used on Elements-based sidechains until recently, when the Elements Project switched to using the version provided by Bitcoin Core 0.13.1 because of the comprehensive testing it received as well as its compatibility with existing Bitcoin software.
+
+- **October 2015** was when a developer described how segwit could be implemented in Bitcoin as a soft fork.  Developers with experience developing the "from scratch" version immediately began designing a soft fork implementation that is backwards compatible with all existing Bitcoin software (although programs do need to upgrade to fully understand segwit).
+
+- **December 2015** ended with the launch of a special segwit-specific testnet (called segnet) that allowed implementers and testers to run segwit in a multi-user environment, and which also allowed wallet authors to test their code for generating segwit transactions. Segnet went through several iterations as problems were found and fixed, and as improvements were discovered and implemented.
+
+- **April 2016** opened with a pull request for segwit made to Bitcoin Core, and all Bitcoin developers from any project were encouraged to provide feedback (and many did).
+
+- **May 2016** marked the activation of segwit on Bitcoin’s testnet.  This provided a live integration test of Bitcoin Core’s implementation against the large variety of other software on testnet to see if it there were any problems interoperating with other software that had upgraded to segwit or whether any problems appeared in programs that had not been upgraded for segwit.  The success of this testing helped demonstrate that segwit would not cause problems for anyone (besides miners) who does not upgrade when segwit activates.  As of the Bitcoin Core 0.13.1 release, segwit has been activated for over six months on testnet with no known consensus failures.
+
+    Also in May 2016, twenty Bitcoin Core developers [met in Switzerland][] for (among other things) an in-person review of the segwit code and ensuring that test coverage was adequate.
+
+- **June 2016** saw the completion of the segwit code review, with several experienced Bitcoin developers completing their reviews and indicating support for segwit's code changes.
+
+    Also in June was the merge of compact blocks, a peer-to-peer protocol enhancement based on developments made over the last several years in the Fast Block Relay Network.  Compact blocks allows more efficient announcements of new blocks between cooperating peers, which is expected to minimize the bandwidth and latency impact of the larger blocks allowed for by segwit.
+
+- **September 2016** saw adoption of Bitcoin Core 0.13.0 (containing compact blocks) starting to be used in production, with over 1,300 Bitcoin Core 0.13.0 nodes accepting incoming connections by the end of the month.  Also by the end of the month, a number of programs besides Bitcoin Core---including the btcd full node and many commonly-used mining programs---had code ready to upgrade to segwit and were actively being used to generate blocks on testnet.
+
+
+
+
+## Null dummy soft fork
+
+Also in Bitcoin Core 0.13.1 and combined with the segwit soft fork is an additional change that turns a long-existing network relay policy into a consensus rule. The OP_CHECKMULTISIG and OP_CHECKMULTISIGVERIFY opcodes consume an extra stack element ("dummy element") after signature validation. The dummy element is not inspected in any manner, and could be replaced by any value without invalidating the script.
+
+Because any value can be used for this dummy element, it's possible for a third-party to insert data into other people's transactions, changing the transaction's txid (called transaction malleability) and possibly causing other problems.
+
+Since Bitcoin Core 0.10.0, nodes have defaulted to only relaying and mining transactions whose dummy element was a null value (0x00, also called OP_0). The null dummy soft fork turns this relay rule into a consensus rule both for non-segwit transactions and segwit transactions, so that this method of mutating transactions is permanently eliminated from the network.
+
+Signaling for the null dummy soft fork is done by signaling support for segwit, and the null dummy soft fork will activate at the same time as segwit.
+
+For more information, please see [BIP147][].
+
+## Conclusion
+
+For details on all the changes made in Bitcoin Core 0.13.1, please read the [release notes][]. To download, please visit the [download page][] or the [files directory][].
+
+Bitcoin Core 0.13.1 is the only soft fork release planned for the 0.13 release series.  The next major planned release is Bitcoin Core 0.14.0, which has feature freeze [scheduled](https://github.com/bitcoin/bitcoin/issues/8719) for mid-January 2017 and release to follow after all testing is completed (this typically takes more than a month in order to give everyone sufficient time to test).
+
+If you are interested in contributing to Bitcoin Core, please see our [contributing page](/en/contribute) and the document [How to contribute code to Bitcoin Core](/en/faq/contributing-code/). If you don’t know where to get started or have any other questions, please stop by either our [IRC](https://en.bitcoin.it/wiki/IRC_channels) or [Slack](https://slack.bitcoincore.org/) chatrooms and we’ll do our best to help you.
+
+## Hashes for verification
+
+These are the SHA-256 hashes of the released files:
+
+    FIXME
+
+
+[segwit upgrade guide]: /en/segwit-upgrade-guide/
+[Elimination of unwanted transaction malleability]: #eliminate-malleability
+[Capacity increase]: #capacity-increase
+[Weighting data based on how it affects node performance]: #weight-data-by-performance
+[signature covers value]: #signature-covers-value
+[Linear scaling of sighash operations]: #linear-scaling-of-sighash-operations
+[Increased security for multisig]: #increased-security-for-multisig
+[More efficient almost-full-node security]: #more-efficient-security
+[Script versioning]: #script-versioning
+[detailed segwit benefits]: #detailed-segwit-benefits
+[segwit benefits faq]: /en/2016/01/26/segwit-benefits/
+[original bitcoin paper]: https://bitcoin.org/bitcoin.pdf
+[elements project sidechain]: https://elementsproject.org/
+[met in switzerland]: https://bitcoincore.org/en/meetings/2016/05/20/
+[download page]: https://bitcoin.org/en/download
+[files directory]: https://bitcoin.org/bin/bitcoin-core-0.13.1/

--- a/_posts/en/releases/2016-10-31-release-0.13.1.md
+++ b/_posts/en/releases/2016-10-31-release-0.13.1.md
@@ -1,0 +1,424 @@
+---
+title: Bitcoin Core 0.13.1
+id: en-release-0.13.1
+name: release-0.13.1
+permalink: /en/releases/0.13.1/
+type: releases
+layout: page
+lang: en
+share: true
+
+# From https://raw.githubusercontent.com/bitcoin/bitcoin/2e2388a5cbb9a6e101b36e4501698fec538a5738/doc/release-notes/release-notes-0.13.1.md
+---
+{% include _download.html %}
+
+Bitcoin Core version 0.13.1 is now available from:
+
+  <https://bitcoin.org/bin/bitcoin-core-0.13.1/>
+
+This is a new minor version release, including activation parameters for the
+segwit softfork, various bugfixes and performance improvements, as well as
+updated translations.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+Compatibility
+==============
+
+Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
+an OS initially released in 2001. This means that not even critical security
+updates will be released anymore. Without security updates, using a bitcoin
+wallet on a XP machine is irresponsible at least.
+
+In addition to that, with 0.12.x there have been varied reports of Bitcoin Core
+randomly crashing on Windows XP. It is [not clear](https://github.com/bitcoin/bitcoin/issues/7681#issuecomment-217439891)
+what the source of these crashes is, but it is likely that upstream
+libraries such as Qt are no longer being tested on XP.
+
+We do not have time nor resources to provide support for an OS that is
+end-of-life. From 0.13.0 on, Windows XP is no longer supported. Users are
+suggested to upgrade to a newer version of Windows, or install an alternative OS
+that is supported.
+
+No attempt is made to prevent installing or running the software on Windows XP,
+you can still do so at your own risk, but do not expect it to work: do not
+report issues about Windows XP to the issue tracker.
+
+From 0.13.1 onwards OS X 10.7 is no longer supported. 0.13.0 was intended to work on 10.7+, 
+but severe issues with the libc++ version on 10.7.x keep it from running reliably. 
+0.13.1 now requires 10.8+, and will communicate that to 10.7 users, rather than crashing unexpectedly.
+
+Notable changes
+===============
+
+Segregated witness soft fork
+----------------------------
+
+Segregated witness (segwit) is a soft fork that, if activated, will
+allow transaction-producing software to separate (segregate) transaction
+signatures (witnesses) from the part of the data in a transaction that is
+covered by the txid. This provides several immediate benefits:
+
+- **Elimination of unwanted transaction malleability:** Segregating the witness
+  allows both existing and upgraded software to calculate the transaction
+  identifier (txid) of transactions without referencing the witness, which can
+  sometimes be changed by third-parties (such as miners) or by co-signers in a
+  multisig spend. This solves all known cases of unwanted transaction
+  malleability, which is a problem that makes programming Bitcoin wallet
+  software more difficult and which seriously complicates the design of smart
+  contracts for Bitcoin.
+
+- **Capacity increase:** Segwit transactions contain new fields that are not
+  part of the data currently used to calculate the size of a block, which
+  allows a block containing segwit transactions to hold more data than allowed
+  by the current maximum block size. Estimates based on the transactions
+  currently found in blocks indicate that if all wallets switch to using
+  segwit, the network will be able to support about 70% more transactions. The
+  network will also be able to support more of the advanced-style payments
+  (such as multisig) than it can support now because of the different weighting
+  given to different parts of a transaction after segwit activates (see the
+  following section for details).
+
+- **Weighting data based on how it affects node performance:** Some parts of
+  each Bitcoin block need to be stored by nodes in order to validate future
+  blocks; other parts of a block can be immediately forgotten (pruned) or used
+  only for helping other nodes sync their copy of the block chain.  One large
+  part of the immediately prunable data are transaction signatures (witnesses),
+  and segwit makes it possible to give a different "weight" to segregated
+  witnesses to correspond with the lower demands they place on node resources.
+  Specifically, each byte of a segregated witness is given a weight of 1, each
+  other byte in a block is given a weight of 4, and the maximum allowed weight
+  of a block is 4 million.  Weighting the data this way better aligns the most
+  profitable strategy for creating blocks with the long-term costs of block
+  validation.
+
+- **Signature covers value:** A simple improvement in the way signatures are
+  generated in segwit simplifies the design of secure signature generators
+  (such as hardware wallets), reduces the amount of data the signature
+  generator needs to download, and allows the signature generator to operate
+  more quickly.  This is made possible by having the generator sign the amount
+  of bitcoins they think they are spending, and by having full nodes refuse to
+  accept those signatures unless the amount of bitcoins being spent is exactly
+  the same as was signed.  For non-segwit transactions, wallets instead had to
+  download the complete previous transactions being spent for every payment
+  they made, which could be a slow operation on hardware wallets and in other
+  situations where bandwidth or computation speed was constrained.
+
+- **Linear scaling of sighash operations:** In 2015 a block was produced that
+  required about 25 seconds to validate on modern hardware because of the way
+  transaction signature hashes are performed.  Other similar blocks, or blocks
+  that could take even longer to validate, can still be produced today.  The
+  problem that caused this can't be fixed in a soft fork without unwanted
+  side-effects, but transactions that opt-in to using segwit will now use a
+  different signature method that doesn't suffer from this problem and doesn't
+  have any unwanted side-effects.
+
+- **Increased security for multisig:** Bitcoin addresses (both P2PKH addresses
+  that start with a '1' and P2SH addresses that start with a '3') use a hash
+  function known as RIPEMD-160.  For P2PKH addresses, this provides about 160
+  bits of security---which is beyond what cryptographers believe can be broken
+  today.  But because P2SH is more flexible, only about 80 bits of security is
+  provided per address. Although 80 bits is very strong security, it is within
+  the realm of possibility that it can be broken by a powerful adversary.
+  Segwit allows advanced transactions to use the SHA256 hash function instead,
+  which provides about 128 bits of security  (that is 281 trillion times as
+  much security as 80 bits and is equivalent to the maximum bits of security
+  believed to be provided by Bitcoin's choice of parameters for its Elliptic
+  Curve Digital Security Algorithm [ECDSA].)
+
+- **More efficient almost-full-node security** Satoshi Nakamoto's original
+  Bitcoin paper describes a method for allowing newly-started full nodes to
+  skip downloading and validating some data from historic blocks that are
+  protected by large amounts of proof of work.  Unfortunately, Nakamoto's
+  method can't guarantee that a newly-started node using this method will
+  produce an accurate copy of Bitcoin's current ledger (called the UTXO set),
+  making the node vulnerable to falling out of consensus with other nodes.
+  Although the problems with Nakamoto's method can't be fixed in a soft fork,
+  Segwit accomplishes something similar to his original proposal: it makes it
+  possible for a node to optionally skip downloading some blockchain data
+  (specifically, the segregated witnesses) while still ensuring that the node
+  can build an accurate copy of the UTXO set for the block chain with the most
+  proof of work.  Segwit enables this capability at the consensus layer, but
+  note that Bitcoin Core does not provide an option to use this capability as
+  of this 0.13.1 release.
+
+- **Script versioning:** Segwit makes it easy for future soft forks to allow
+  Bitcoin users to individually opt-in to almost any change in the Bitcoin
+  Script language when those users receive new transactions.  Features
+  currently being researched by Bitcoin Core contributors that may use this
+  capability include support for Schnorr signatures, which can improve the
+  privacy and efficiency of multisig transactions (or transactions with
+  multiple inputs), and Merklized Abstract Syntax Trees (MAST), which can
+  improve the privacy and efficiency of scripts with two or more conditions.
+  Other Bitcoin community members are studying several other improvements
+  that can be made using script versioning.
+
+Activation for the segwit soft fork is being managed using BIP9
+versionbits.  Segwit's version bit is bit 1, and nodes will begin
+tracking which blocks signal support for segwit at the beginning of the
+first retarget period after segwit's start date of 15 November 2016.  If
+95% of blocks within a 2,016-block retarget period (about two weeks)
+signal support for segwit, the soft fork will be locked in.  After
+another 2,016 blocks, segwit will activate.
+
+For more information about segwit, please see the [segwit FAQ][], the
+[segwit wallet developers guide][] or BIPs [141][BIP141], [143][BIP143],
+[144][BIP144], and [145][BIP145].  If you're a miner or mining pool
+operator, please see the [versionbits FAQ][] for information about
+signaling support for a soft fork.
+
+[Segwit FAQ]: https://bitcoincore.org/en/2016/01/26/segwit-benefits/
+[segwit wallet developers guide]: https://bitcoincore.org/en/segwit_wallet_dev/
+[BIP141]: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki
+[BIP143]: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
+[BIP144]: https://github.com/bitcoin/bips/blob/master/bip-0144.mediawiki
+[BIP145]: https://github.com/bitcoin/bips/blob/master/bip-0145.mediawiki
+[versionbits FAQ]: https://bitcoincore.org/en/2016/06/08/version-bits-miners-faq/
+
+
+Null dummy soft fork
+-------------------
+
+Combined with the segwit soft fork is an additional change that turns a
+long-existing network relay policy into a consensus rule. The
+`OP_CHECKMULTISIG` and `OP_CHECKMULTISIGVERIFY` opcodes consume an extra
+stack element ("dummy element") after signature validation. The dummy
+element is not inspected in any manner, and could be replaced by any
+value without invalidating the script.
+
+Because any value can be used for this dummy element, it's possible for
+a third-party to insert data into other people's transactions, changing
+the transaction's txid (called transaction malleability) and possibly
+causing other problems.
+
+Since Bitcoin Core 0.10.0, nodes have defaulted to only relaying and
+mining transactions whose dummy element was a null value (0x00, also
+called OP_0).  The null dummy soft fork turns this relay rule into a
+consensus rule both for non-segwit transactions and segwit transactions,
+so that this method of mutating transactions is permanently eliminated
+from the network.
+
+Signaling for the null dummy soft fork is done by signaling support
+for segwit, and the null dummy soft fork will activate at the same time
+as segwit.
+
+For more information, please see [BIP147][].
+
+[BIP147]: https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki
+
+Low-level RPC changes
+---------------------
+
+- `importprunedfunds` only accepts two required arguments. Some versions accept
+  an optional third arg, which was always ignored. Make sure to never pass more
+  than two arguments.
+
+
+Linux ARM builds
+----------------
+
+With the 0.13.0 release, pre-built Linux ARM binaries were added to the set of
+uploaded executables. Additional detail on the ARM architecture targeted by each
+is provided below.
+
+The following extra files can be found in the download directory or torrent:
+
+- `bitcoin-${VERSION}-arm-linux-gnueabihf.tar.gz`: Linux binaries targeting
+  the 32-bit ARMv7-A architecture.
+- `bitcoin-${VERSION}-aarch64-linux-gnu.tar.gz`: Linux binaries targeting
+  the 64-bit ARMv8-A architecture.
+
+ARM builds are still experimental. If you have problems on a certain device or
+Linux distribution combination please report them on the bug tracker, it may be
+possible to resolve them. Note that the device you use must be (backward)
+compatible with the architecture targeted by the binary that you use.
+For example, a Raspberry Pi 2 Model B or Raspberry Pi 3 Model B (in its 32-bit
+execution state) device, can run the 32-bit ARMv7-A targeted binary. However,
+no model of Raspberry Pi 1 device can run either binary because they are all
+ARMv6 architecture devices that are not compatible with ARMv7-A or ARMv8-A.
+
+Note that Android is not considered ARM Linux in this context. The executables
+are not expected to work out of the box on Android.
+
+
+0.13.1 Change log
+=================
+
+Detailed release notes follow. This overview includes changes that affect
+behavior, not code moves, refactors and string updates. For convenience in locating
+the code changes and accompanying discussion, both the pull request and
+git merge commit are mentioned.
+
+### Consensus
+- \#8636 `9dfa0c8` Implement NULLDUMMY softfork (BIP147) (jl2012)
+- \#8848 `7a34a46` Add NULLDUMMY verify flag in bitcoinconsensus.h (jl2012)
+- \#8937 `8b66659` Define start and end time for segwit deployment (sipa)
+
+### RPC and other APIs
+- \#8581 `526d2b0` Drop misleading option in importprunedfunds (MarcoFalke)
+- \#8699 `a5ec248` Remove createwitnessaddress RPC command (jl2012)
+- \#8780 `794b007` Deprecate getinfo (MarcoFalke)
+- \#8832 `83ad563` Throw JSONRPCError when utxo set can not be read (MarcoFalke)
+- \#8884 `b987348` getblockchaininfo help: pruneheight is the lowest, not highest, block (luke-jr)
+- \#8858 `3f508ed` rpc: Generate auth cookie in hex instead of base64 (laanwj)
+- \#8951 `7c2bf4b` RPC/Mining: getblocktemplate: Update and fix formatting of help (luke-jr)
+
+### Block and transaction handling
+- \#8611 `a9429ca` Reduce default number of blocks to check at startup (sipa)
+- \#8634 `3e80ab7` Add policy: null signature for failed CHECK(MULTI)SIG (jl2012)
+- \#8525 `1672225` Do not store witness txn in rejection cache (sipa)
+- \#8499 `9777fe1` Add several policy limits and disable uncompressed keys for segwit scripts (jl2012)
+- \#8526 `0027672` Make non-minimal OP_IF/NOTIF argument non-standard for P2WSH (jl2012)
+- \#8524 `b8c79a0` Precompute sighashes (sipa)
+- \#8651 `b8c79a0` Predeclare PrecomputedTransactionData as struct (sipa)
+
+### P2P protocol and network code
+- \#8740 `42ea51a` No longer send local address in addrMe (laanwj)
+- \#8427 `69d1cd2` Ignore `notfound` P2P messages (laanwj)
+- \#8573 `4f84082` Set jonasschnellis dns-seeder filter flag (jonasschnelli)
+- \#8712 `23feab1` Remove maxuploadtargets recommended minimum (jonasschnelli)
+- \#8862 `7ae6242` Fix a few cases where messages were sent after requested disconnect (theuni)
+- \#8393 `fe1975a` Support for compact blocks together with segwit (sipa)
+- \#8282 `2611ad7` Feeler connections to increase online addrs in the tried table (EthanHeilman)
+- \#8612 `2215c22` Check for compatibility with download in FindNextBlocksToDownload (sipa)
+- \#8606 `bbf379b` Fix some locks (sipa)
+- \#8594 `ab295bb` Do not add random inbound peers to addrman (gmaxwell)
+- \#8940 `5b4192b` Add x9 service bit support to dnsseed.bluematt.me, seed.bitcoinstats.com (TheBlueMatt, cdecker)
+- \#8944 `685e4c7` Remove bogus assert on number of oubound connections. (TheBlueMatt)
+- \#8949 `0dbc48a` Be more agressive in getting connections to peers with relevant services (gmaxwell)
+
+### Build system
+- \#8293 `fa5b249` Allow building libbitcoinconsensus without any univalue (luke-jr)
+- \#8492 `8b0bdd3` Allow building bench_bitcoin by itself (luke-jr)
+- \#8563 `147003c` Add configure check for -latomic (ajtowns)
+- \#8626 `ea51b0f` Berkeley DB v6 compatibility fix (netsafe)
+- \#8520 `75f2065` Remove check for `openssl/ec.h` (laanwj)
+
+### GUI
+- \#8481 `d9f0d4e` Fix minimize and close bugs (adlawren)
+- \#8487 `a37cec5` Persist the datadir after option reset (achow101)
+- \#8697 `41fd852` Fix op order to append first alert (rodasmith)
+- \#8678 `8e03382` Fix UI bug that could result in paying unexpected fee (jonasschnelli)
+- \#8911 `7634d8e` Translate all files, even if wallet disabled (laanwj)
+- \#8540 `1db3352` Fix random segfault when closing "Choose data directory" dialog (laanwj)
+- \#7579 `f1c0d78` Show network/chain errors in the GUI (jonasschnelli)
+
+### Wallet
+- \#8443 `464dedd` Trivial cleanup of HD wallet changes (jonasschnelli)
+- \#8539 `cb07f19` CDB: fix debug output (crowning-)
+- \#8664 `091cdeb` Fix segwit-related wallet bug (sdaftuar)
+- \#8693 `c6a6291` Add witness address to address book (instagibbs)
+- \#8765 `6288659` Remove "unused" ThreadFlushWalletDB from removeprunedfunds (jonasschnelli)
+
+### Tests and QA
+- \#8713 `ae8c7df` create_cache: Delete temp dir when done (MarcoFalke)
+- \#8716 `e34374e` Check legacy wallet as well (MarcoFalke)
+- \#8750 `d6ebe13` Refactor RPCTestHandler to prevent TimeoutExpired (MarcoFalke)
+- \#8652 `63462c2` remove root test directory for RPC tests (yurizhykin)
+- \#8724 `da94272` walletbackup: Sync blocks inside the loop (MarcoFalke)
+- \#8400 `bea02dc` enable rpcbind_test (yurizhykin)
+- \#8417 `f70be14` Add walletdump RPC test (including HD- & encryption-tests) (jonasschnelli)
+- \#8419 `a7aa3cc` Enable size accounting in mining unit tests (sdaftuar)
+- \#8442 `8bb1efd` Rework hd wallet dump test (MarcoFalke)
+- \#8528 `3606b6b` Update p2p-segwit.py to reflect correct behavior (instagibbs)
+- \#8531 `a27cdd8` abandonconflict: Use assert_equal (MarcoFalke)
+- \#8667 `6b07362` Fix SIGHASH_SINGLE bug in test_framework SignatureHash (jl2012)
+- \#8673 `03b0196` Fix obvious assignment/equality error in test (JeremyRubin)
+- \#8739 `cef633c` Fix broken sendcmpct test in p2p-compactblocks.py (sdaftuar)
+- \#8418 `ff893aa` Add tests for compact blocks (sdaftuar)
+- \#8803 `375437c` Ping regularly in p2p-segwit.py to keep connection alive (jl2012)
+- \#8827 `9bbe66e` Split up slow RPC calls to avoid pruning test timeouts (sdaftuar)
+- \#8829 `2a8bca4` Add bitcoin-tx JSON tests (jnewbery)
+- \#8834 `1dd1783` blockstore: Switch to dumb dbm (MarcoFalke)
+- \#8835 `d87227d` nulldummy.py: Don't run unused code (MarcoFalke)
+- \#8836 `eb18cc1` bitcoin-util-test.py should fail if the output file is empty (jnewbery)
+- \#8839 `31ab2f8` Avoid ConnectionResetErrors during RPC tests (laanwj)
+- \#8840 `cbc3fe5` Explicitly set encoding to utf8 when opening text files (laanwj)
+- \#8841 `3e4abb5` Fix nulldummy test (jl2012)
+- \#8854 `624a007` Fix race condition in p2p-compactblocks test (sdaftuar)
+- \#8857 `1f60d45` mininode: Only allow named args in wait_until (MarcoFalke)
+- \#8860 `0bee740` util: Move wait_bitcoinds() into stop_nodes() (MarcoFalke)
+- \#8882 `b73f065` Fix race conditions in p2p-compactblocks.py and sendheaders.py (sdaftuar)
+- \#8904 `cc6f551` Fix compact block shortids for a test case (dagurval)
+
+### Documentation
+- \#8754 `0e2c6bd` Target protobuf 2.6 in OS X build notes. (fanquake)
+- \#8461 `b17a3f9` Document return value of networkhashps for getmininginfo RPC endpoint (jlopp)
+- \#8512 `156e305` Corrected JSON typo on setban of net.cpp (sevastos)
+- \#8683 `8a7d7ff` Fix incorrect file name bitcoin.qrc  (bitcoinsSG)
+- \#8891 `5e0dd9e` Update bips.md for Segregated Witness (fanquake)
+- \#8545 `863ae74` Update git-subtree-check.sh README (MarcoFalke)
+- \#8607 `486650a` Fix doxygen off-by-one comments, fix typos (MarcoFalke)
+- \#8560 `c493f43` Fix two VarInt examples in serialize.h (cbarcenas)
+- \#8737 `084cae9` UndoReadFromDisk works on undo files (rev), not on block files (paveljanik)
+- \#8625 `0a35573` Clarify statement about parallel jobs in rpc-tests.py (isle2983)
+- \#8624 `0e6d753` build: Mention curl (MarcoFalke)
+- \#8604 `b09e13c` build,doc: Update for 0.13.0+ and OpenBSD 5.9 (laanwj)
+- \#8939 `06d15fb` Update implemented bips for 0.13.1 (sipa)
+
+### Miscellaneous
+- \#8742 `d31ac72` Specify Protobuf version 2 in paymentrequest.proto (fanquake)
+- \#8414,#8558,#8676,#8700,#8701,#8702 Add missing copyright headers (isle2983, kazcw)
+- \#8899 `4ed2627` Fix wake from sleep issue with Boost 1.59.0 (fanquake)
+- \#8817 `bcf3806` update bitcoin-tx to output witness data (jnewbery)
+- \#8513 `4e5fc31` Fix a type error that would not compile on OSX. (JeremyRubin)
+- \#8392 `30eac2d` Fix several node initialization issues (sipa)
+- \#8548 `305d8ac` Use `__func__` to get function name for output printing (MarcoFalke)
+- \#8291 `a987431` [util] CopyrightHolders: Check for untranslated substitution (MarcoFalke)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- adlawren
+- Alexey Vesnin
+- Anders Øyvind Urke-Sætre
+- Andrew Chow
+- Anthony Towns
+- BtcDrak
+- Chris Stewart
+- Christian Barcenas
+- Christian Decker
+- Cory Fields
+- crowning-
+- Dagur Valberg Johannsson
+- David A. Harding
+- Eric Lombrozo
+- Ethan Heilman
+- fanquake
+- Gaurav Rana
+- Gregory Maxwell
+- instagibbs
+- isle2983
+- Jameson Lopp
+- Jeremy Rubin
+- jnewbery
+- Johnson Lau
+- Jonas Schnelli
+- jonnynewbs
+- Justin Camarena
+- Kaz Wesley
+- leijurv
+- Luke Dashjr
+- MarcoFalke
+- Marty Jones
+- Matt Corallo
+- Micha
+- Michael Ford
+- mruddy
+- Pavel Janík
+- Pieter Wuille
+- rodasmith
+- Sev
+- Suhas Daftuar
+- whythat
+- Wladimir J. van der Laan
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).


### PR DESCRIPTION
This adds a release blog post for 0.13.1.

**TODO**

- [ ] This assumes the release date is Monday 31 Oct 2016.  If it as any other date, the file needs to be moved and the YAML header needs to edited.
- [ ] At the very top of the document, a link needs to be added to @laanwj's PGP-signed release announcement (as we did with the previous release).  The tests should fail until this is added, but I see they succeeded, which I guess means I'll have to fix that...
- [ ] The SHA256 hashes of the release files should be added to the bottom of this document (the "Hashes for verification" section) as was done for the previous release.
- [x] https://github.com/bitcoin-core/bitcoincore.org/pull/240 needs to be merged before this, or this document needs to be edited to stop linking to it.  (The tests should also be failing because that's missing in this branch...)

---

A preview for the blog post as of fd373869eab2e473c7953efe3098d2d604a2f9c3 may be found at: http://imgur.com/a/gKi9W

The post entry on the main page looks like this:

![2016-10-26-21_01_20_253721417](https://cloud.githubusercontent.com/assets/61096/19750483/6613a372-9bbf-11e6-8b5a-36d88d3e100d.png)

Please note that if you attempt to generate a preview of this document, you will need to add `--future` to Jekyll's parameters because the post is dated for 2016-10-31.

Several people provided suggestions on this in draft form, for which I am very grateful. Any errors that appear in this version are entirely my fault.  For anyone who read the final draft version, I've made a few small changes:

1. I further shortened some of the descriptions in the new features summary section at the top.  The only significant phrasing change is in point 7 (More efficient almost-full-node security).  I added a few paragraph breaks in the corresponding detail subsections but no words were changed there.

2. To the end of the document, I added a new Conclusion section (and also the template Hashes For Verification section) to match the format of the 0.13.0 release blog.

3. I changed the opening to the null dummy section to make it flow a little better.

As requested in some of the draft feedback, I added the ability to link directly to each of the items on the timeline.  This is a little bit ugly, so I'm open to suggestions for making it look nicer.  Screenshot below (the `#` are both the link and the anchor):

![2016-10-26-21_07_22_112758683](https://cloud.githubusercontent.com/assets/61096/19750577/393364d6-9bc0-11e6-9240-ea88e9dedf75.png)


