### PR TITLE
Travis: build all possible pages for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ cache: bundler
 ## Disable external link checking to prevent spurious failures because
 ## of other people's downtime. This can also avoid wasting their
 ## bandwidth.
-script: bundle exec jekyll build && bundle exec htmlproof --disable-external ./_site
+#
+## Build all possible jekyll pages for use with link checking.
+script: bundle exec jekyll build --future --drafts --unpublished && bundle exec htmlproof --disable-external ./_site
 
 env:
   global:

--- a/README.md
+++ b/README.md
@@ -55,15 +55,21 @@ and then run the following commands:
 
 To preview the site (this will launch a tiny webserver on port 4000):
 
-    bundle exec jekyll server
+    bundle exec jekyll server --future
 
 To simply build the site (output placed in the `_site` directory):
 
-    bundle exec jekyll build
+    bundle exec jekyll build --future
+
+Note that the `--future` parameter is only required if you're adding any
+pages dated in the future (such as prepared release announcements).
 
 To test the site:
 
-    bundle exec jekyll build && bundle exec htmlproof ./_site
+    bundle exec jekyll build --future --drafts --unpublished && bundle exec htmlproof ./_site
+
+The additional parameters to `jekyll build` ensure that all possible
+pages are built and checked.
 
 ## Contributing
 


### PR DESCRIPTION
In https://github.com/bitcoin-core/bitcoincore.org/pull/241#issue-185549835 I mentioned that the Travis CI tests were passing when they were expected to fail.  This commit resolves that issue.

The problem was that pull request included a page with a future date and the previous Travis configuration didn't build or test pages with future dates.  As of this commit, Travis should build all possible pages (as best I can tell from `jekyll build --help`) so that they are all tested.