### PR TITLE
Meeting notes 2017-10-27: correct attribution for harding

### DIFF
--- a/_includes/_references.md
+++ b/_includes/_references.md
@@ -37,6 +37,7 @@
 [Michagogo]: https://github.com/Michagogo
 [Olaoluwa Osuntokun]: https://github.com/Roasbeef
 [Chris Stewart]: https://github.com/Christewart
+[David Harding]: https://github.com/harding/
 
 [BIP1]: https://github.com/bitcoin/bips/blob/master/bip-0001.mediawiki
 [BIP9]: https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki

--- a/_posts/en/meetings/2016-10-27-meeting.md
+++ b/_posts/en/meetings/2016-10-27-meeting.md
@@ -77,7 +77,7 @@ The difficulty can fall that low under a soft fork to a different proof-of-work,
 | Chris_Stewart_5 | [Chris Stewart][]         |
 | CodeShark       | [Eric Lombrozo][]         |
 | morcos          | [Alex Morcos][]           |
-| Harding         | [Tom Harding][]           |
+| harding         | [David Harding][]           |
 | jtimon          | [Jorge Timón][]           |
 | BlueMatt        | [Matt Corallo][]          |
 | kanzure         | [Bryan Bishop][]          |


### PR DESCRIPTION
The following line from the meeting,

```
15:09 < harding> btcdrak: https://lists.linuxfoundation.org/pipermail/bitcoin-core-dev/2016-October/000023.html
```

was attributed to Tom Harding, who uses the nick `dgenr8` rather than to me.  I'm not sure pasting a link is noteworthy enough to be included as a "participant", but this commit corrects the attribution anyway.

Thanks to /u/thorjag on Reddit for [pointing this out](https://www.reddit.com/r/Bitcoin/comments/5as3mu/bitcoin_core_irc_meeting_summary_october_27_2016/d9jn732/).  

@G1lius sorry for the confusion.  In case it helps in the future, there is an IRC command, `/whois` that will display information about a user, including a real name that the user can optionally set.  (On Freenode, I think you need to be in at least one of the same rooms as the user to use it).

```text
/whois harding
04:20 -!- harding [~harding@mail.dtrt.org]
04:20 -!-  ircname  : David A. Harding
04:20 -!-  channels : #sidechains-dev #bitcoin-core-dev #bitcoin 
04:20 -!-  server   : rajaniemi.freenode.net [Helsinki, FI, EU]
04:20 -!-  hostname : [...]
04:20 -!-  idle     : 5 days 11 hours 42 mins 20 secs [signon: Mon Oct 24 08:40:14 2016]
04:20 -!-  account  : harding
```

That may help identifying some people.

**Edit:** oh, related to this commit, I also scanned the log for the day of the meeting, and dgenr8/Tom didn't say anything that day, so removing him from the list should be fine.