### PR TITLE
Add bitcoinreminder.com to segwitsupport.csv

### DIFF
--- a/_data/segwitsupport.csv
+++ b/_data/segwitsupport.csv
@@ -15,6 +15,7 @@ Bitcoin Knots,https://bitcoinknots.org/,ready,"node, wallet",n/a
 BitcoinJ,https://bitcoinj.github.io/,wip,library,n/a
 bitcoin-lib,https://github.com/ACINQ/bitcoin-lib,ready,library,n/a
 bitcoin-s,https://github.com/bitcoin-s/bitcoin-s-core,ready,library,
+BitcoinReminder.com,https://bitcoinreminder.com,ready,service,
 Bitcoinjs,http://bitcoinjs.org/,wip,library,n/a
 bitcore-lib,https://bitcore.io/,wip,library,n/a
 Bitfinex,https://www.bitfinex.com/,ready,exchange,


### PR DESCRIPTION
If possible, would be nice if you could add our service, because we are big fans of core & segwit.

We also announced our segwit + core support in our news announcements (https://bitcoinreminder.com, look at the left side)