### PR TITLE
Meetings: fix quote attribution in 2017-03-23 meeting

### DIFF
--- a/_posts/en/meetings/2017-03-23-meeting.md
+++ b/_posts/en/meetings/2017-03-23-meeting.md
@@ -84,7 +84,7 @@ Gregory Maxwell asked if developers would be willing to sign a statement regardi
 
 > The Bitcoin project would never ask users to run a binary without providing the source.  If it ever does, you may safely assume that the actual contributors to the project are locked in a basement somewhere. In that case, please send help.
 
-Wladimir van der Laan suggested that people send not only help but also food.
+Bryan Bishop suggested that people send not only help but also food.
 
 There were several other suggestions to refine the statement but no one spoke in opposition of the statement.
 


### PR DESCRIPTION
In writing the notes, I misinterpreted the colorized logs and gave the wrong attribution for this quote.  I guess it's back to reading raw logs in `less` for me.

![2017-03-31-21_42_56_058956272](https://cloud.githubusercontent.com/assets/61096/24574052/0b406a4a-165b-11e7-98fe-8539b820918c.png)