### PR TITLE
Add BIP152 to implemented list

### DIFF
--- a/_includes/pages/bips-list.md
+++ b/_includes/pages/bips-list.md
@@ -29,3 +29,4 @@
 |[144][BIP144]| v0.13.0       |[Segregated Witness (Peer Services)][BIP144]|
 |[145][BIP145]| v0.13.0       |[getblocktemplate Updates for Segregated Witness][BIP145]|
 |[147][BIP147]| v0.13.1       |[Dealing with dummy stack element malleability][BIP147]|
+|[152][BIP152]| v0.13.0       |[Compact Block Relay][BIP152]|


### PR DESCRIPTION
[BIP152](https://github.com/bitcoin/bips/blob/master/bip-0152.mediawiki) (compact block relay) was [implemented in 0.13.0](https://bitcoincore.org/en/releases/0.13.0/#compact-block-support-bip-152).