### PR TITLE
Release blog & notes for 0.14.1

### DIFF
--- a/_posts/en/posts/2017-04-22-release-0.14.1.md
+++ b/_posts/en/posts/2017-04-22-release-0.14.1.md
@@ -1,0 +1,75 @@
+---
+title: Bitcoin Core 0.14.1 Released
+name: blog-release-0.14.1
+id: en-blog-release-0.14.1
+lang: en
+permalink: /en/2017/04/22/release-0.14.1/
+type: posts
+layout: post
+share: true
+version: 1
+
+excerpt: The latest stable version of Bitcoin Core is now available.
+---
+{% include _toc.html %}
+{% include _references.md %}
+
+We are pleased to announce the general availability of Bitcoin Core 0.14.1. This release forms part of the regular maintenance cycle of Bitcoin Core and brings bug fixes, optimisations and improvements to the 0.14.x series.
+
+## Notable changes
+
+### RPC changes
+
+- The first positional argument of `createrawtransaction` was renamed from `transactions` to `inputs`.
+
+- The argument of `disconnectnode` was renamed from `node` to `address`.
+
+These interface changes break compatibility with 0.14.0, when the named arguments functionality, introduced in 0.14.0, is used. Client software using these calls with named arguments need to be updated.
+
+### Mining
+
+In previous versions, the `getblocktemplate` RPC required segwit support from downstream clients/miners once segwit activated on the network. In this version, it now supports non-segwit clients even after activation by removing all segwit transactions from the returned block template.  This allows non-segwit miners to continue functioning correctly even after segwit has activated.
+
+Due to the limitations in previous versions, getblocktemplate also recommended non-segwit clients to not signal for the segwit version-bit. Since this is no longer an issue, getblocktemplate now always recommends signalling segwit for all miners. This is safe because the ability to enforce the rule is the only required criteria for safe activation (actually producing segwit-enabled blocks is not required).
+
+### UTXO memory accounting
+
+Memory usage for the UTXO cache is being calculated more accurately, so that the configured limit (`-dbcache`) will be respected when memory usage peaks during cache flushes.  The memory accounting in prior releases is estimated to only account for half the actual peak utilization.
+
+The default `-dbcache` has also been changed in this release to 450MiB.  Users who currently set `-dbcache` to a high value (e.g. to keep the UTXO more fully cached in memory) should consider increasing this setting in order to achieve the same cache performance as prior releases.  Users on low-memory systems (such as systems with 1GB or less) should consider specifying a lower value for this parameter.
+
+Additional information relating to running on low-memory systems can be found here: [reducing-bitcoind-memory-usage](https://gist.github.com/laanwj/efe29c7661ce9b6620a7).
+
+## Conclusion
+
+For details on all the changes made in Bitcoin Core 0.14.1, please read the [release notes][]. To download, please visit the [download page][] or the [files directory][].
+
+The next major planned release will be Bitcoin Core 0.15.0.  It will begin with a freeze on new feature additions in mid-July and a release when release candidate testing has completed, anticipated to be in early September.  For more information, please see the [schedule][].
+
+If you are interested in contributing to Bitcoin Core, please see our [contributing page][] and the document [How to contribute code to Bitcoin Core][]. If you don’t know where to get started or have any other questions, please stop by either our [IRC][] or [Slack][] chatrooms and we’ll do our best to help you.
+
+## Hashes for verification
+
+{% highlight text %}
+a60d7c8dde9b77e7ff547976ce37db1fe98c71833003465befe650d6bc102b6b  bitcoin-0.14.1-aarch64-linux-gnu.tar.gz
+cd23ffe044b56dd56d3b9ba384e606c44000b60f44e0a74a19c313a4f30ea5c8  bitcoin-0.14.1-arm-linux-gnueabihf.tar.gz
+ff6bf851dae036905de6272562cca4b94c4842f758b7bd68879a088fe7b0f662  bitcoin-0.14.1-i686-pc-linux-gnu.tar.gz
+a786381246b92a81a5f5c9cb538d162ab051e51e84a10449f5f7fc310137b258  bitcoin-0.14.1-osx64.tar.gz
+2052793453ad37b8e00527942a7150f23f1c5dd5903e5e3e8a3b444dee81e3e0  bitcoin-0.14.1-osx.dmg
+f21203e07f054dce3177539be89a066d4faee1e2fa432157c1444e4e6dd4f9a3  bitcoin-0.14.1.tar.gz
+875f5995a47e5a1b1becaa02591400fc90bfc1a471b15eed71232b161efcdb1b  bitcoin-0.14.1-win32-setup.exe
+7146cfd057eb9d9f37444106e2649d059cc85fa390e5af0037acd8ef61574aaf  bitcoin-0.14.1-win32.zip
+3ebf2c58e3b60dd79153bf2a043a5f90402b8067b21a93dd88763c96dd8baba6  bitcoin-0.14.1-win64-setup.exe
+851306112811ef49e89b2a105f4c78dd38fa4997dc913b9a748040605a33640d  bitcoin-0.14.1-win64.zip
+0c6920a9f3181a95ca029fdac5342b5702569ee441ec2128d19051f281683058  bitcoin-0.14.1-x86_64-linux-gnu.tar.gz
+{% endhighlight %}
+
+[release notes]: /en/releases/0.14.1/
+[download page]: https://bitcoin.org/en/download
+[files directory]: https://bitcoin.org/bin/bitcoin-core-0.14.1/
+[schedule]: https://github.com/bitcoin/bitcoin/issues/9961
+[contributing page]: /en/contribute
+[How to contribute code to Bitcoin Core]: /en/faq/contributing-code/
+[IRC]: https://en.bitcoin.it/wiki/IRC_channels
+[Slack]: https://slack.bitcoincore.org/
+

--- a/_posts/en/releases/2017-04-22-release-0.14.1.md
+++ b/_posts/en/releases/2017-04-22-release-0.14.1.md
@@ -1,0 +1,165 @@
+---
+title: Bitcoin Core 0.14.1
+id: en-release-0.14.1
+name: release-0.14.1
+permalink: /en/releases/0.14.1/
+type: releases
+layout: page
+lang: en
+share: true
+
+# From bitcoin commit 964a185cc83af34587194a6ecda3ed9cf6b49263
+#
+# Note: if updating this file using copy/paste, you want to make the
+#       following global substitution to get the lists of merged PRs to
+#       render correctly: s/^- #/- \\#/  (so "- #" becomes "- \#") 
+#
+#       Also recommended is to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+{% include _download.html %}
+
+Bitcoin Core version 0.14.1 is now available from:
+
+  <https://bitcoin.org/bin/bitcoin-core-0.14.1/>
+
+This is a new minor version release, including various bugfixes and
+performance improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+Compatibility
+==============
+
+Bitcoin Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later.
+
+Microsoft ended support for Windows XP on [April 8th, 2014](https://www.microsoft.com/en-us/WindowsForBusiness/end-of-xp-support),
+No attempt is made to prevent installing or running the software on Windows XP, you
+can still do so at your own risk but be aware that there are known instabilities and issues.
+Please do not report issues about Windows XP to the issue tracker.
+
+Bitcoin Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+Notable changes
+===============
+
+RPC changes
+-----------
+
+- The first positional argument of `createrawtransaction` was renamed from
+  `transactions` to `inputs`.
+
+- The argument of `disconnectnode` was renamed from `node` to `address`.
+
+These interface changes break compatibility with 0.14.0, when the named
+arguments functionality, introduced in 0.14.0, is used. Client software
+using these calls with named arguments needs to be updated.
+
+Mining
+------
+
+In previous versions, getblocktemplate required segwit support from downstream
+clients/miners once the feature activated on the network. In this version, it
+now supports non-segwit clients even after activation, by removing all segwit
+transactions from the returned block template. This allows non-segwit miners to
+continue functioning correctly even after segwit has activated.
+
+Due to the limitations in previous versions, getblocktemplate also recommended
+non-segwit clients to not signal for the segwit version-bit. Since this is no
+longer an issue, getblocktemplate now always recommends signalling segwit for
+all miners. This is safe because ability to enforce the rule is the only
+required criteria for safe activation, not actually producing segwit-enabled
+blocks.
+
+UTXO memory accounting
+----------------------
+
+Memory usage for the UTXO cache is being calculated more accurately, so that
+the configured limit (`-dbcache`) will be respected when memory usage peaks
+during cache flushes.  The memory accounting in prior releases is estimated to
+only account for half the actual peak utilization.
+
+The default `-dbcache` has also been changed in this release to 450MiB.  Users
+who currently set `-dbcache` to a high value (e.g. to keep the UTXO more fully
+cached in memory) should consider increasing this setting in order to achieve
+the same cache performance as prior releases.  Users on low-memory systems
+(such as systems with 1GB or less) should consider specifying a lower value for
+this parameter.
+
+Additional information relating to running on low-memory systems can be found
+here:
+[reducing-bitcoind-memory-usage.md](https://gist.github.com/laanwj/efe29c7661ce9b6620a7).
+
+0.14.1 Change log
+=================
+
+Detailed release notes follow. This overview includes changes that affect
+behavior, not code moves, refactors and string updates. For convenience in locating
+the code changes and accompanying discussion, both the pull request and
+git merge commit are mentioned.
+
+### RPC and other APIs
+- \#10084 `142fbb2` Rename first named arg of createrawtransaction (MarcoFalke)
+- \#10139 `f15268d` Remove auth cookie on shutdown (practicalswift)
+- \#10146 `2fea10a` Better error handling for submitblock (rawodb, gmaxwell)
+- \#10144 `d947afc` Prioritisetransaction wasn't always updating ancestor fee (sdaftuar)
+- \#10204 `3c79602` Rename disconnectnode argument (jnewbery)
+
+### Block and transaction handling
+- \#10126 `0b5e162` Compensate for memory peak at flush time (sipa)
+- \#9912 `fc3d7db` Optimize GetWitnessHash() for non-segwit transactions (sdaftuar)
+- \#10133 `ab864d3` Clean up calculations of pcoinsTip memory usage (morcos)
+
+### P2P protocol and network code
+- \#9953/#10013 `d2548a4` Fix shutdown hang with >= 8 -addnodes set (TheBlueMatt)
+- \#10176 `30fa231` net: gracefully handle NodeId wrapping (theuni)
+
+### Build system
+- \#9973 `e9611d1` depends: fix zlib build on osx (theuni)
+
+### GUI
+- \#10060 `ddc2dd1` Ensure an item exists on the rpcconsole stack before adding (achow101)
+
+### Mining
+- \#9955/#10006 `569596c` Don't require segwit in getblocktemplate for segwit signalling or mining (sdaftuar)
+- \#9959/#10127 `b5c3440` Prevent slowdown in CreateNewBlock on large mempools (sdaftuar)
+
+### Tests and QA
+- \#10157 `55f641c` Fix the `mempool_packages.py` test (sdaftuar)
+
+### Miscellaneous
+- \#10037 `4d8e660` Trivial: Fix typo in help getrawtransaction RPC (keystrike)
+- \#10120 `e4c9a90` util: Work around (virtual) memory exhaustion on 32-bit w/ glibc (laanwj)
+- \#10130 `ecc5232` bitcoin-tx input verification (awemany, jnewbery)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Alex Morcos
+- Andrew Chow
+- Awemany
+- Cory Fields
+- Gregory Maxwell
+- James Evans
+- John Newbery
+- MarcoFalke
+- Matt Corallo
+- Pieter Wuille
+- practicalswift
+- rawodb
+- Suhas Daftuar
+- Wladimir J. van der Laan
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+


### PR DESCRIPTION
Release blog post is just the Notable Changes section of the release notes with some introduction and conclusion boilerplate bolted on, and a couple minor edits.