### PR TITLE
Update Armory segwit status to Ready

### DIFF
--- a/_data/segwitsupport.csv
+++ b/_data/segwitsupport.csv
@@ -2,7 +2,7 @@ name,url,status,notes,depends
 1200wd,https://github.com/1200wd/bitcoinlib,wip,library,
 AirBitz,https://airbitz.co/,ready,wallet,
 AnycoinDirect,https://anycoindirect.eu,wip,broker,bitcoin core
-Armory,https://github.com/goatpig/BitcoinArmory/tree/SegWit/,wip,wallet,bitcoin core
+Armory,https://github.com/goatpig/BitcoinArmory/,ready,wallet,bitcoin core
 Authparty,http://authparty.io,planned,authentication library,bitcoin core
 Bcoin,https://github.com/bcoin-org/bcoin,ready,library,
 BetKing,https://betking.io,wip,gambling,bitcoin core


### PR DESCRIPTION
Armory's latest release, 0.96.0, has all segwit functionality but is hard coded to be disabled on the mainnet. This will be changed in another release to enabled once segwit is activated or until we finish BIP 9 soft fork detection. I think that is enough to mark it as ready.