### PR TITLE
Pages: add new page about Twitter Impersonation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -90,6 +90,9 @@ en:
       announcements:
         title: "Announcements"
         url: "/en/list/announcements/join/"
+      twitter_impersonation:
+        title: "Twitter impersonation"
+        url: "/en/twitter-impersonation"
 zh_CN:
   home:
     title: "Bitcoin Core"

--- a/_posts/en/pages/2017-01-01-twitter-impersonation.md
+++ b/_posts/en/pages/2017-01-01-twitter-impersonation.md
@@ -1,0 +1,57 @@
+---
+title: Twitter impersonation
+name: contact
+permalink: /en/twitter-impersonation/
+type: pages
+layout: page
+lang: en
+share: false
+version: 1
+---
+We are aware of several accounts on Twitter that violate [Twitter's
+Impersonation Policy][] by pretending to be the Bitcoin Core project or
+well-known individuals associated with Bitcoin Core.  These accounts
+have been spreading false and misleading information about Bitcoin Core
+and its contributors.
+
+If you see one of these accounts, you may [report it to Twitter][].  If
+you are reporting an issue about the Bitcoin Core project and Twitter
+asks that you enter the project's official email address, please use:
+contact<span style="display:none"></span>@bitcoincore.org
+
+This appears to be an unfortunately common issue on Twitter that affects
+many other projects and individuals as well, so we urge you to carefully
+evaluate any posts you see on Twitter---and elsewhere---to determine
+whether or not they truly came from the indicated sender.
+
+It is especially important to be careful about posts that recommend you
+take an action that could potentially compromise your bitcoins or your
+computer, such as a suggestion that you download a newer version of
+Bitcoin software.  The latest version of Bitcoin Core can always be
+obtained from the [download page][], and for greater security you are
+recommended to verify the binary integrity using PGP (see the [full node
+guide][] for instructions).
+
+The Bitcoin Core project will never contact you to ask you to disclose
+information from your Bitcoin wallet, including your balance, addresses,
+transactions, or private keys.  If you receive a security announcement
+and aren't sure whether or not it is legitimate, you can safely shutdown
+your Bitcoin Core program to eliminate any immediate problems and give
+yourself time to investigate.
+
+Although Bitcoin Core does have an official Twitter account,
+[@bitcoincoreorg][], any important announcements about the project will
+also sent to our low-traffic [announcements mailing list][] or posted on
+the [front page of this website][] (which also has an [RSS feed][]).  If
+you know how to use PGP security software, subscribing to the mailing
+list is particularly recommended as all announcements will be
+cryptographically signed by a developer.
+
+[Twitter's Impersonation Policy]: https://support.twitter.com/articles/18366#
+[report it to Twitter]: https://support.twitter.com/forms/impersonation
+[@bitcoincoreorg]: https://twitter.com/bitcoincoreorg
+[announcements mailing list]: /en/list/announcements/join/
+[front page of this website]: /
+[RSS feed]: /en/rss.xml
+[download page]: /bin/
+[full node guide]: https://bitcoin.org/en/full-node


### PR DESCRIPTION
In https://github.com/bitcoin-dot-org/bitcoin.org/issues/1842 @midnightmagic requested a page explicitly mentioning the Twitter impersonation accounts are fake.  This PR adds a short statement to that effect, including mentioning Bitcoin Core's official twitter account.

The page is added to the Contact menu:

![2017-10-07-10_18_46_574829865](https://user-images.githubusercontent.com/61096/31308694-014ecddc-ab49-11e7-9b73-9230bc241d31.png)

Note that I reported one of the accounts (*@BcoreProject*) to Twitter about a month ago and it's still there, so I'm not sure we can expect much action from Twitter on this issue.