### PR TITLE
Fix name duplication

### DIFF
--- a/_posts/en/pages/2017-01-01-twitter-impersonation.md
+++ b/_posts/en/pages/2017-01-01-twitter-impersonation.md
@@ -1,6 +1,6 @@
 ---
 title: Twitter impersonation
-name: contact
+name: twitter-impersonation
 permalink: /en/twitter-impersonation/
 type: pages
 layout: page


### PR DESCRIPTION
Twitter impersonation page's name description is duplicate with Contact page. 
So language pulldown shows duplicate menu.

<img width="249" alt="screen" src="https://user-images.githubusercontent.com/1539047/31496773-ad83b4b2-af97-11e7-9628-3c4a303e1ddc.png">
