### PR TITLE
Add link to meeting bot logs

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -11,4 +11,6 @@ version: 2
 The project usually holds IRC meetings every Thursday at 19:00 UTC in `#bitcoin-core-dev` on irc.freenode.net.
 Everyone is welcome to attend.
 
+The following summaries list may not be complete due to constraints on volunteers' time. To view more recent logs, all meeting logs and raw minutes can be found [here](http://www.erisian.com.au/meetbot/bitcoin-core-dev/).
+
 {% include _meetings.html %}


### PR DESCRIPTION
A few people have asked about the out-of-date meeting list in IRC recently. This adds a note to the page with a link to the minutes and logs produced by the meeting bot.