### PR TITLE
Download page: change "source code" link to current tag

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -69,7 +69,7 @@
       <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc" class="dl">{{ page.downloadsig }}</a><br>
       <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}.torrent" class="dl">{{ page.downloadtorrent }}</a>
         {% if magnet %} <a href="{{ magnet | replace: '&', '\&amp;'}}" class="magnetlink" data-proofer-ignore></a>{% endif %}<br>
-      <a href="https://github.com/bitcoin/bitcoin" class="dl">{{ page.source }}</a><br>
+      <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX}}.tar.gz" class="dl">{{ page.source }}</a><br>
       <a href="/en/releases">{{ page.versionhistory }}</a>
     </p>
     <p class="downloadkeys">


### PR DESCRIPTION
Requested by @MarcoFalke in https://github.com/bitcoin-core/bitcoincore.org/pull/452#pullrequestreview-70759560

I confirmed using a local preview that the current link points to https://github.com/bitcoin/bitcoin/releases/tag/v0.15.0.1

Not implemented is @MarcoFalke's suggestion to change the text associated with the link.  I think "source code" is more understandable to most people than "git source".  If there is still a desire to change the text, I'm happy to do that.