### PR TITLE
Blogs: post for 0.16.0 release

### DIFF
--- a/_posts/en/posts/2018-02-26-release-0.16.0.md
+++ b/_posts/en/posts/2018-02-26-release-0.16.0.md
@@ -1,0 +1,191 @@
+---
+title: Bitcoin Core 0.16.0 Released
+name: blog-release-0.16.0
+id: en-blog-release-0.16.0
+lang: en
+permalink: /en/2018/02/26/release-0.16.0/
+type: posts
+layout: post
+share: true
+version: 1
+
+excerpt: >
+  Bitcoin Core 0.16.0 has been released with default wallet support for
+  segwit.
+
+---
+{% include _toc.html %}
+{% include _references.md %}
+
+We are pleased to announce the release of Bitcoin Core 0.16.0, the first
+version of Bitcoin Core to include default wallet support for segregated
+witness (segwit).  The release also contains several other improvements
+and bug fixes as described below.
+
+The latest release is available for download from the [Download
+Page][] 
+
+The following sections describe the most significant changes in this
+release.  For full details, please see the [Release Notes][].
+
+### Segwit Wallet
+
+Bitcoin Core 0.16.0 introduces full support for segwit in the wallet and user interfaces. A new `-addresstype` argument has been added, which supports `legacy`, `p2sh-segwit` (default), and `bech32` addresses. It controls what kind of addresses are produced by `getnewaddress`, `getaccountaddress`, and `createmultisigaddress`. A `-changetype` argument has also been added, with the same options, and by default equal to `-addresstype`, to control which kind of change is used.
+
+A new `address_type` parameter has been added to the `getnewaddress` and `addmultisigaddress` RPCs to specify which type of address to generate.
+A `change_type` argument has been added to the `fundrawtransaction` RPC to override the `-changetype` argument for specific transactions.
+
+- All segwit addresses created through `getnewaddress` or `*multisig` RPCs explicitly get their redeemscripts added to the wallet file. This means that downgrading after creating a segwit address will work, as long as the wallet file is up to date.
+- All segwit keys in the wallet get an implicit redeemscript added, without it being written to the file. This means recovery of an old backup will work, as long as you use new software.
+- All keypool keys that are seen used in transactions explicitly get their redeemscripts added to the wallet files. This means that downgrading after recovering from a backup that includes a segwit address will work
+
+Note that some RPCs do not yet support segwit addresses. Notably, `signmessage`/`verifymessage` doesn't support segwit addresses, nor does `importmulti` at this time. Support for segwit in those RPCs will continue to be added in future versions.
+
+P2WPKH change outputs are now used by default if any destination in the transaction is a P2WPKH or P2WSH output. This is done to ensure the change output is as indistinguishable from the other outputs as possible in either case.
+
+### BIP173 (Bech32) Address support ("bc1..." addresses)
+
+Full support for native segwit addresses (BIP173 / Bech32) has now been added.
+This includes the ability to send to BIP173 addresses (including non-v0 ones), and generating these
+addresses (including as default new addresses, see above).
+
+A checkbox has been added to the GUI to select whether a Bech32 address or P2SH-wrapped address should be generated when using segwit addresses. When launched with `-addresstype=bech32` it is checked by default. When launched with `-addresstype=legacy` it is unchecked and disabled.
+
+### HD-wallets by default
+
+Due to a backward-incompatible change in the wallet database, wallets created
+with version 0.16.0 will be rejected by previous versions. Also, version 0.16.0
+will only create hierarchical deterministic (HD) wallets. Note that this only applies
+to new wallets; wallets made with previous versions will not be upgraded to be HD.
+
+### Replace-By-Fee by default in GUI
+
+The send screen now uses BIP125 RBF by default, regardless of `-walletrbf`.
+There is a checkbox to mark the transaction as final.
+
+The RPC default remains unchanged: to use RBF, launch with `-walletrbf=1` or
+use the `replaceable` argument for individual transactions.
+
+### Wallets directory configuration
+
+Bitcoin Core now has more flexibility in where the wallets directory can be
+located. Previously wallet database files were stored at the top level of the
+bitcoin data directory. The behavior is now:
+
+- For new installations (where the data directory doesn't already exist),
+  wallets will now be stored in a new `wallets/` subdirectory inside the data
+  directory by default.
+- For existing nodes (where the data directory already exists), wallets will be
+  stored in the data directory root by default. If a `wallets/` subdirectory
+  already exists in the data directory root, then wallets will be stored in the
+  `wallets/` subdirectory by default.
+- The location of the wallets directory can be overridden by specifying a
+  `-walletdir=<path>` option where `<path>` can be an absolute path to a
+  directory or directory symlink.
+
+Care should be taken when choosing the wallets directory location, as if it
+becomes unavailable during operation, funds may be lost.
+
+### Support for signalling pruned nodes (BIP159)
+
+Pruned nodes can now signal BIP159's NODE_NETWORK_LIMITED using service bits, in preparation for
+full BIP159 support in later versions. This would allow pruned nodes to serve the most recent blocks. However, the current change does not yet include support for connecting to these pruned peers.
+
+### Performance: SHA256 assembly enabled by default
+
+The SHA256 hashing optimizations for architectures supporting SSE4, which lead to ~50% speedups in SHA256 on supported hardware (~5% faster synchronization and block validation), have now been enabled by default. In previous versions they were enabled using the `--enable-experimental-asm` flag when building, but are now the default and no longer deemed experimental.
+
+### GUI changes
+
+- Uses of "µBTC" in the GUI now also show the more colloquial term "bits", specified in BIP176.
+- The option to reuse a previous address has now been removed. This was justified by the need to "resend" an invoice, but now that we have the request history, that need should be gone.
+- Support for searching by TXID has been added, rather than just address and label.
+- A "Use available balance" option has been added to the send coins dialog, to add the remaining available wallet balance to a transaction output.
+- A toggle for unblinding the password fields on the password dialog has been added.
+
+### New rescanblockchain RPC
+
+A new RPC `rescanblockchain` has been added to manually invoke a blockchain rescan.
+The RPC supports start and end-height arguments for the rescan, and can be used in a
+multiwallet environment to rescan the blockchain at runtime.
+
+### New savemempool RPC
+
+A new `savemempool` RPC has been added which allows the current mempool to be saved to
+disk at any time to avoid it being lost due to crashes / power loss.
+
+### Safe mode disabled by default
+
+Safe mode is now disabled by default and must be manually enabled (with `-disablesafemode=0`) if you wish to use it. Safe mode is a feature that disables a subset of RPC calls - mostly related to the wallet and sending - automatically in case certain problem conditions with the network are detected. However, developers have come to regard these checks as not reliable enough to act on automatically. Even with safe mode disabled, they will still cause warnings in the `warnings` field of the `getneworkinfo` RPC and launch the `-alertnotify` command.
+
+### Renamed script for creating JSON-RPC credentials
+
+The `share/rpcuser/rpcuser.py` script was renamed to `share/rpcauth/rpcauth.py`. This script can be
+used to create `rpcauth` credentials for a JSON-RPC user.
+
+### Validateaddress improvements
+
+The `validateaddress` RPC output has been extended with a few new fields, and support for segwit addresses (both P2SH and Bech32). Specifically:
+* A new field `iswitness` is True for P2WPKH and P2WSH addresses ("bc1..." addresses), but not for P2SH-wrapped segwit addresses (see below).
+* The existing field `isscript` will now also report True for P2WSH addresses.
+* A new field `embedded` is present for all script addresses where the script is known and matches something that can be interpreted as a known address. This is particularly true for P2SH-P2WPKH and P2SH-P2WSH addresses. The value for `embedded` includes much of the information `validateaddress` would report if invoked directly on the embedded address.
+* For multisig scripts a new `pubkeys` field was added that reports the full public keys involved in the script (if known). This is a replacement for the existing `addresses` field (which reports the same information but encoded as P2PKH addresses), represented in a more useful and less confusing way. The `addresses` field remains present for non-segwit addresses for backward compatibility.
+* For all single-key addresses with known key (even when wrapped in P2SH or P2WSH), the `pubkey` field will be present. In particular, this means that invoking `validateaddress` on the output of `getnewaddress` will always report the `pubkey`, even when the address type is P2SH-P2WPKH.
+
+### Low-level changes
+
+- The deprecated RPC `getinfo` was removed. It is recommended that the more specific RPCs are used:
+  * `getblockchaininfo`
+  * `getnetworkinfo`
+  * `getwalletinfo`
+  * `getmininginfo`
+- The wallet RPC `getreceivedbyaddress` will return an error if called with an address not in the wallet.
+- The wallet RPC `addwitnessaddress` was deprecated and will be removed in version 0.17,
+  set the `address_type` argument of `getnewaddress`, or option `-addresstype=[bech32|p2sh-segwit]` instead.
+- `dumpwallet` now includes hex-encoded scripts from the wallet in the dumpfile, and
+  `importwallet` now imports these scripts, but corresponding addresses may not be added
+  correctly or a manual rescan may be required to find relevant transactions.
+- The RPC `getblockchaininfo` now includes an `errors` field.
+- A new `blockhash` parameter has been added to the `getrawtransaction` RPC which allows for a raw transaction to be fetched from a specific block if known, even without `-txindex` enabled.
+- The `decoderawtransaction` and `fundrawtransaction` RPCs now have optional `iswitness` parameters to override the
+  heuristic witness checks if necessary.
+- The `walletpassphrase` timeout is now clamped to 2^30 seconds.
+- Using addresses with the `createmultisig` RPC is now deprecated, and will be removed in a later version. Public keys should be used instead.
+- Blockchain rescans now no longer lock the wallet for the entire rescan process, so other RPCs can now be used at the same time (although results of balances / transactions may be incorrect or incomplete until the rescan is complete).
+- The `logging` RPC has now been made public rather than hidden.
+- An `initialblockdownload` boolean has been added to the `getblockchaininfo` RPC to indicate whether the node is currently in IBD or not.
+- `minrelaytxfee` is now included in the output of `getmempoolinfo`
+
+### Other changed command-line options
+
+- `-debuglogfile=<file>` can be used to specify an alternative debug logging file.
+- bitcoin-cli now has an `-stdinrpcpass` option to allow the RPC password to be read from standard input.
+- The `-usehd` option has been removed.
+- bitcoin-cli now supports a new `-getinfo` flag which returns an output like that of the now-removed `getinfo` RPC.
+
+### Testing changes
+
+- The default regtest JSON-RPC port has been changed to 18443 to avoid conflict with testnet's default of 18332.
+- Segwit is now always active in regtest mode by default. Thus, if you upgrade a regtest node you will need to either -reindex or use the old rules by adding `vbparams=segwit:0:999999999999` to your regtest bitcoin.conf. Failure to do this will result in a CheckBlockIndex() assertion failure that will look like: Assertion `(pindexFirstNeverProcessed != nullptr) == (pindex->nChainTx == 0)' failed.
+
+## Hashes for verification
+
+{% highlight text %}
+f51392e0cbf7940627944602a64890ed65cf44838fc4795d493cf12aafe37012  bitcoin-0.16.0-aarch64-linux-gnu.tar.gz
+59f95da96f40b3a9acfeda9085e6389f2075ee40ef1fe7f023031f86c946c3ea  bitcoin-0.16.0-arm-linux-gnueabihf.tar.gz
+d7c173e2921e39df3631b7cd652ae7330c2735b0b221f9dc8f7c899887b4fb59  bitcoin-0.16.0-i686-pc-linux-gnu.tar.gz
+ade85a8e39de8c36a134721c3da9853a80f29a8625048e0c2a5295ca8b23a88c  bitcoin-0.16.0-osx64.tar.gz
+df0036bae9f40536095908c9944ed66c0946f178ae8ef07639caf25a390b2ee7  bitcoin-0.16.0-osx.dmg
+8cbec0397d932cab7297a8c23c918392f6eebd410646b4b954787de9f4a3ee40  bitcoin-0.16.0.tar.gz
+7558249b04527d7d0bf2663f9cfe76d6c5f83ae90e513241f94fda6151396a29  bitcoin-0.16.0-win32-setup.exe
+60d65d6e57f42164e1c04bb5bb65156d87f0433825a1c1f1f5f6aebf5c8df424  bitcoin-0.16.0-win32.zip
+6d93ba3b9c3e34f74ccfaeacc79f968755ba0da1e2d75ce654cf276feb2aa16d  bitcoin-0.16.0-win64-setup.exe
+42706da1a95b2db8c5808529f73c2063a0dd770f71e0c8506bfa86dc0f3403ef  bitcoin-0.16.0-win64.zip
+e6322c69bcc974a29e6a715e0ecb8799d2d21691d683eeb8fef65fc5f6a66477  bitcoin-0.16.0-x86_64-linux-gnu.tar.gz
+{% endhighlight %}
+
+
+[release notes]: /en/releases/0.16.0/
+[IRC]: https://en.bitcoin.it/wiki/IRC_channels
+[Slack]: https://slack.bitcoincore.org/
+[download page]: /en/download

--- a/_releases/0.16.0.md
+++ b/_releases/0.16.0.md
@@ -10,6 +10,13 @@ release: [0, 16, 0]
 
 date: 2018-02-26
 
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink: "magnet:?xt=urn:btih:6493ae7a15b4d32bb4eca1dfaf6dcc0c143492cb&dn=bitcoin-core-0.16.0&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+
 # Note: it is recommended to check all links to ensure they use
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).


### PR DESCRIPTION
Preview: http://dg0.dtrt.org/en/2018/02/26/release-0.16.0/

This PR contains a blog post for the 0.16.0 release that is mostly a copy of the release notes.  I've replaced the release notes introduction with a more blog-like introduction, removed the PR-by-PR changelog and credits, and made some minor edits mainly for formatting (e.g. `text in backtics` in subheads doesn't render well in the table of contents).  Links are provided in the blog post to the download page and full release notes.

A diff between the actual release notes and the blog file is concise enough for easy review for anyone who wants to check my work.

    diff -u _releases/0.16.0.md _posts/en/posts/2018-02-26-release-0.16.0.md | colordiff | less -R

I've also added the magnet URI to the release file so the magnet link shows up on the /en/download page and the SHA256SUMS.asc content to the bottom of the blog post (per our usual convention).  These should both be verified by reviewers of this PR.