### PR TITLE
Add example flame graph, to be linked from bitcoin docs.

### DIFF
--- a/assets/images/bitcoin-flamegraph.svg
+++ b/assets/images/bitcoin-flamegraph.svg
@@ -1,0 +1,4426 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" width="1200" height="646" onload="init(evt)" viewBox="0 0 1200 646" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<!-- Flame graph stack visualization. See https://github.com/brendangregg/FlameGraph for latest version, and http://www.brendangregg.com/flamegraphs.html for examples. -->
+<!-- NOTES:  -->
+<defs >
+	<linearGradient id="background" y1="0" y2="1" x1="0" x2="0" >
+		<stop stop-color="#eeeeee" offset="5%" />
+		<stop stop-color="#eeeeb0" offset="95%" />
+	</linearGradient>
+</defs>
+<style type="text/css">
+	.func_g:hover { stroke:black; stroke-width:0.5; cursor:pointer; }
+</style>
+<script type="text/ecmascript">
+<![CDATA[
+	var details, searchbtn, matchedtxt, svg;
+	function init(evt) {
+		details = document.getElementById("details").firstChild;
+		searchbtn = document.getElementById("search");
+		matchedtxt = document.getElementById("matched");
+		svg = document.getElementsByTagName("svg")[0];
+		searching = 0;
+	}
+
+	// mouse-over for info
+	function s(node) {		// show
+		info = g_to_text(node);
+		details.nodeValue = "Function: " + info;
+	}
+	function c() {			// clear
+		details.nodeValue = ' ';
+	}
+
+	// ctrl-F for search
+	window.addEventListener("keydown",function (e) {
+		if (e.keyCode === 114 || (e.ctrlKey && e.keyCode === 70)) {
+			e.preventDefault();
+			search_prompt();
+		}
+	})
+
+	// functions
+	function find_child(parent, name, attr) {
+		var children = parent.childNodes;
+		for (var i=0; i<children.length;i++) {
+			if (children[i].tagName == name)
+				return (attr != undefined) ? children[i].attributes[attr].value : children[i];
+		}
+		return;
+	}
+	function orig_save(e, attr, val) {
+		if (e.attributes["_orig_"+attr] != undefined) return;
+		if (e.attributes[attr] == undefined) return;
+		if (val == undefined) val = e.attributes[attr].value;
+		e.setAttribute("_orig_"+attr, val);
+	}
+	function orig_load(e, attr) {
+		if (e.attributes["_orig_"+attr] == undefined) return;
+		e.attributes[attr].value = e.attributes["_orig_"+attr].value;
+		e.removeAttribute("_orig_"+attr);
+	}
+	function g_to_text(e) {
+		var text = find_child(e, "title").firstChild.nodeValue;
+		return (text)
+	}
+	function g_to_func(e) {
+		var func = g_to_text(e);
+		// if there's any manipulation we want to do to the function
+		// name before it's searched, do it here before returning.
+		return (func);
+	}
+	function update_text(e) {
+		var r = find_child(e, "rect");
+		var t = find_child(e, "text");
+		var w = parseFloat(r.attributes["width"].value) -3;
+		var txt = find_child(e, "title").textContent.replace(/\([^(]*\)$/,"");
+		t.attributes["x"].value = parseFloat(r.attributes["x"].value) +3;
+
+		// Smaller than this size won't fit anything
+		if (w < 2*12*0.59) {
+			t.textContent = "";
+			return;
+		}
+
+		t.textContent = txt;
+		// Fit in full text width
+		if (/^ *$/.test(txt) || t.getSubStringLength(0, txt.length) < w)
+			return;
+
+		for (var x=txt.length-2; x>0; x--) {
+			if (t.getSubStringLength(0, x+2) <= w) {
+				t.textContent = txt.substring(0,x) + "..";
+				return;
+			}
+		}
+		t.textContent = "";
+	}
+
+	// zoom
+	function zoom_reset(e) {
+		if (e.attributes != undefined) {
+			orig_load(e, "x");
+			orig_load(e, "width");
+		}
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_reset(c[i]);
+		}
+	}
+	function zoom_child(e, x, ratio) {
+		if (e.attributes != undefined) {
+			if (e.attributes["x"] != undefined) {
+				orig_save(e, "x");
+				e.attributes["x"].value = (parseFloat(e.attributes["x"].value) - x - 10) * ratio + 10;
+				if(e.tagName == "text") e.attributes["x"].value = find_child(e.parentNode, "rect", "x") + 3;
+			}
+			if (e.attributes["width"] != undefined) {
+				orig_save(e, "width");
+				e.attributes["width"].value = parseFloat(e.attributes["width"].value) * ratio;
+			}
+		}
+
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_child(c[i], x-10, ratio);
+		}
+	}
+	function zoom_parent(e) {
+		if (e.attributes) {
+			if (e.attributes["x"] != undefined) {
+				orig_save(e, "x");
+				e.attributes["x"].value = 10;
+			}
+			if (e.attributes["width"] != undefined) {
+				orig_save(e, "width");
+				e.attributes["width"].value = parseInt(svg.width.baseVal.value) - (10*2);
+			}
+		}
+		if (e.childNodes == undefined) return;
+		for(var i=0, c=e.childNodes; i<c.length; i++) {
+			zoom_parent(c[i]);
+		}
+	}
+	function zoom(node) {
+		var attr = find_child(node, "rect").attributes;
+		var width = parseFloat(attr["width"].value);
+		var xmin = parseFloat(attr["x"].value);
+		var xmax = parseFloat(xmin + width);
+		var ymin = parseFloat(attr["y"].value);
+		var ratio = (svg.width.baseVal.value - 2*10) / width;
+
+		// XXX: Workaround for JavaScript float issues (fix me)
+		var fudge = 0.0001;
+
+		var unzoombtn = document.getElementById("unzoom");
+		unzoombtn.style["opacity"] = "1.0";
+
+		var el = document.getElementsByTagName("g");
+		for(var i=0;i<el.length;i++){
+			var e = el[i];
+			var a = find_child(e, "rect").attributes;
+			var ex = parseFloat(a["x"].value);
+			var ew = parseFloat(a["width"].value);
+			// Is it an ancestor
+			if (0 == 0) {
+				var upstack = parseFloat(a["y"].value) > ymin;
+			} else {
+				var upstack = parseFloat(a["y"].value) < ymin;
+			}
+			if (upstack) {
+				// Direct ancestor
+				if (ex <= xmin && (ex+ew+fudge) >= xmax) {
+					e.style["opacity"] = "0.5";
+					zoom_parent(e);
+					e.onclick = function(e){unzoom(); zoom(this);};
+					update_text(e);
+				}
+				// not in current path
+				else
+					e.style["display"] = "none";
+			}
+			// Children maybe
+			else {
+				// no common path
+				if (ex < xmin || ex + fudge >= xmax) {
+					e.style["display"] = "none";
+				}
+				else {
+					zoom_child(e, xmin, ratio);
+					e.onclick = function(e){zoom(this);};
+					update_text(e);
+				}
+			}
+		}
+	}
+	function unzoom() {
+		var unzoombtn = document.getElementById("unzoom");
+		unzoombtn.style["opacity"] = "0.0";
+
+		var el = document.getElementsByTagName("g");
+		for(i=0;i<el.length;i++) {
+			el[i].style["display"] = "block";
+			el[i].style["opacity"] = "1";
+			zoom_reset(el[i]);
+			update_text(el[i]);
+		}
+	}
+
+	// search
+	function reset_search() {
+		var el = document.getElementsByTagName("rect");
+		for (var i=0; i < el.length; i++) {
+			orig_load(el[i], "fill")
+		}
+	}
+	function search_prompt() {
+		if (!searching) {
+			var term = prompt("Enter a search term (regexp " +
+			    "allowed, eg: ^ext4_)", "");
+			if (term != null) {
+				search(term)
+			}
+		} else {
+			reset_search();
+			searching = 0;
+			searchbtn.style["opacity"] = "0.1";
+			searchbtn.firstChild.nodeValue = "Search"
+			matchedtxt.style["opacity"] = "0.0";
+			matchedtxt.firstChild.nodeValue = ""
+		}
+	}
+	function search(term) {
+		var re = new RegExp(term);
+		var el = document.getElementsByTagName("g");
+		var matches = new Object();
+		var maxwidth = 0;
+		for (var i = 0; i < el.length; i++) {
+			var e = el[i];
+			if (e.attributes["class"].value != "func_g")
+				continue;
+			var func = g_to_func(e);
+			var rect = find_child(e, "rect");
+			if (rect == null) {
+				// the rect might be wrapped in an anchor
+				// if nameattr href is being used
+				if (rect = find_child(e, "a")) {
+				    rect = find_child(r, "rect");
+				}
+			}
+			if (func == null || rect == null)
+				continue;
+
+			// Save max width. Only works as we have a root frame
+			var w = parseFloat(rect.attributes["width"].value);
+			if (w > maxwidth)
+				maxwidth = w;
+
+			if (func.match(re)) {
+				// highlight
+				var x = parseFloat(rect.attributes["x"].value);
+				orig_save(rect, "fill");
+				rect.attributes["fill"].value =
+				    "rgb(230,0,230)";
+
+				// remember matches
+				if (matches[x] == undefined) {
+					matches[x] = w;
+				} else {
+					if (w > matches[x]) {
+						// overwrite with parent
+						matches[x] = w;
+					}
+				}
+				searching = 1;
+			}
+		}
+		if (!searching)
+			return;
+
+		searchbtn.style["opacity"] = "1.0";
+		searchbtn.firstChild.nodeValue = "Reset Search"
+
+		// calculate percent matched, excluding vertical overlap
+		var count = 0;
+		var lastx = -1;
+		var lastw = 0;
+		var keys = Array();
+		for (k in matches) {
+			if (matches.hasOwnProperty(k))
+				keys.push(k);
+		}
+		// sort the matched frames by their x location
+		// ascending, then width descending
+		keys.sort(function(a, b){
+			return a - b;
+		});
+		// Step through frames saving only the biggest bottom-up frames
+		// thanks to the sort order. This relies on the tree property
+		// where children are always smaller than their parents.
+		var fudge = 0.0001;	// JavaScript floating point
+		for (var k in keys) {
+			var x = parseFloat(keys[k]);
+			var w = matches[keys[k]];
+			if (x >= lastx + lastw - fudge) {
+				count += w;
+				lastx = x;
+				lastw = w;
+			}
+		}
+		// display matched percent
+		matchedtxt.style["opacity"] = "1.0";
+		pct = 100 * count / maxwidth;
+		if (pct == 100)
+			pct = "100"
+		else
+			pct = pct.toFixed(1)
+		matchedtxt.firstChild.nodeValue = "Matched: " + pct + "%";
+	}
+	function searchover(e) {
+		searchbtn.style["opacity"] = "1.0";
+	}
+	function searchout(e) {
+		if (searching) {
+			searchbtn.style["opacity"] = "1.0";
+		} else {
+			searchbtn.style["opacity"] = "0.1";
+		}
+	}
+]]>
+</script>
+<rect x="0.0" y="0" width="1200.0" height="646.0" fill="url(#background)"  />
+<text text-anchor="middle" x="600.00" y="24" font-size="17" font-family="Verdana" fill="rgb(0,0,0)"  >Flame Graph</text>
+<text text-anchor="" x="10.00" y="629" font-size="12" font-family="Verdana" fill="rgb(0,0,0)" id="details" > </text>
+<text text-anchor="" x="10.00" y="24" font-size="12" font-family="Verdana" fill="rgb(0,0,0)" id="unzoom" onclick="unzoom()" style="opacity:0.0;cursor:pointer" >Reset Zoom</text>
+<text text-anchor="" x="1090.00" y="24" font-size="12" font-family="Verdana" fill="rgb(0,0,0)" id="search" onmouseover="searchover()" onmouseout="searchout()" onclick="search_prompt()" style="opacity:0.1;cursor:pointer" >Search</text>
+<text text-anchor="" x="1090.00" y="629" font-size="12" font-family="Verdana" fill="rgb(0,0,0)" id="matched" > </text>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_read (2 samples, 0.02%)</title><rect x="895.0" y="229" width="0.2" height="15.0" fill="rgb(82,194,194)" rx="2" ry="2" />
+<text text-anchor="" x="897.98" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::GetLengthPrefixedSlice (427 samples, 3.32%)</title><rect x="137.6" y="469" width="39.3" height="15.0" fill="rgb(201,201,59)" rx="2" ry="2" />
+<text text-anchor="" x="140.62" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >lev..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (5 samples, 0.04%)</title><rect x="443.0" y="293" width="0.5" height="15.0" fill="rgb(74,222,74)" rx="2" ry="2" />
+<text text-anchor="" x="446.02" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ThreadImport (9 samples, 0.07%)</title><rect x="1075.2" y="517" width="0.9" height="15.0" fill="rgb(76,224,76)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__lll_unlock_wake (5 samples, 0.04%)</title><rect x="1052.8" y="373" width="0.5" height="15.0" fill="rgb(247,118,118)" rx="2" ry="2" />
+<text text-anchor="" x="1055.82" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::InternalKeyComparator::Compare (105 samples, 0.82%)</title><rect x="176.9" y="469" width="9.6" height="15.0" fill="rgb(189,189,55)" rx="2" ry="2" />
+<text text-anchor="" x="179.85" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (4 samples, 0.03%)</title><rect x="251.2" y="165" width="0.3" height="15.0" fill="rgb(239,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_page_fault (47 samples, 0.37%)</title><rect x="253.8" y="421" width="4.3" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="256.75" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="238.1" y="405" width="0.2" height="15.0" fill="rgb(59,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="241.14" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (2 samples, 0.02%)</title><rect x="1010.1" y="245" width="0.2" height="15.0" fill="rgb(53,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="1013.10" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__check_object_size (12 samples, 0.09%)</title><rect x="433.8" y="165" width="1.1" height="15.0" fill="rgb(104,215,215)" rx="2" ry="2" />
+<text text-anchor="" x="436.84" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Reset (2 samples, 0.02%)</title><rect x="949.5" y="341" width="0.1" height="15.0" fill="rgb(56,205,56)" rx="2" ry="2" />
+<text text-anchor="" x="952.46" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (14 samples, 0.11%)</title><rect x="932.4" y="293" width="1.3" height="15.0" fill="rgb(106,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="935.37" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_write@@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="830.6" y="261" width="0.2" height="15.0" fill="rgb(236,102,102)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::BytewiseComparatorImpl::Compare (24 samples, 0.19%)</title><rect x="216.5" y="437" width="2.2" height="15.0" fill="rgb(222,222,67)" rx="2" ry="2" />
+<text text-anchor="" x="219.45" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (5 samples, 0.04%)</title><rect x="831.9" y="373" width="0.4" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="834.86" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::PutVarint32 (2 samples, 0.02%)</title><rect x="710.9" y="325" width="0.1" height="15.0" fill="rgb(203,203,60)" rx="2" ry="2" />
+<text text-anchor="" x="713.85" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_read_lock (2 samples, 0.02%)</title><rect x="18.5" y="533" width="0.1" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="21.45" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScript::GetSigOpCount (142 samples, 1.11%)</title><rect x="354.1" y="373" width="13.0" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="357.09" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>core_sys_select (21 samples, 0.16%)</title><rect x="1158.3" y="485" width="1.9" height="15.0" fill="rgb(73,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="1161.30" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sys_futex (2 samples, 0.02%)</title><rect x="1053.3" y="341" width="0.2" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (20 samples, 0.16%)</title><rect x="251.9" y="421" width="1.9" height="15.0" fill="rgb(250,122,122)" rx="2" ry="2" />
+<text text-anchor="" x="254.92" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>apic_timer_interrupt (3 samples, 0.02%)</title><rect x="136.0" y="485" width="0.2" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="138.97" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Function_base::_Base_manager&lt;CMainSignals::BlockConnected (264 samples, 2.06%)</title><rect x="1162.0" y="453" width="24.2" height="15.0" fill="rgb(97,243,97)" rx="2" ry="2" />
+<text text-anchor="" x="1164.98" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >s..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_end_request (2 samples, 0.02%)</title><rect x="997.6" y="213" width="0.2" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (2 samples, 0.02%)</title><rect x="1007.3" y="117" width="0.1" height="15.0" fill="rgb(216,73,73)" rx="2" ry="2" />
+<text text-anchor="" x="1010.25" y="127.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::ShardedLRUCache::Lookup (10 samples, 0.08%)</title><rect x="231.8" y="453" width="0.9" height="15.0" fill="rgb(227,227,69)" rx="2" ry="2" />
+<text text-anchor="" x="234.80" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (133 samples, 1.04%)</title><rect x="287.0" y="357" width="12.2" height="15.0" fill="rgb(90,236,90)" rx="2" ry="2" />
+<text text-anchor="" x="290.01" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (2 samples, 0.02%)</title><rect x="1010.1" y="229" width="0.2" height="15.0" fill="rgb(67,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="1013.10" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vp_notify (2 samples, 0.02%)</title><rect x="1007.3" y="69" width="0.1" height="15.0" fill="rgb(249,121,121)" rx="2" ry="2" />
+<text text-anchor="" x="1010.25" y="79.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop2_26 (34 samples, 0.26%)</title><rect x="946.2" y="309" width="3.2" height="15.0" fill="rgb(62,211,62)" rx="2" ry="2" />
+<text text-anchor="" x="949.25" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="250.9" y="389" width="0.2" height="15.0" fill="rgb(63,177,177)" rx="2" ry="2" />
+<text text-anchor="" x="253.91" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>get_page_from_freelist (8 samples, 0.06%)</title><rect x="886.0" y="165" width="0.7" height="15.0" fill="rgb(52,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="888.97" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_lock (2 samples, 0.02%)</title><rect x="232.3" y="421" width="0.1" height="15.0" fill="rgb(214,71,71)" rx="2" ry="2" />
+<text text-anchor="" x="235.25" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CTxOutCompressor::DecompressAmount (3 samples, 0.02%)</title><rect x="406.7" y="261" width="0.3" height="15.0" fill="rgb(82,229,82)" rx="2" ry="2" />
+<text text-anchor="" x="409.73" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_lock (3 samples, 0.02%)</title><rect x="198.4" y="453" width="0.3" height="15.0" fill="rgb(222,82,82)" rx="2" ry="2" />
+<text text-anchor="" x="201.44" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (2 samples, 0.02%)</title><rect x="887.5" y="101" width="0.2" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="890.53" y="111.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CTxMemPool::removeForBlock (104 samples, 0.81%)</title><rect x="694.1" y="421" width="9.6" height="15.0" fill="rgb(76,224,76)" rx="2" ry="2" />
+<text text-anchor="" x="697.13" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__clone (8,766 samples, 68.26%)</title><rect x="269.8" y="565" width="805.4" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >__clone</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vp_notify (2 samples, 0.02%)</title><rect x="1007.4" y="53" width="0.2" height="15.0" fill="rgb(231,96,96)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="63.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__add_to_page_cache_locked (5 samples, 0.04%)</title><rect x="888.4" y="213" width="0.4" height="15.0" fill="rgb(108,218,218)" rx="2" ry="2" />
+<text text-anchor="" x="891.36" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_filemap_fault (18 samples, 0.14%)</title><rect x="255.2" y="341" width="1.7" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="258.22" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>AppInit (2 samples, 0.02%)</title><rect x="1189.8" y="517" width="0.2" height="15.0" fill="rgb(90,236,90)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (220 samples, 1.71%)</title><rect x="873.3" y="325" width="20.2" height="15.0" fill="rgb(221,81,81)" rx="2" ry="2" />
+<text text-anchor="" x="876.29" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (29 samples, 0.23%)</title><rect x="867.3" y="341" width="2.7" height="15.0" fill="rgb(223,84,84)" rx="2" ry="2" />
+<text text-anchor="" x="870.32" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (39 samples, 0.30%)</title><rect x="879.1" y="229" width="3.6" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="882.08" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (11 samples, 0.09%)</title><rect x="830.6" y="293" width="1.0" height="15.0" fill="rgb(209,63,63)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (16 samples, 0.12%)</title><rect x="868.5" y="325" width="1.5" height="15.0" fill="rgb(50,165,165)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (8 samples, 0.06%)</title><rect x="1008.1" y="245" width="0.7" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="1011.08" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>page_fault (47 samples, 0.37%)</title><rect x="253.8" y="437" width="4.3" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="256.75" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop1_26 (370 samples, 2.88%)</title><rect x="952.5" y="325" width="34.0" height="15.0" fill="rgb(78,226,78)" rx="2" ry="2" />
+<text text-anchor="" x="955.49" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Ll..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>apic_timer_interrupt (2 samples, 0.02%)</title><rect x="596.1" y="389" width="0.2" height="15.0" fill="rgb(105,215,215)" rx="2" ry="2" />
+<text text-anchor="" x="599.10" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (14 samples, 0.11%)</title><rect x="1033.3" y="357" width="1.2" height="15.0" fill="rgb(221,81,81)" rx="2" ry="2" />
+<text text-anchor="" x="1036.25" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Serialize_impl&lt;CSizeComputer, CTxIn, std::allocator&lt;CTxIn&gt;, CTxIn&gt; (37 samples, 0.29%)</title><rect x="370.5" y="373" width="3.4" height="15.0" fill="rgb(59,209,59)" rx="2" ry="2" />
+<text text-anchor="" x="373.53" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__schedule (2 samples, 0.02%)</title><rect x="867.1" y="213" width="0.2" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="870.14" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__clone (317 samples, 2.47%)</title><rect x="1160.7" y="565" width="29.1" height="15.0" fill="rgb(235,101,101)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >__..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (10 samples, 0.08%)</title><rect x="1000.7" y="309" width="0.9" height="15.0" fill="rgb(77,225,77)" rx="2" ry="2" />
+<text text-anchor="" x="1003.73" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtqueue_notify (3 samples, 0.02%)</title><rect x="251.3" y="149" width="0.2" height="15.0" fill="rgb(66,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="254.27" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (5 samples, 0.04%)</title><rect x="894.8" y="293" width="0.5" height="15.0" fill="rgb(214,71,71)" rx="2" ry="2" />
+<text text-anchor="" x="897.79" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::HaveInputs (9 samples, 0.07%)</title><rect x="1075.2" y="405" width="0.9" height="15.0" fill="rgb(55,205,55)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pthread_cond_timedwait@@GLIBC_2.3.2 (2 samples, 0.02%)</title><rect x="1156.9" y="469" width="0.2" height="15.0" fill="rgb(232,96,96)" rx="2" ry="2" />
+<text text-anchor="" x="1159.92" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__detail::_Hashtable_alloc&lt;std::allocator&lt;std::__detail::_Hash_node&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, true&gt; &gt; &gt;::_M_allocate_node&lt;std::piecewise_construct_t const&amp;, std::tuple&lt;COutPoint const&amp;&gt;, std::tuple&lt;&gt; &gt; (121 samples, 0.94%)</title><rect x="309.9" y="357" width="11.1" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="312.89" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (4 samples, 0.03%)</title><rect x="436.8" y="261" width="0.3" height="15.0" fill="rgb(240,109,109)" rx="2" ry="2" />
+<text text-anchor="" x="439.78" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__hrtimer_init (2 samples, 0.02%)</title><rect x="1188.0" y="373" width="0.2" height="15.0" fill="rgb(72,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="1190.98" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (2 samples, 0.02%)</title><rect x="909.2" y="245" width="0.2" height="15.0" fill="rgb(95,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="912.22" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::_M_range_insert&lt;char const*&gt; (3 samples, 0.02%)</title><rect x="710.2" y="341" width="0.3" height="15.0" fill="rgb(102,247,102)" rx="2" ry="2" />
+<text text-anchor="" x="713.21" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libstdc++.so.6.0.24] (2 samples, 0.02%)</title><rect x="1160.4" y="533" width="0.2" height="15.0" fill="rgb(254,129,129)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (81 samples, 0.63%)</title><rect x="495.0" y="293" width="7.5" height="15.0" fill="rgb(212,67,67)" rx="2" ry="2" />
+<text text-anchor="" x="498.03" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Finalize (2 samples, 0.02%)</title><rect x="831.7" y="373" width="0.2" height="15.0" fill="rgb(89,235,89)" rx="2" ry="2" />
+<text text-anchor="" x="834.67" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_close_it@@GLIBC_2.2.5 (2 samples, 0.02%)</title><rect x="1024.5" y="373" width="0.2" height="15.0" fill="rgb(227,90,90)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::num_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::_M_insert_float&lt;double&gt; (2 samples, 0.02%)</title><rect x="1037.9" y="357" width="0.2" height="15.0" fill="rgb(244,114,114)" rx="2" ry="2" />
+<text text-anchor="" x="1040.94" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_perform_write (6 samples, 0.05%)</title><rect x="830.9" y="181" width="0.6" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (5 samples, 0.04%)</title><rect x="868.6" y="197" width="0.5" height="15.0" fill="rgb(59,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="871.61" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewErrorCatcher::GetCoin (9 samples, 0.07%)</title><rect x="1075.2" y="325" width="0.9" height="15.0" fill="rgb(92,238,92)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (36 samples, 0.28%)</title><rect x="567.5" y="341" width="3.3" height="15.0" fill="rgb(83,230,83)" rx="2" ry="2" />
+<text text-anchor="" x="570.52" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ConnectTip (9 samples, 0.07%)</title><rect x="1075.2" y="453" width="0.9" height="15.0" fill="rgb(90,237,90)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>queue_unplugged (5 samples, 0.04%)</title><rect x="868.6" y="213" width="0.5" height="15.0" fill="rgb(58,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="871.61" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (2 samples, 0.02%)</title><rect x="917.2" y="293" width="0.2" height="15.0" fill="rgb(107,218,218)" rx="2" ry="2" />
+<text text-anchor="" x="920.21" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_seekoff@@GLIBC_2.2.5 (403 samples, 3.14%)</title><rect x="833.0" y="357" width="37.0" height="15.0" fill="rgb(245,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="835.96" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >_IO..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (2 samples, 0.02%)</title><rect x="1024.5" y="325" width="0.2" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_file_read_iter (4 samples, 0.03%)</title><rect x="932.4" y="261" width="0.3" height="15.0" fill="rgb(72,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="935.37" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CDataStream::Xor (5 samples, 0.04%)</title><rect x="709.1" y="357" width="0.5" height="15.0" fill="rgb(54,203,54)" rx="2" ry="2" />
+<text text-anchor="" x="712.11" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="1053.3" y="261" width="0.2" height="15.0" fill="rgb(93,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (38 samples, 0.30%)</title><rect x="889.2" y="245" width="3.5" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="892.19" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>page_fault (4 samples, 0.03%)</title><rect x="711.8" y="293" width="0.3" height="15.0" fill="rgb(62,176,176)" rx="2" ry="2" />
+<text text-anchor="" x="714.77" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_emplace&lt;std::piecewise_construct_t const&amp;, std::tuple&lt;COutPoint const&amp;&gt;, std::tuple&lt;Coin&amp;&amp;&gt; &gt; (335 samples, 2.61%)</title><rect x="486.9" y="341" width="30.8" height="15.0" fill="rgb(107,252,107)" rx="2" ry="2" />
+<text text-anchor="" x="489.94" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >st..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prepare_exit_to_usermode (123 samples, 0.96%)</title><rect x="425.2" y="229" width="11.3" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="428.20" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::date_time::time_facet&lt;boost::posix_time::ptime, char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::put (17 samples, 0.13%)</title><rect x="1031.7" y="373" width="1.6" height="15.0" fill="rgb(210,210,62)" rx="2" ry="2" />
+<text text-anchor="" x="1034.69" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>VersionBitsState (2 samples, 0.02%)</title><rect x="588.1" y="405" width="0.2" height="15.0" fill="rgb(89,236,89)" rx="2" ry="2" />
+<text text-anchor="" x="591.10" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>smp_apic_timer_interrupt (2 samples, 0.02%)</title><rect x="596.1" y="373" width="0.2" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="599.10" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ret_from_intr (2 samples, 0.02%)</title><rect x="909.2" y="277" width="0.2" height="15.0" fill="rgb(64,177,177)" rx="2" ry="2" />
+<text text-anchor="" x="912.22" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Arena::AllocateFallback (66 samples, 0.51%)</title><rect x="717.6" y="309" width="6.0" height="15.0" fill="rgb(183,183,53)" rx="2" ry="2" />
+<text text-anchor="" x="720.56" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>tcp_poll (5 samples, 0.04%)</title><rect x="1159.6" y="437" width="0.4" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="1162.59" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (77 samples, 0.60%)</title><rect x="342.0" y="341" width="7.0" height="15.0" fill="rgb(85,232,85)" rx="2" ry="2" />
+<text text-anchor="" x="344.96" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScheduler::serviceQueue (317 samples, 2.47%)</title><rect x="1160.7" y="485" width="29.1" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CS..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop2_26 (42 samples, 0.33%)</title><rect x="337.7" y="309" width="3.9" height="15.0" fill="rgb(52,202,52)" rx="2" ry="2" />
+<text text-anchor="" x="340.73" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (9 samples, 0.07%)</title><rect x="1075.2" y="341" width="0.9" height="15.0" fill="rgb(94,240,94)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_emplace&lt;std::piecewise_construct_t const&amp;, std::tuple&lt;COutPoint const&amp;&gt;, std::tuple&lt;&gt; &gt; (398 samples, 3.10%)</title><rect x="284.4" y="373" width="36.6" height="15.0" fill="rgb(89,236,89)" rx="2" ry="2" />
+<text text-anchor="" x="287.44" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >std..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>arch_uprobe_pre_xol (2 samples, 0.02%)</title><rect x="267.6" y="469" width="0.2" height="15.0" fill="rgb(108,218,218)" rx="2" ry="2" />
+<text text-anchor="" x="270.63" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (6 samples, 0.05%)</title><rect x="918.7" y="277" width="0.5" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="921.68" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CRollingBloomFilter::insert (4 samples, 0.03%)</title><rect x="1156.3" y="421" width="0.3" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="1159.28" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (2 samples, 0.02%)</title><rect x="596.1" y="341" width="0.2" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="599.10" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (545 samples, 4.24%)</title><rect x="949.6" y="341" width="50.1" height="15.0" fill="rgb(58,207,58)" rx="2" ry="2" />
+<text text-anchor="" x="952.64" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CSHA2..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (19 samples, 0.15%)</title><rect x="285.3" y="357" width="1.7" height="15.0" fill="rgb(72,220,72)" rx="2" ry="2" />
+<text text-anchor="" x="288.27" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_fault (47 samples, 0.37%)</title><rect x="253.8" y="405" width="4.3" height="15.0" fill="rgb(67,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="256.75" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ActivateBestChainStep (8,522 samples, 66.36%)</title><rect x="269.8" y="453" width="783.0" height="15.0" fill="rgb(99,245,99)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CChainState::ActivateBestChainStep</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (5 samples, 0.04%)</title><rect x="831.9" y="325" width="0.4" height="15.0" fill="rgb(245,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="834.86" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (2 samples, 0.02%)</title><rect x="1007.9" y="261" width="0.2" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="1010.90" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>all (12,843 samples, 100%)</title><rect x="10.0" y="597" width="1180.0" height="15.0" fill="rgb(230,94,94)" rx="2" ry="2" />
+<text text-anchor="" x="13.00" y="607.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_sgetn (3 samples, 0.02%)</title><rect x="920.8" y="341" width="0.3" height="15.0" fill="rgb(240,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="923.79" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_user_enhanced_fast_string (3 samples, 0.02%)</title><rect x="1006.7" y="197" width="0.3" height="15.0" fill="rgb(90,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="1009.70" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::detail::thread_data&lt;boost::_bi::bind_t&lt;void, void  (317 samples, 2.47%)</title><rect x="1160.7" y="517" width="29.1" height="15.0" fill="rgb(217,217,65)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >bo..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::operator&gt;&gt;&lt;std::vector&lt;CTxIn, std::allocator&lt;CTxIn&gt; &gt; &gt; (624 samples, 4.86%)</title><rect x="870.9" y="373" width="57.3" height="15.0" fill="rgb(89,236,89)" rx="2" ry="2" />
+<text text-anchor="" x="873.90" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CAutoF..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CRollingBloomFilter::insert (4 samples, 0.03%)</title><rect x="1156.3" y="405" width="0.3" height="15.0" fill="rgb(75,223,75)" rx="2" ry="2" />
+<text text-anchor="" x="1159.28" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (22 samples, 0.17%)</title><rect x="1187.5" y="453" width="2.0" height="15.0" fill="rgb(108,218,218)" rx="2" ry="2" />
+<text text-anchor="" x="1190.52" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Lock (4 samples, 0.03%)</title><rect x="261.8" y="453" width="0.4" height="15.0" fill="rgb(180,180,52)" rx="2" ry="2" />
+<text text-anchor="" x="264.84" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;CTxIn, std::allocator&lt;CTxIn&gt; &gt;::_M_default_append (77 samples, 0.60%)</title><rect x="921.2" y="357" width="7.0" height="15.0" fill="rgb(68,216,68)" rx="2" ry="2" />
+<text text-anchor="" x="924.16" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::detail::interruption_checker::~interruption_checker (2 samples, 0.02%)</title><rect x="1186.3" y="469" width="0.2" height="15.0" fill="rgb(205,205,60)" rx="2" ry="2" />
+<text text-anchor="" x="1189.32" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (4 samples, 0.03%)</title><rect x="230.4" y="405" width="0.4" height="15.0" fill="rgb(219,78,78)" rx="2" ry="2" />
+<text text-anchor="" x="233.42" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_finish_plug (6 samples, 0.05%)</title><rect x="1007.1" y="197" width="0.5" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="1010.07" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>arch_uretprobe_hijack_return_addr (18 samples, 0.14%)</title><rect x="433.7" y="181" width="1.7" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="436.75" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_io_completion (2 samples, 0.02%)</title><rect x="997.6" y="229" width="0.2" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (3 samples, 0.02%)</title><rect x="1152.2" y="485" width="0.3" height="15.0" fill="rgb(54,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="1155.24" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pthread_cond_timedwait@@GLIBC_2.3.2 (29 samples, 0.23%)</title><rect x="1186.9" y="469" width="2.6" height="15.0" fill="rgb(247,119,119)" rx="2" ry="2" />
+<text text-anchor="" x="1189.88" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_user_generic_unrolled (3 samples, 0.02%)</title><rect x="435.1" y="149" width="0.3" height="15.0" fill="rgb(57,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="438.12" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__nanosleep (2 samples, 0.02%)</title><rect x="1189.8" y="453" width="0.2" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (58 samples, 0.45%)</title><rect x="1180.9" y="389" width="5.3" height="15.0" fill="rgb(235,101,101)" rx="2" ry="2" />
+<text text-anchor="" x="1183.90" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="997.6" y="197" width="0.2" height="15.0" fill="rgb(57,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (2 samples, 0.02%)</title><rect x="711.1" y="325" width="0.2" height="15.0" fill="rgb(224,85,85)" rx="2" ry="2" />
+<text text-anchor="" x="714.13" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libboost_thread.so.1.64.0] (317 samples, 2.47%)</title><rect x="1160.7" y="533" width="29.1" height="15.0" fill="rgb(222,82,82)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >[l..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>PrecomputedTransactionData::PrecomputedTransactionData (12 samples, 0.09%)</title><rect x="572.8" y="405" width="1.1" height="15.0" fill="rgb(107,252,107)" rx="2" ry="2" />
+<text text-anchor="" x="575.76" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memset_avx2_unaligned_erms (4 samples, 0.03%)</title><rect x="420.1" y="261" width="0.3" height="15.0" fill="rgb(254,129,129)" rx="2" ry="2" />
+<text text-anchor="" x="423.06" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_flush_plug_list (10 samples, 0.08%)</title><rect x="886.8" y="165" width="0.9" height="15.0" fill="rgb(61,175,175)" rx="2" ry="2" />
+<text text-anchor="" x="889.80" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (57 samples, 0.44%)</title><rect x="1003.9" y="341" width="5.3" height="15.0" fill="rgb(202,54,54)" rx="2" ry="2" />
+<text text-anchor="" x="1006.95" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (10 samples, 0.08%)</title><rect x="997.8" y="325" width="0.9" height="15.0" fill="rgb(206,59,59)" rx="2" ry="2" />
+<text text-anchor="" x="1000.79" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vfs_read (4 samples, 0.03%)</title><rect x="892.7" y="245" width="0.3" height="15.0" fill="rgb(88,199,199)" rx="2" ry="2" />
+<text text-anchor="" x="895.68" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (66 samples, 0.51%)</title><rect x="717.6" y="261" width="6.0" height="15.0" fill="rgb(205,57,57)" rx="2" ry="2" />
+<text text-anchor="" x="720.56" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadCompactSize&lt;CAutoFile&gt; (11 samples, 0.09%)</title><rect x="871.5" y="357" width="1.1" height="15.0" fill="rgb(109,254,109)" rx="2" ry="2" />
+<text text-anchor="" x="874.55" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::DBImpl::Get (34 samples, 0.26%)</title><rect x="266.7" y="549" width="3.1" height="15.0" fill="rgb(229,229,69)" rx="2" ry="2" />
+<text text-anchor="" x="269.71" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (2 samples, 0.02%)</title><rect x="830.7" y="213" width="0.1" height="15.0" fill="rgb(70,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="833.66" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (11 samples, 0.09%)</title><rect x="219.4" y="405" width="1.0" height="15.0" fill="rgb(222,82,82)" rx="2" ry="2" />
+<text text-anchor="" x="222.39" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CMainSignals::Inventory (4 samples, 0.03%)</title><rect x="1155.9" y="437" width="0.4" height="15.0" fill="rgb(81,228,81)" rx="2" ry="2" />
+<text text-anchor="" x="1158.91" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::BytewiseComparatorImpl::Compare (77 samples, 0.60%)</title><rect x="179.4" y="453" width="7.1" height="15.0" fill="rgb(191,191,55)" rx="2" ry="2" />
+<text text-anchor="" x="182.42" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (6 samples, 0.05%)</title><rect x="1035.0" y="325" width="0.6" height="15.0" fill="rgb(230,95,95)" rx="2" ry="2" />
+<text text-anchor="" x="1038.00" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>swapgs_restore_regs_and_return_to_usermode (3 samples, 0.02%)</title><rect x="867.0" y="277" width="0.3" height="15.0" fill="rgb(92,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="870.05" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::locale::_Impl::_M_install_facet (14 samples, 0.11%)</title><rect x="1033.3" y="373" width="1.2" height="15.0" fill="rgb(243,112,112)" rx="2" ry="2" />
+<text text-anchor="" x="1036.25" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (65 samples, 0.51%)</title><rect x="581.8" y="389" width="5.9" height="15.0" fill="rgb(224,85,85)" rx="2" ry="2" />
+<text text-anchor="" x="584.76" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>queue_unplugged (4 samples, 0.03%)</title><rect x="251.2" y="245" width="0.3" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (123 samples, 0.96%)</title><rect x="425.2" y="213" width="11.3" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="428.20" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::BytewiseComparatorImpl::Compare (7 samples, 0.05%)</title><rect x="188.9" y="501" width="0.6" height="15.0" fill="rgb(209,209,62)" rx="2" ry="2" />
+<text text-anchor="" x="191.89" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prepare_exit_to_usermode (3 samples, 0.02%)</title><rect x="867.0" y="261" width="0.3" height="15.0" fill="rgb(103,213,213)" rx="2" ry="2" />
+<text text-anchor="" x="870.05" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (121 samples, 0.94%)</title><rect x="491.4" y="325" width="11.1" height="15.0" fill="rgb(213,70,70)" rx="2" ry="2" />
+<text text-anchor="" x="494.35" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ondemand_readahead (20 samples, 0.16%)</title><rect x="885.9" y="213" width="1.8" height="15.0" fill="rgb(79,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="888.88" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_unlock (3 samples, 0.02%)</title><rect x="263.8" y="469" width="0.2" height="15.0" fill="rgb(236,103,103)" rx="2" ry="2" />
+<text text-anchor="" x="266.77" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::AddCoin (416 samples, 3.24%)</title><rect x="282.8" y="389" width="38.2" height="15.0" fill="rgb(91,238,91)" rx="2" ry="2" />
+<text text-anchor="" x="285.79" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCo..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>smp_apic_timer_interrupt (2 samples, 0.02%)</title><rect x="337.5" y="277" width="0.2" height="15.0" fill="rgb(70,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="340.55" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (6 samples, 0.05%)</title><rect x="1035.0" y="293" width="0.6" height="15.0" fill="rgb(72,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="1038.00" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (8 samples, 0.06%)</title><rect x="693.2" y="373" width="0.7" height="15.0" fill="rgb(237,104,104)" rx="2" ry="2" />
+<text text-anchor="" x="696.21" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (37 samples, 0.29%)</title><rect x="444.6" y="261" width="3.4" height="15.0" fill="rgb(210,64,64)" rx="2" ry="2" />
+<text text-anchor="" x="447.59" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (16 samples, 0.12%)</title><rect x="713.0" y="373" width="1.4" height="15.0" fill="rgb(244,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="715.97" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;Coin, std::allocator&lt;Coin&gt; &gt;::~vector (32 samples, 0.25%)</title><rect x="596.9" y="405" width="3.0" height="15.0" fill="rgb(86,233,86)" rx="2" ry="2" />
+<text text-anchor="" x="599.92" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>fseek (403 samples, 3.14%)</title><rect x="833.0" y="373" width="37.0" height="15.0" fill="rgb(216,73,73)" rx="2" ry="2" />
+<text text-anchor="" x="835.96" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >fseek</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (2 samples, 0.02%)</title><rect x="1008.9" y="309" width="0.2" height="15.0" fill="rgb(251,124,124)" rx="2" ry="2" />
+<text text-anchor="" x="1011.91" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>finish_task_switch (2 samples, 0.02%)</title><rect x="1158.9" y="389" width="0.1" height="15.0" fill="rgb(95,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="1161.85" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CConnman::ThreadSocketHandler (34 samples, 0.26%)</title><rect x="1157.3" y="565" width="3.1" height="15.0" fill="rgb(96,242,96)" rx="2" ry="2" />
+<text text-anchor="" x="1160.29" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (167 samples, 1.30%)</title><rect x="877.7" y="277" width="15.3" height="15.0" fill="rgb(239,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="880.70" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prevector&lt;28u, unsigned char, unsigned int, int&gt;::change_capacity (2 samples, 0.02%)</title><rect x="1017.1" y="373" width="0.2" height="15.0" fill="rgb(84,231,84)" rx="2" ry="2" />
+<text text-anchor="" x="1020.08" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (6 samples, 0.05%)</title><rect x="256.2" y="213" width="0.6" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="259.24" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (2 samples, 0.02%)</title><rect x="1007.4" y="101" width="0.2" height="15.0" fill="rgb(224,85,85)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="111.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::WriteBatchInternal::InsertInto (1,253 samples, 9.76%)</title><rect x="715.4" y="357" width="115.2" height="15.0" fill="rgb(229,229,69)" rx="2" ry="2" />
+<text text-anchor="" x="718.45" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::Write..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (7 samples, 0.05%)</title><rect x="596.3" y="389" width="0.6" height="15.0" fill="rgb(252,126,126)" rx="2" ry="2" />
+<text text-anchor="" x="599.28" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (127 samples, 0.99%)</title><rect x="909.5" y="357" width="11.7" height="15.0" fill="rgb(247,119,119)" rx="2" ry="2" />
+<text text-anchor="" x="912.49" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>find_get_entry (5 samples, 0.04%)</title><rect x="887.8" y="197" width="0.5" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="890.81" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CDataStream::Xor (15 samples, 0.12%)</title><rect x="404.7" y="261" width="1.4" height="15.0" fill="rgb(79,226,79)" rx="2" ry="2" />
+<text text-anchor="" x="407.71" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (15 samples, 0.12%)</title><rect x="915.8" y="261" width="1.4" height="15.0" fill="rgb(64,177,177)" rx="2" ry="2" />
+<text text-anchor="" x="918.83" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>set_fd_set (2 samples, 0.02%)</title><rect x="1160.0" y="469" width="0.2" height="15.0" fill="rgb(66,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="1163.05" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (222 samples, 1.73%)</title><rect x="873.1" y="341" width="20.4" height="15.0" fill="rgb(67,215,67)" rx="2" ry="2" />
+<text text-anchor="" x="876.11" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>finish_task_switch (4 samples, 0.03%)</title><rect x="1052.9" y="277" width="0.4" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="1055.92" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (10 samples, 0.08%)</title><rect x="877.9" y="261" width="0.9" height="15.0" fill="rgb(53,168,168)" rx="2" ry="2" />
+<text text-anchor="" x="880.89" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__handle_mm_fault (3 samples, 0.02%)</title><rect x="711.9" y="229" width="0.2" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="714.86" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (2 samples, 0.02%)</title><rect x="1024.5" y="309" width="0.2" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::reserve (4 samples, 0.03%)</title><rect x="437.8" y="261" width="0.4" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="440.79" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (59 samples, 0.46%)</title><rect x="1069.7" y="421" width="5.5" height="15.0" fill="rgb(203,54,54)" rx="2" ry="2" />
+<text text-anchor="" x="1072.73" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (10 samples, 0.08%)</title><rect x="882.7" y="261" width="0.9" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="885.67" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop1_26 (2 samples, 0.02%)</title><rect x="831.7" y="341" width="0.2" height="15.0" fill="rgb(53,203,53)" rx="2" ry="2" />
+<text text-anchor="" x="834.67" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (3 samples, 0.02%)</title><rect x="1162.2" y="405" width="0.2" height="15.0" fill="rgb(215,72,72)" rx="2" ry="2" />
+<text text-anchor="" x="1165.16" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (2 samples, 0.02%)</title><rect x="1157.8" y="517" width="0.2" height="15.0" fill="rgb(104,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="1160.84" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::MemTable::Add (1,242 samples, 9.67%)</title><rect x="716.5" y="325" width="114.1" height="15.0" fill="rgb(208,208,62)" rx="2" ry="2" />
+<text text-anchor="" x="719.46" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::MemTa..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (3 samples, 0.02%)</title><rect x="1010.1" y="309" width="0.3" height="15.0" fill="rgb(222,82,82)" rx="2" ry="2" />
+<text text-anchor="" x="1013.10" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (2 samples, 0.02%)</title><rect x="1160.2" y="533" width="0.2" height="15.0" fill="rgb(244,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="1163.23" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::GetLengthPrefixedSlice (9 samples, 0.07%)</title><rect x="715.6" y="325" width="0.9" height="15.0" fill="rgb(178,178,51)" rx="2" ry="2" />
+<text text-anchor="" x="718.63" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (14 samples, 0.11%)</title><rect x="1031.9" y="245" width="1.3" height="15.0" fill="rgb(200,50,50)" rx="2" ry="2" />
+<text text-anchor="" x="1034.88" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (80 samples, 0.62%)</title><rect x="1173.6" y="389" width="7.3" height="15.0" fill="rgb(204,57,57)" rx="2" ry="2" />
+<text text-anchor="" x="1176.55" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (2 samples, 0.02%)</title><rect x="571.6" y="341" width="0.1" height="15.0" fill="rgb(242,112,112)" rx="2" ry="2" />
+<text text-anchor="" x="574.56" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>GetTransactionSigOpCost (275 samples, 2.14%)</title><rect x="547.5" y="405" width="25.3" height="15.0" fill="rgb(96,242,96)" rx="2" ry="2" />
+<text text-anchor="" x="550.49" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >G..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScheduler::schedule (2 samples, 0.02%)</title><rect x="1053.6" y="405" width="0.1" height="15.0" fill="rgb(87,233,87)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::log::Writer::EmitPhysicalRecord (11 samples, 0.09%)</title><rect x="830.6" y="341" width="1.0" height="15.0" fill="rgb(178,178,51)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadBlockFromDisk (2,174 samples, 16.93%)</title><rect x="831.7" y="421" width="199.7" height="15.0" fill="rgb(56,206,56)" rx="2" ry="2" />
+<text text-anchor="" x="834.67" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >ReadBlockFromDisk</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (49 samples, 0.38%)</title><rect x="443.5" y="277" width="4.5" height="15.0" fill="rgb(213,70,70)" rx="2" ry="2" />
+<text text-anchor="" x="446.48" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>bitcoind (2 samples, 0.02%)</title><rect x="1189.8" y="581" width="0.2" height="15.0" fill="rgb(232,97,97)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="591.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (56 samples, 0.44%)</title><rect x="582.6" y="357" width="5.1" height="15.0" fill="rgb(225,87,87)" rx="2" ry="2" />
+<text text-anchor="" x="585.59" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (6 samples, 0.05%)</title><rect x="256.2" y="197" width="0.6" height="15.0" fill="rgb(237,105,105)" rx="2" ry="2" />
+<text text-anchor="" x="259.24" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>fclose@@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="1024.5" y="389" width="0.3" height="15.0" fill="rgb(215,71,71)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>bitcoin-loadblk (12,465 samples, 97.06%)</title><rect x="10.0" y="581" width="1145.3" height="15.0" fill="rgb(242,112,112)" rx="2" ry="2" />
+<text text-anchor="" x="13.00" y="591.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >bitcoin-loadblk</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::InternalKeyComparator::Compare (32 samples, 0.25%)</title><rect x="215.7" y="453" width="3.0" height="15.0" fill="rgb(185,185,53)" rx="2" ry="2" />
+<text text-anchor="" x="218.72" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_append (12 samples, 0.09%)</title><rect x="711.0" y="341" width="1.1" height="15.0" fill="rgb(233,99,99)" rx="2" ry="2" />
+<text text-anchor="" x="714.04" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::multi_index::detail::bucket_array_base&lt;true&gt;::position (2 samples, 0.02%)</title><rect x="703.5" y="389" width="0.2" height="15.0" fill="rgb(184,184,53)" rx="2" ry="2" />
+<text text-anchor="" x="706.50" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>wake_up_q (2 samples, 0.02%)</title><rect x="1053.3" y="293" width="0.2" height="15.0" fill="rgb(64,177,177)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;CNode*, std::allocator&lt;CNode*&gt; &gt;::operator= (2 samples, 0.02%)</title><rect x="1160.2" y="549" width="0.2" height="15.0" fill="rgb(66,214,66)" rx="2" ry="2" />
+<text text-anchor="" x="1163.23" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (3 samples, 0.02%)</title><rect x="932.7" y="277" width="0.3" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="935.74" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (62 samples, 0.48%)</title><rect x="717.9" y="229" width="5.7" height="15.0" fill="rgb(209,64,64)" rx="2" ry="2" />
+<text text-anchor="" x="720.93" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__generic_file_write_iter (6 samples, 0.05%)</title><rect x="830.9" y="197" width="0.6" height="15.0" fill="rgb(50,165,165)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (3 samples, 0.02%)</title><rect x="436.9" y="245" width="0.2" height="15.0" fill="rgb(240,109,109)" rx="2" ry="2" />
+<text text-anchor="" x="439.87" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::thread::_State_impl&lt;std::thread::_Invoker&lt;std::tuple&lt;void  (2 samples, 0.02%)</title><rect x="1160.4" y="517" width="0.2" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prevector&lt;28u, unsigned char, unsigned int, int&gt;::change_capacity (150 samples, 1.17%)</title><rect x="895.7" y="325" width="13.8" height="15.0" fill="rgb(54,204,54)" rx="2" ry="2" />
+<text text-anchor="" x="898.71" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>apic_timer_interrupt (3 samples, 0.02%)</title><rect x="1152.2" y="517" width="0.3" height="15.0" fill="rgb(58,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="1155.24" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Finalize (150 samples, 1.17%)</title><rect x="328.1" y="341" width="13.8" height="15.0" fill="rgb(106,251,106)" rx="2" ry="2" />
+<text text-anchor="" x="331.08" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (2 samples, 0.02%)</title><rect x="909.2" y="229" width="0.2" height="15.0" fill="rgb(72,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="912.22" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtqueue_notify (2 samples, 0.02%)</title><rect x="1007.3" y="85" width="0.1" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="1010.25" y="95.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewErrorCatcher::GetCoin (495 samples, 3.85%)</title><rect x="396.6" y="309" width="45.5" height="15.0" fill="rgb(81,228,81)" rx="2" ry="2" />
+<text text-anchor="" x="399.63" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoi..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (2 samples, 0.02%)</title><rect x="255.7" y="197" width="0.2" height="15.0" fill="rgb(229,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="258.68" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_file_read_iter (2 samples, 0.02%)</title><rect x="895.0" y="213" width="0.2" height="15.0" fill="rgb(68,182,182)" rx="2" ry="2" />
+<text text-anchor="" x="897.98" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (37 samples, 0.29%)</title><rect x="889.3" y="229" width="3.4" height="15.0" fill="rgb(91,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="892.28" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_write (4 samples, 0.03%)</title><rect x="1035.8" y="309" width="0.4" height="15.0" fill="rgb(68,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="1038.83" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (146 samples, 1.14%)</title><rect x="328.5" y="325" width="13.4" height="15.0" fill="rgb(57,206,57)" rx="2" ry="2" />
+<text text-anchor="" x="331.45" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_done_softirq (2 samples, 0.02%)</title><rect x="997.6" y="245" width="0.2" height="15.0" fill="rgb(103,213,213)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_da_write_begin (3 samples, 0.02%)</title><rect x="830.9" y="165" width="0.3" height="15.0" fill="rgb(56,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (5 samples, 0.04%)</title><rect x="1187.0" y="453" width="0.4" height="15.0" fill="rgb(102,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="1189.97" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (14 samples, 0.11%)</title><rect x="1033.3" y="341" width="1.2" height="15.0" fill="rgb(222,83,83)" rx="2" ry="2" />
+<text text-anchor="" x="1036.25" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (5 samples, 0.04%)</title><rect x="588.3" y="389" width="0.4" height="15.0" fill="rgb(240,109,109)" rx="2" ry="2" />
+<text text-anchor="" x="591.29" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (11 samples, 0.09%)</title><rect x="237.3" y="437" width="1.0" height="15.0" fill="rgb(73,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="240.31" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__radix_tree_lookup (2 samples, 0.02%)</title><rect x="888.1" y="165" width="0.2" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="891.09" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>run_timer_softirq (2 samples, 0.02%)</title><rect x="853.2" y="213" width="0.2" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="856.17" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::ReadBlock (267 samples, 2.08%)</title><rect x="233.5" y="453" width="24.6" height="15.0" fill="rgb(184,184,53)" rx="2" ry="2" />
+<text text-anchor="" x="236.54" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >l..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_page_to_iter (3 samples, 0.02%)</title><rect x="1006.7" y="229" width="0.3" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="1009.70" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (3 samples, 0.02%)</title><rect x="235.9" y="405" width="0.3" height="15.0" fill="rgb(92,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="238.93" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_cache_readahead (7 samples, 0.05%)</title><rect x="918.0" y="229" width="0.7" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="921.04" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (2 samples, 0.02%)</title><rect x="1010.1" y="277" width="0.2" height="15.0" fill="rgb(214,70,70)" rx="2" ry="2" />
+<text text-anchor="" x="1013.10" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop1_26 (48 samples, 0.37%)</title><rect x="342.3" y="325" width="4.4" height="15.0" fill="rgb(76,224,76)" rx="2" ry="2" />
+<text text-anchor="" x="345.33" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (56 samples, 0.44%)</title><rect x="1011.9" y="341" width="5.2" height="15.0" fill="rgb(227,89,89)" rx="2" ry="2" />
+<text text-anchor="" x="1014.94" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ConnectBlock (3,587 samples, 27.93%)</title><rect x="270.3" y="421" width="329.6" height="15.0" fill="rgb(81,228,81)" rx="2" ry="2" />
+<text text-anchor="" x="273.29" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CChainState::ConnectBlock</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (26 samples, 0.20%)</title><rect x="502.5" y="325" width="2.4" height="15.0" fill="rgb(99,245,99)" rx="2" ry="2" />
+<text text-anchor="" x="505.47" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memcmp_avx2_movbe (17 samples, 0.13%)</title><rect x="217.0" y="421" width="1.6" height="15.0" fill="rgb(230,94,94)" rx="2" ry="2" />
+<text text-anchor="" x="220.00" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>futex_wait_setup (2 samples, 0.02%)</title><rect x="1189.3" y="373" width="0.1" height="15.0" fill="rgb(57,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="1192.26" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>main (2 samples, 0.02%)</title><rect x="1189.8" y="533" width="0.2" height="15.0" fill="rgb(69,217,69)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>DateTimeStrFormat[abi:cxx11] (3 samples, 0.02%)</title><rect x="1034.5" y="389" width="0.3" height="15.0" fill="rgb(93,240,93)" rx="2" ry="2" />
+<text text-anchor="" x="1037.54" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_rehash (107 samples, 0.83%)</title><rect x="299.9" y="341" width="9.8" height="15.0" fill="rgb(86,233,86)" rx="2" ry="2" />
+<text text-anchor="" x="302.88" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (3 samples, 0.02%)</title><rect x="1069.5" y="405" width="0.2" height="15.0" fill="rgb(223,84,84)" rx="2" ry="2" />
+<text text-anchor="" x="1072.45" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sock_poll (11 samples, 0.09%)</title><rect x="1159.0" y="453" width="1.0" height="15.0" fill="rgb(95,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="1162.04" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (4 samples, 0.03%)</title><rect x="831.9" y="309" width="0.4" height="15.0" fill="rgb(94,205,205)" rx="2" ry="2" />
+<text text-anchor="" x="834.95" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (3 samples, 0.02%)</title><rect x="1007.2" y="149" width="0.2" height="15.0" fill="rgb(106,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="1010.16" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (22 samples, 0.17%)</title><rect x="1158.2" y="533" width="2.0" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="1161.21" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (6 samples, 0.05%)</title><rect x="187.1" y="453" width="0.5" height="15.0" fill="rgb(229,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="190.05" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="714.4" y="373" width="0.3" height="15.0" fill="rgb(213,70,70)" rx="2" ry="2" />
+<text text-anchor="" x="717.44" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_user_enhanced_fast_string (22 samples, 0.17%)</title><rect x="883.8" y="181" width="2.0" height="15.0" fill="rgb(88,200,200)" rx="2" ry="2" />
+<text text-anchor="" x="886.77" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (3 samples, 0.02%)</title><rect x="1162.2" y="421" width="0.2" height="15.0" fill="rgb(213,69,69)" rx="2" ry="2" />
+<text text-anchor="" x="1165.16" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>iowrite16 (3 samples, 0.02%)</title><rect x="887.0" y="37" width="0.3" height="15.0" fill="rgb(92,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="889.98" y="47.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (132 samples, 1.03%)</title><rect x="407.9" y="261" width="12.2" height="15.0" fill="rgb(69,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="410.93" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::EncodeVarint32 (2 samples, 0.02%)</title><rect x="60.3" y="501" width="0.1" height="15.0" fill="rgb(196,196,57)" rx="2" ry="2" />
+<text text-anchor="" x="63.26" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_fault (18 samples, 0.14%)</title><rect x="255.2" y="357" width="1.7" height="15.0" fill="rgb(106,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="258.22" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vp_notify (3 samples, 0.02%)</title><rect x="251.3" y="133" width="0.2" height="15.0" fill="rgb(200,50,50)" rx="2" ry="2" />
+<text text-anchor="" x="254.27" y="143.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Lock (21 samples, 0.16%)</title><rect x="264.4" y="517" width="1.9" height="15.0" fill="rgb(204,204,60)" rx="2" ry="2" />
+<text text-anchor="" x="267.41" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Table::BlockReader (299 samples, 2.33%)</title><rect x="230.9" y="469" width="27.4" height="15.0" fill="rgb(199,199,58)" rx="2" ry="2" />
+<text text-anchor="" x="233.88" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >l..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sys_select (21 samples, 0.16%)</title><rect x="1158.3" y="501" width="1.9" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="1161.30" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_user_enhanced_fast_string (5 samples, 0.04%)</title><rect x="917.5" y="213" width="0.4" height="15.0" fill="rgb(58,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="920.49" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (2 samples, 0.02%)</title><rect x="1037.1" y="405" width="0.2" height="15.0" fill="rgb(68,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="1040.11" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CTransaction::GetValueOut (74 samples, 0.58%)</title><rect x="538.3" y="389" width="6.8" height="15.0" fill="rgb(87,234,87)" rx="2" ry="2" />
+<text text-anchor="" x="541.30" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (81 samples, 0.63%)</title><rect x="313.6" y="309" width="7.4" height="15.0" fill="rgb(204,56,56)" rx="2" ry="2" />
+<text text-anchor="" x="316.57" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScriptCompressor::GetSpecialSize (5 samples, 0.04%)</title><rect x="406.3" y="261" width="0.4" height="15.0" fill="rgb(72,220,72)" rx="2" ry="2" />
+<text text-anchor="" x="409.27" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScriptCompressor::Decompress (7 samples, 0.05%)</title><rect x="1075.2" y="277" width="0.7" height="15.0" fill="rgb(62,211,62)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (3 samples, 0.02%)</title><rect x="235.9" y="437" width="0.3" height="15.0" fill="rgb(226,89,89)" rx="2" ry="2" />
+<text text-anchor="" x="238.93" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>TraceThread&lt;std::function&lt;void  (22 samples, 0.17%)</title><rect x="1155.3" y="501" width="2.0" height="15.0" fill="rgb(86,233,86)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copyout (3 samples, 0.02%)</title><rect x="1006.7" y="213" width="0.3" height="15.0" fill="rgb(80,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="1009.70" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>WriteVarInt&lt;CDataStream, unsigned long&gt; (3 samples, 0.02%)</title><rect x="710.5" y="357" width="0.3" height="15.0" fill="rgb(71,219,71)" rx="2" ry="2" />
+<text text-anchor="" x="713.48" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (4 samples, 0.03%)</title><rect x="420.5" y="261" width="0.4" height="15.0" fill="rgb(214,71,71)" rx="2" ry="2" />
+<text text-anchor="" x="423.51" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (14 samples, 0.11%)</title><rect x="1031.9" y="229" width="1.3" height="15.0" fill="rgb(205,57,57)" rx="2" ry="2" />
+<text text-anchor="" x="1034.88" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>WriteCompactSize&lt;CHashWriter&gt; (5 samples, 0.04%)</title><rect x="1001.6" y="341" width="0.5" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="1004.65" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::AccessCoin (34 samples, 0.26%)</title><rect x="547.7" y="389" width="3.1" height="15.0" fill="rgb(94,240,94)" rx="2" ry="2" />
+<text text-anchor="" x="550.67" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::this_thread::interruption_point (3 samples, 0.02%)</title><rect x="1186.5" y="469" width="0.3" height="15.0" fill="rgb(190,190,55)" rx="2" ry="2" />
+<text text-anchor="" x="1189.51" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memcmp_avx2_movbe (6 samples, 0.05%)</title><rect x="189.0" y="485" width="0.5" height="15.0" fill="rgb(239,106,106)" rx="2" ry="2" />
+<text text-anchor="" x="191.98" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__virt_addr_valid (10 samples, 0.08%)</title><rect x="434.0" y="149" width="0.9" height="15.0" fill="rgb(92,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="437.02" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (16 samples, 0.12%)</title><rect x="578.7" y="341" width="1.5" height="15.0" fill="rgb(72,220,72)" rx="2" ry="2" />
+<text text-anchor="" x="581.73" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Table::InternalGet (650 samples, 5.06%)</title><rect x="198.7" y="485" width="59.7" height="15.0" fill="rgb(180,180,51)" rx="2" ry="2" />
+<text text-anchor="" x="201.72" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveld..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (66 samples, 0.51%)</title><rect x="1011.0" y="373" width="6.1" height="15.0" fill="rgb(240,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="1014.02" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (13 samples, 0.10%)</title><rect x="420.9" y="261" width="1.2" height="15.0" fill="rgb(220,80,80)" rx="2" ry="2" />
+<text text-anchor="" x="423.88" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CheckBlock (540 samples, 4.20%)</title><rect x="324.4" y="405" width="49.6" height="15.0" fill="rgb(80,228,80)" rx="2" ry="2" />
+<text text-anchor="" x="327.41" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Check..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SerializeHash&lt;CBlockHeader&gt; (2 samples, 0.02%)</title><rect x="831.7" y="389" width="0.2" height="15.0" fill="rgb(73,221,73)" rx="2" ry="2" />
+<text text-anchor="" x="834.67" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (11 samples, 0.09%)</title><rect x="1002.1" y="341" width="1.0" height="15.0" fill="rgb(203,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="1005.11" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (3 samples, 0.02%)</title><rect x="986.2" y="277" width="0.3" height="15.0" fill="rgb(72,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_write_trylock (2 samples, 0.02%)</title><rect x="418.2" y="245" width="0.2" height="15.0" fill="rgb(52,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="421.22" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_replace (6 samples, 0.05%)</title><rect x="230.3" y="453" width="0.6" height="15.0" fill="rgb(223,84,84)" rx="2" ry="2" />
+<text text-anchor="" x="233.33" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sha256_sse4::Transform (10 samples, 0.08%)</title><rect x="998.8" y="325" width="0.9" height="15.0" fill="rgb(88,235,88)" rx="2" ry="2" />
+<text text-anchor="" x="1001.80" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kmem_cache_alloc_trace (9 samples, 0.07%)</title><rect x="435.7" y="181" width="0.8" height="15.0" fill="rgb(77,190,190)" rx="2" ry="2" />
+<text text-anchor="" x="438.67" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="986.2" y="197" width="0.2" height="15.0" fill="rgb(69,182,182)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CConnman::ThreadOpenConnections (2 samples, 0.02%)</title><rect x="1160.4" y="469" width="0.2" height="15.0" fill="rgb(56,205,56)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtqueue_notify (2 samples, 0.02%)</title><rect x="1007.4" y="69" width="0.2" height="15.0" fill="rgb(77,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="79.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::WriteBatch::Put (14 samples, 0.11%)</title><rect x="710.9" y="357" width="1.2" height="15.0" fill="rgb(188,188,54)" rx="2" ry="2" />
+<text text-anchor="" x="713.85" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>iowrite16 (2 samples, 0.02%)</title><rect x="1007.3" y="53" width="0.1" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="1010.25" y="63.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>find_vma (2 samples, 0.02%)</title><rect x="435.5" y="181" width="0.2" height="15.0" fill="rgb(78,191,191)" rx="2" ry="2" />
+<text text-anchor="" x="438.49" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>start_thread (22 samples, 0.17%)</title><rect x="1155.3" y="549" width="2.0" height="15.0" fill="rgb(229,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::CSHA256 (2 samples, 0.02%)</title><rect x="327.9" y="341" width="0.2" height="15.0" fill="rgb(79,226,79)" rx="2" ry="2" />
+<text text-anchor="" x="330.90" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (3 samples, 0.02%)</title><rect x="887.0" y="85" width="0.3" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="889.98" y="95.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pthread_cond_signal@@GLIBC_2.3.2 (2 samples, 0.02%)</title><rect x="1053.3" y="389" width="0.2" height="15.0" fill="rgb(239,106,106)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>futex_wait_queue_me (11 samples, 0.09%)</title><rect x="1188.3" y="373" width="1.0" height="15.0" fill="rgb(103,213,213)" rx="2" ry="2" />
+<text text-anchor="" x="1191.25" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (3 samples, 0.02%)</title><rect x="1053.7" y="437" width="0.3" height="15.0" fill="rgb(207,60,60)" rx="2" ry="2" />
+<text text-anchor="" x="1056.74" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop1_26 (109 samples, 0.85%)</title><rect x="936.2" y="309" width="10.0" height="15.0" fill="rgb(78,226,78)" rx="2" ry="2" />
+<text text-anchor="" x="939.23" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Serialize_impl&lt;CSizeComputer, CTxIn, std::allocator&lt;CTxIn&gt;, CTxIn&gt; (13 samples, 0.10%)</title><rect x="352.2" y="373" width="1.2" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="355.16" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::AddToProcessQueue (8 samples, 0.06%)</title><rect x="1052.8" y="437" width="0.8" height="15.0" fill="rgb(57,206,57)" rx="2" ry="2" />
+<text text-anchor="" x="1055.82" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>finish_task_switch (2 samples, 0.02%)</title><rect x="1189.1" y="325" width="0.2" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="1192.08" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>memcmp@plt (2 samples, 0.02%)</title><rect x="830.3" y="229" width="0.2" height="15.0" fill="rgb(109,254,109)" rx="2" ry="2" />
+<text text-anchor="" x="833.29" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__libc_recv (2 samples, 0.02%)</title><rect x="1157.8" y="549" width="0.2" height="15.0" fill="rgb(224,86,86)" rx="2" ry="2" />
+<text text-anchor="" x="1160.84" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::this_thread::hidden::sleep_for (2 samples, 0.02%)</title><rect x="1189.8" y="469" width="0.2" height="15.0" fill="rgb(199,199,58)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_unlock (5 samples, 0.04%)</title><rect x="1052.8" y="389" width="0.5" height="15.0" fill="rgb(211,66,66)" rx="2" ry="2" />
+<text text-anchor="" x="1055.82" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::GetCoin (1,150 samples, 8.95%)</title><rect x="381.3" y="341" width="105.6" height="15.0" fill="rgb(95,241,95)" rx="2" ry="2" />
+<text text-anchor="" x="384.28" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewCa..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (2 samples, 0.02%)</title><rect x="1035.6" y="309" width="0.2" height="15.0" fill="rgb(78,191,191)" rx="2" ry="2" />
+<text text-anchor="" x="1038.64" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_doallocate (374 samples, 2.91%)</title><rect x="833.0" y="325" width="34.3" height="15.0" fill="rgb(208,62,62)" rx="2" ry="2" />
+<text text-anchor="" x="835.96" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >_I..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_flush_plug_list (4 samples, 0.03%)</title><rect x="251.2" y="261" width="0.3" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (33 samples, 0.26%)</title><rect x="593.1" y="389" width="3.0" height="15.0" fill="rgb(242,111,111)" rx="2" ry="2" />
+<text text-anchor="" x="596.06" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256 (23 samples, 0.18%)</title><rect x="701.4" y="389" width="2.1" height="15.0" fill="rgb(57,207,57)" rx="2" ry="2" />
+<text text-anchor="" x="704.39" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::PosixWritableFile::Append (11 samples, 0.09%)</title><rect x="830.6" y="325" width="1.0" height="15.0" fill="rgb(217,217,65)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>rcu_process_callbacks (2 samples, 0.02%)</title><rect x="337.5" y="229" width="0.2" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="340.55" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_page_to_iter (23 samples, 0.18%)</title><rect x="883.8" y="213" width="2.1" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="886.77" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::InternalFilterPolicy::KeyMayMatch (24 samples, 0.19%)</title><rect x="228.0" y="453" width="2.2" height="15.0" fill="rgb(180,180,52)" rx="2" ry="2" />
+<text text-anchor="" x="231.03" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ActivateBestChain (9 samples, 0.07%)</title><rect x="1075.2" y="485" width="0.9" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>AlreadyHave (4 samples, 0.03%)</title><rect x="1155.5" y="437" width="0.4" height="15.0" fill="rgb(99,245,99)" rx="2" ry="2" />
+<text text-anchor="" x="1158.55" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_unlock (3 samples, 0.02%)</title><rect x="266.3" y="501" width="0.3" height="15.0" fill="rgb(214,71,71)" rx="2" ry="2" />
+<text text-anchor="" x="269.34" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>radix_tree_lookup_slot (2 samples, 0.02%)</title><rect x="888.1" y="181" width="0.2" height="15.0" fill="rgb(86,198,198)" rx="2" ry="2" />
+<text text-anchor="" x="891.09" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (24 samples, 0.19%)</title><rect x="1165.4" y="389" width="2.2" height="15.0" fill="rgb(213,69,69)" rx="2" ry="2" />
+<text text-anchor="" x="1168.38" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>handle_mm_fault (35 samples, 0.27%)</title><rect x="254.9" y="389" width="3.2" height="15.0" fill="rgb(106,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="257.86" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (2 samples, 0.02%)</title><rect x="1158.0" y="533" width="0.2" height="15.0" fill="rgb(56,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="1161.03" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memset_avx2_unaligned_erms (2 samples, 0.02%)</title><rect x="1010.7" y="341" width="0.2" height="15.0" fill="rgb(219,78,78)" rx="2" ry="2" />
+<text text-anchor="" x="1013.74" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (17 samples, 0.13%)</title><rect x="893.7" y="309" width="1.6" height="15.0" fill="rgb(223,84,84)" rx="2" ry="2" />
+<text text-anchor="" x="896.69" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (3 samples, 0.02%)</title><rect x="258.1" y="437" width="0.2" height="15.0" fill="rgb(211,66,66)" rx="2" ry="2" />
+<text text-anchor="" x="261.07" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>find_get_entry (2 samples, 0.02%)</title><rect x="1007.7" y="213" width="0.2" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="1010.71" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="256.2" y="165" width="0.2" height="15.0" fill="rgb(59,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="259.24" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_flush_plug_list (13 samples, 0.10%)</title><rect x="255.6" y="277" width="1.2" height="15.0" fill="rgb(82,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="258.59" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__add_to_page_cache_locked (5 samples, 0.04%)</title><rect x="237.3" y="389" width="0.5" height="15.0" fill="rgb(73,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="240.31" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (31 samples, 0.24%)</title><rect x="422.3" y="245" width="2.8" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="425.26" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (33 samples, 0.26%)</title><rect x="266.8" y="501" width="3.0" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="269.80" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (26 samples, 0.20%)</title><rect x="931.4" y="341" width="2.3" height="15.0" fill="rgb(227,89,89)" rx="2" ry="2" />
+<text text-anchor="" x="934.36" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (40 samples, 0.31%)</title><rect x="879.0" y="245" width="3.7" height="15.0" fill="rgb(68,182,182)" rx="2" ry="2" />
+<text text-anchor="" x="881.99" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::FilterBlockReader::KeyMayMatch (43 samples, 0.33%)</title><rect x="226.3" y="469" width="3.9" height="15.0" fill="rgb(179,179,51)" rx="2" ry="2" />
+<text text-anchor="" x="229.28" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>schedule (4 samples, 0.03%)</title><rect x="1052.9" y="309" width="0.4" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="1055.92" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::ShardedLRUCache::Release (8 samples, 0.06%)</title><rect x="198.0" y="485" width="0.7" height="15.0" fill="rgb(221,221,66)" rx="2" ry="2" />
+<text text-anchor="" x="200.98" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Unserialize_impl&lt;CAutoFile, 28u, unsigned char&gt; (86 samples, 0.67%)</title><rect x="1003.1" y="373" width="7.9" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="1006.12" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScheduler::schedule (3 samples, 0.02%)</title><rect x="1155.9" y="389" width="0.3" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="1158.91" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (12 samples, 0.09%)</title><rect x="252.7" y="405" width="1.1" height="15.0" fill="rgb(222,83,83)" rx="2" ry="2" />
+<text text-anchor="" x="255.65" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (2 samples, 0.02%)</title><rect x="1053.6" y="357" width="0.1" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadCompactSize&lt;CAutoFile&gt; (11 samples, 0.09%)</title><rect x="1002.1" y="373" width="1.0" height="15.0" fill="rgb(81,228,81)" rx="2" ry="2" />
+<text text-anchor="" x="1005.11" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>schedule_hrtimeout_range_clock (3 samples, 0.02%)</title><rect x="1158.8" y="437" width="0.2" height="15.0" fill="rgb(90,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="1161.76" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::SaveValue (7 samples, 0.05%)</title><rect x="230.2" y="469" width="0.7" height="15.0" fill="rgb(188,188,54)" rx="2" ry="2" />
+<text text-anchor="" x="233.23" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (66 samples, 0.51%)</title><rect x="717.6" y="277" width="6.0" height="15.0" fill="rgb(245,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="720.56" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (9 samples, 0.07%)</title><rect x="256.0" y="245" width="0.8" height="15.0" fill="rgb(108,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="258.96" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_mutate@plt (3 samples, 0.02%)</title><rect x="187.8" y="485" width="0.3" height="15.0" fill="rgb(251,124,124)" rx="2" ry="2" />
+<text text-anchor="" x="190.79" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>mem_cgroup_try_charge (2 samples, 0.02%)</title><rect x="888.6" y="197" width="0.2" height="15.0" fill="rgb(84,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="891.64" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Serialize_impl&lt;CHashWriter, 28u, unsigned char&gt; (21 samples, 0.16%)</title><rect x="999.7" y="341" width="1.9" height="15.0" fill="rgb(57,207,57)" rx="2" ry="2" />
+<text text-anchor="" x="1002.72" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__alloc_pages_nodemask (9 samples, 0.07%)</title><rect x="885.9" y="181" width="0.8" height="15.0" fill="rgb(82,194,194)" rx="2" ry="2" />
+<text text-anchor="" x="888.88" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>find_vma (13 samples, 0.10%)</title><rect x="47.4" y="485" width="1.2" height="15.0" fill="rgb(52,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="50.39" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>strncmp (11 samples, 0.09%)</title><rect x="419.0" y="245" width="1.1" height="15.0" fill="rgb(73,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="422.04" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::AccessCoin (32 samples, 0.25%)</title><rect x="321.5" y="405" width="2.9" height="15.0" fill="rgb(54,204,54)" rx="2" ry="2" />
+<text text-anchor="" x="324.47" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ActivateBestChain (8,766 samples, 68.26%)</title><rect x="269.8" y="469" width="805.4" height="15.0" fill="rgb(95,241,95)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CChainState::ActivateBestChain</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_done_softirq (3 samples, 0.02%)</title><rect x="986.2" y="245" width="0.3" height="15.0" fill="rgb(106,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>iowrite16 (2 samples, 0.02%)</title><rect x="1007.4" y="37" width="0.2" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="47.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ret_from_intr (3 samples, 0.02%)</title><rect x="986.2" y="309" width="0.3" height="15.0" fill="rgb(65,178,178)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>swapgs_restore_regs_and_return_to_usermode (322 samples, 2.51%)</title><rect x="19.3" y="549" width="29.6" height="15.0" fill="rgb(67,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="22.28" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >sw..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::AddToProcessQueue (4 samples, 0.03%)</title><rect x="1155.9" y="421" width="0.4" height="15.0" fill="rgb(79,226,79)" rx="2" ry="2" />
+<text text-anchor="" x="1158.91" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SYSC_recvfrom (2 samples, 0.02%)</title><rect x="1157.8" y="501" width="0.2" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="1160.84" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>smp_apic_timer_interrupt (2 samples, 0.02%)</title><rect x="853.2" y="261" width="0.2" height="15.0" fill="rgb(67,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="856.17" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (18 samples, 0.14%)</title><rect x="450.7" y="293" width="1.6" height="15.0" fill="rgb(60,209,60)" rx="2" ry="2" />
+<text text-anchor="" x="453.65" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__x86_indirect_thunk_rax (3 samples, 0.02%)</title><rect x="18.9" y="549" width="0.3" height="15.0" fill="rgb(71,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="21.91" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (157 samples, 1.22%)</title><rect x="1038.4" y="405" width="14.4" height="15.0" fill="rgb(249,121,121)" rx="2" ry="2" />
+<text text-anchor="" x="1041.40" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::AddToProcessQueue (2 samples, 0.02%)</title><rect x="1053.6" y="437" width="0.1" height="15.0" fill="rgb(101,246,101)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (12 samples, 0.09%)</title><rect x="439.0" y="245" width="1.1" height="15.0" fill="rgb(207,60,60)" rx="2" ry="2" />
+<text text-anchor="" x="441.98" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (32 samples, 0.25%)</title><rect x="547.9" y="373" width="2.9" height="15.0" fill="rgb(77,225,77)" rx="2" ry="2" />
+<text text-anchor="" x="550.86" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (7 samples, 0.05%)</title><rect x="1037.3" y="357" width="0.6" height="15.0" fill="rgb(207,61,61)" rx="2" ry="2" />
+<text text-anchor="" x="1040.30" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (3 samples, 0.02%)</title><rect x="255.7" y="229" width="0.3" height="15.0" fill="rgb(66,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="258.68" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::multi_index::detail::hashed_index&lt;mempoolentry_txid, SaltedTxidHasher, std::equal_to&lt;uint256&gt;, boost::multi_index::detail::nth_layer&lt;1, CTxMemPoolEntry, boost::multi_index::indexed_by&lt;boost::multi_index::hashed_unique&lt;mempoolentry_txid, SaltedTxidHasher, mpl_::na, mpl_::na&gt;, boost::multi_index::ordered_non_unique&lt;boost::multi_index::tag&lt;descendant_score, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na&gt;, boost::multi_index::identity&lt;CTxMemPoolEntry&gt;, CompareTxMemPoolEntryByDescendantScore&gt;, boost::multi_index::ordered_non_unique&lt;boost::multi_index::tag&lt;entry_time, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na&gt;, boost::multi_index::identity&lt;CTxMemPoolEntry&gt;, CompareTxMemPoolEntryByEntryTime&gt;, boost::multi_index::ordered_non_unique&lt;boost::multi_index::tag&lt;ancestor_score, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na&gt;, boost::multi_index::identity&lt;CTxMemPoolEntry&gt;, CompareTxMemPoolEntryByAncestorFee&gt;, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na, mpl_::na&gt;, std::allocator&lt;CTxMemPoolEntry&gt; &gt;, boost::mpl::vector0&lt;mpl_::na&gt;, boost::multi_index::detail::hashed_unique_tag&gt;::find&lt;uint256, SaltedTxidHasher, std::equal_to&lt;uint256&gt; &gt; (28 samples, 0.22%)</title><rect x="701.1" y="405" width="2.6" height="15.0" fill="rgb(208,208,62)" rx="2" ry="2" />
+<text text-anchor="" x="704.11" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (23 samples, 0.18%)</title><rect x="58.1" y="501" width="2.2" height="15.0" fill="rgb(228,90,90)" rx="2" ry="2" />
+<text text-anchor="" x="61.14" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_file_read_iter (14 samples, 0.11%)</title><rect x="1006.6" y="245" width="1.3" height="15.0" fill="rgb(106,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="1009.61" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prevector&lt;28u, unsigned char, unsigned int, int&gt;::resize (6 samples, 0.05%)</title><rect x="1010.5" y="357" width="0.5" height="15.0" fill="rgb(55,204,55)" rx="2" ry="2" />
+<text text-anchor="" x="1013.47" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (224 samples, 1.74%)</title><rect x="517.7" y="341" width="20.6" height="15.0" fill="rgb(53,203,53)" rx="2" ry="2" />
+<text text-anchor="" x="520.72" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>TraceThread&lt;std::function&lt;void  (317 samples, 2.47%)</title><rect x="1160.7" y="501" width="29.1" height="15.0" fill="rgb(94,240,94)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Tr..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>swapgs_restore_regs_and_return_to_usermode (22 samples, 0.17%)</title><rect x="440.1" y="261" width="2.0" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="443.08" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (33 samples, 0.26%)</title><rect x="917.4" y="293" width="3.0" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="920.40" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>MilliSleep (2 samples, 0.02%)</title><rect x="1189.8" y="485" width="0.2" height="15.0" fill="rgb(91,237,91)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (1,264 samples, 9.84%)</title><rect x="715.4" y="389" width="116.2" height="15.0" fill="rgb(204,56,56)" rx="2" ry="2" />
+<text text-anchor="" x="718.45" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >[unknown]</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>futex_wake (2 samples, 0.02%)</title><rect x="1053.3" y="309" width="0.2" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::_M_range_insert&lt;char const*&gt; (2 samples, 0.02%)</title><rect x="1075.9" y="277" width="0.2" height="15.0" fill="rgb(102,247,102)" rx="2" ry="2" />
+<text text-anchor="" x="1078.89" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CheckTransaction (46 samples, 0.36%)</title><rect x="349.1" y="389" width="4.3" height="15.0" fill="rgb(93,239,93)" rx="2" ry="2" />
+<text text-anchor="" x="352.12" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (42 samples, 0.33%)</title><rect x="878.8" y="261" width="3.9" height="15.0" fill="rgb(252,125,125)" rx="2" ry="2" />
+<text text-anchor="" x="881.81" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (1,711 samples, 13.32%)</title><rect x="381.1" y="357" width="157.2" height="15.0" fill="rgb(94,240,94)" rx="2" ry="2" />
+<text text-anchor="" x="384.10" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewCache::Fet..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (15 samples, 0.12%)</title><rect x="490.0" y="325" width="1.4" height="15.0" fill="rgb(91,238,91)" rx="2" ry="2" />
+<text text-anchor="" x="492.98" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::MemTable::Get (1,389 samples, 10.82%)</title><rect x="60.4" y="517" width="127.7" height="15.0" fill="rgb(202,202,59)" rx="2" ry="2" />
+<text text-anchor="" x="63.44" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::MemTabl..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (2 samples, 0.02%)</title><rect x="1007.3" y="101" width="0.1" height="15.0" fill="rgb(225,86,86)" rx="2" ry="2" />
+<text text-anchor="" x="1010.25" y="111.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sys_futex (21 samples, 0.16%)</title><rect x="1187.6" y="421" width="1.9" height="15.0" fill="rgb(61,175,175)" rx="2" ry="2" />
+<text text-anchor="" x="1190.61" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CNode::AddInventoryKnown (4 samples, 0.03%)</title><rect x="1156.3" y="437" width="0.3" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="1159.28" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>alloc_pages_current (2 samples, 0.02%)</title><rect x="255.4" y="293" width="0.2" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="258.41" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>xol_free_insn_slot (13 samples, 0.10%)</title><rect x="268.6" y="469" width="1.2" height="15.0" fill="rgb(104,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="271.64" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Consensus::CheckTxInputs (9 samples, 0.07%)</title><rect x="1075.2" y="421" width="0.9" height="15.0" fill="rgb(103,248,103)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (13 samples, 0.10%)</title><rect x="448.0" y="293" width="1.2" height="15.0" fill="rgb(93,239,93)" rx="2" ry="2" />
+<text text-anchor="" x="450.99" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (103 samples, 0.80%)</title><rect x="883.6" y="261" width="9.4" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="886.58" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::MaybeScheduleProcessQueue (2 samples, 0.02%)</title><rect x="1160.7" y="453" width="0.2" height="15.0" fill="rgb(108,253,108)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>start_thread (317 samples, 2.47%)</title><rect x="1160.7" y="549" width="29.1" height="15.0" fill="rgb(211,67,67)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >st..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_append (22 samples, 0.17%)</title><rect x="218.7" y="453" width="2.0" height="15.0" fill="rgb(252,126,126)" rx="2" ry="2" />
+<text text-anchor="" x="221.66" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (11 samples, 0.09%)</title><rect x="219.4" y="421" width="1.0" height="15.0" fill="rgb(254,128,128)" rx="2" ry="2" />
+<text text-anchor="" x="222.39" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>start_thread (2 samples, 0.02%)</title><rect x="1160.4" y="549" width="0.2" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_copy_from_user (2 samples, 0.02%)</title><rect x="1187.7" y="405" width="0.2" height="15.0" fill="rgb(53,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="1190.70" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::FindFile (85 samples, 0.66%)</title><rect x="189.5" y="501" width="7.8" height="15.0" fill="rgb(226,226,68)" rx="2" ry="2" />
+<text text-anchor="" x="192.53" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::num_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::_M_insert_int&lt;long&gt; (2 samples, 0.02%)</title><rect x="1038.1" y="357" width="0.2" height="15.0" fill="rgb(207,60,60)" rx="2" ry="2" />
+<text text-anchor="" x="1041.12" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>tinyformat::detail::formatImpl (5 samples, 0.04%)</title><rect x="1037.9" y="405" width="0.5" height="15.0" fill="rgb(87,234,87)" rx="2" ry="2" />
+<text text-anchor="" x="1040.94" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (2 samples, 0.02%)</title><rect x="1157.8" y="533" width="0.2" height="15.0" fill="rgb(83,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="1160.84" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::AccessCoin (55 samples, 0.43%)</title><rect x="375.6" y="389" width="5.0" height="15.0" fill="rgb(92,238,92)" rx="2" ry="2" />
+<text text-anchor="" x="378.59" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (65 samples, 0.51%)</title><rect x="1011.1" y="357" width="6.0" height="15.0" fill="rgb(232,97,97)" rx="2" ry="2" />
+<text text-anchor="" x="1014.11" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScript::GetSigOpCount (171 samples, 1.33%)</title><rect x="551.2" y="373" width="15.7" height="15.0" fill="rgb(70,218,70)" rx="2" ry="2" />
+<text text-anchor="" x="554.17" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_flush_plug_list (6 samples, 0.05%)</title><rect x="868.5" y="229" width="0.6" height="15.0" fill="rgb(91,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__schedule (2 samples, 0.02%)</title><rect x="1158.9" y="405" width="0.1" height="15.0" fill="rgb(66,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="1161.85" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memcmp_avx2_movbe (59 samples, 0.46%)</title><rect x="180.7" y="437" width="5.4" height="15.0" fill="rgb(202,53,53)" rx="2" ry="2" />
+<text text-anchor="" x="183.71" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_mutate (5 samples, 0.04%)</title><rect x="230.4" y="437" width="0.5" height="15.0" fill="rgb(207,60,60)" rx="2" ry="2" />
+<text text-anchor="" x="233.42" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>task_work_run (2 samples, 0.02%)</title><rect x="1024.5" y="293" width="0.2" height="15.0" fill="rgb(92,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (5 samples, 0.04%)</title><rect x="1005.7" y="277" width="0.5" height="15.0" fill="rgb(206,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="1008.69" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (20 samples, 0.16%)</title><rect x="378.8" y="341" width="1.8" height="15.0" fill="rgb(79,227,79)" rx="2" ry="2" />
+<text text-anchor="" x="381.80" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (58 samples, 0.45%)</title><rect x="928.6" y="357" width="5.3" height="15.0" fill="rgb(233,99,99)" rx="2" ry="2" />
+<text text-anchor="" x="931.60" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (7 samples, 0.05%)</title><rect x="1037.3" y="373" width="0.6" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="1040.30" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pagecache_get_page (5 samples, 0.04%)</title><rect x="887.8" y="213" width="0.5" height="15.0" fill="rgb(63,176,176)" rx="2" ry="2" />
+<text text-anchor="" x="890.81" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (2 samples, 0.02%)</title><rect x="693.8" y="341" width="0.1" height="15.0" fill="rgb(225,86,86)" rx="2" ry="2" />
+<text text-anchor="" x="696.76" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (5 samples, 0.04%)</title><rect x="230.4" y="421" width="0.5" height="15.0" fill="rgb(206,59,59)" rx="2" ry="2" />
+<text text-anchor="" x="233.42" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_page_fault (2 samples, 0.02%)</title><rect x="711.1" y="293" width="0.2" height="15.0" fill="rgb(88,200,200)" rx="2" ry="2" />
+<text text-anchor="" x="714.13" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (4 samples, 0.03%)</title><rect x="251.2" y="197" width="0.3" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (12 samples, 0.09%)</title><rect x="867.3" y="309" width="1.1" height="15.0" fill="rgb(81,193,193)" rx="2" ry="2" />
+<text text-anchor="" x="870.32" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop2_26 (21 samples, 0.16%)</title><rect x="346.7" y="325" width="2.0" height="15.0" fill="rgb(57,207,57)" rx="2" ry="2" />
+<text text-anchor="" x="349.74" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>queue_unplugged (3 samples, 0.02%)</title><rect x="918.4" y="181" width="0.3" height="15.0" fill="rgb(91,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="921.41" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (2 samples, 0.02%)</title><rect x="915.6" y="293" width="0.2" height="15.0" fill="rgb(66,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="918.65" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::log::Writer::AddRecord (11 samples, 0.09%)</title><rect x="830.6" y="357" width="1.0" height="15.0" fill="rgb(223,223,67)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>fread@plt (2 samples, 0.02%)</title><rect x="933.9" y="357" width="0.2" height="15.0" fill="rgb(66,214,66)" rx="2" ry="2" />
+<text text-anchor="" x="936.93" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__radix_tree_lookup (2 samples, 0.02%)</title><rect x="1007.7" y="181" width="0.2" height="15.0" fill="rgb(107,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="1010.71" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_page_to_iter (3 samples, 0.02%)</title><rect x="932.4" y="245" width="0.2" height="15.0" fill="rgb(88,200,200)" rx="2" ry="2" />
+<text text-anchor="" x="935.37" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScheduler::schedule (8 samples, 0.06%)</title><rect x="1052.8" y="405" width="0.8" height="15.0" fill="rgb(107,252,107)" rx="2" ry="2" />
+<text text-anchor="" x="1055.82" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_block_write_begin (2 samples, 0.02%)</title><rect x="830.9" y="149" width="0.2" height="15.0" fill="rgb(91,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::BatchWrite (1,020 samples, 7.94%)</title><rect x="600.2" y="405" width="93.7" height="15.0" fill="rgb(82,229,82)" rx="2" ry="2" />
+<text text-anchor="" x="603.23" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewC..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (9 samples, 0.07%)</title><rect x="236.2" y="437" width="0.8" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="239.21" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (5 samples, 0.04%)</title><rect x="831.9" y="341" width="0.4" height="15.0" fill="rgb(219,77,77)" rx="2" ry="2" />
+<text text-anchor="" x="834.86" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copyout (5 samples, 0.04%)</title><rect x="917.5" y="229" width="0.4" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="920.49" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_read (14 samples, 0.11%)</title><rect x="1006.6" y="261" width="1.3" height="15.0" fill="rgb(51,166,166)" rx="2" ry="2" />
+<text text-anchor="" x="1009.61" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (862 samples, 6.71%)</title><rect x="1076.1" y="533" width="79.2" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="1079.07" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >exit_to_u..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CTxMemPool::ClearPrioritisation (2 samples, 0.02%)</title><rect x="698.9" y="405" width="0.2" height="15.0" fill="rgb(67,216,67)" rx="2" ry="2" />
+<text text-anchor="" x="701.91" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_insert_unique_node (8 samples, 0.06%)</title><rect x="604.2" y="389" width="0.7" height="15.0" fill="rgb(85,232,85)" rx="2" ry="2" />
+<text text-anchor="" x="607.18" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (11 samples, 0.09%)</title><rect x="919.3" y="261" width="1.0" height="15.0" fill="rgb(67,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="922.32" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (73 samples, 0.57%)</title><rect x="1017.7" y="341" width="6.7" height="15.0" fill="rgb(246,117,117)" rx="2" ry="2" />
+<text text-anchor="" x="1020.73" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>default_post_xol_op (4 samples, 0.03%)</title><rect x="1154.7" y="485" width="0.4" height="15.0" fill="rgb(70,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="1157.72" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::HaveInputs (1,716 samples, 13.36%)</title><rect x="380.6" y="389" width="157.7" height="15.0" fill="rgb(64,213,64)" rx="2" ry="2" />
+<text text-anchor="" x="383.64" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewCache::Hav..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;CTxOut, std::allocator&lt;CTxOut&gt; &gt;::_M_default_append (78 samples, 0.61%)</title><rect x="1017.4" y="373" width="7.1" height="15.0" fill="rgb(87,234,87)" rx="2" ry="2" />
+<text text-anchor="" x="1020.36" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ActivateBestChain (9 samples, 0.07%)</title><rect x="1075.2" y="501" width="0.9" height="15.0" fill="rgb(108,253,108)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (7 samples, 0.05%)</title><rect x="693.3" y="357" width="0.6" height="15.0" fill="rgb(237,104,104)" rx="2" ry="2" />
+<text text-anchor="" x="696.30" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (12 samples, 0.09%)</title><rect x="439.0" y="229" width="1.1" height="15.0" fill="rgb(246,117,117)" rx="2" ry="2" />
+<text text-anchor="" x="441.98" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::InternalKeyComparator::Compare (2 samples, 0.02%)</title><rect x="724.4" y="277" width="0.2" height="15.0" fill="rgb(193,193,56)" rx="2" ry="2" />
+<text text-anchor="" x="727.45" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (13 samples, 0.10%)</title><rect x="1009.3" y="341" width="1.2" height="15.0" fill="rgb(84,231,84)" rx="2" ry="2" />
+<text text-anchor="" x="1012.27" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (2,402 samples, 18.70%)</title><rect x="49.1" y="565" width="220.7" height="15.0" fill="rgb(212,68,68)" rx="2" ry="2" />
+<text text-anchor="" x="52.14" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >[unknown]</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memset_avx2_erms (2 samples, 0.02%)</title><rect x="693.9" y="389" width="0.2" height="15.0" fill="rgb(217,75,75)" rx="2" ry="2" />
+<text text-anchor="" x="696.95" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (4 samples, 0.03%)</title><rect x="571.4" y="357" width="0.3" height="15.0" fill="rgb(241,110,110)" rx="2" ry="2" />
+<text text-anchor="" x="574.38" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>filemap_fault (18 samples, 0.14%)</title><rect x="255.2" y="325" width="1.7" height="15.0" fill="rgb(55,170,170)" rx="2" ry="2" />
+<text text-anchor="" x="258.22" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_to_page (6 samples, 0.05%)</title><rect x="267.9" y="469" width="0.6" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="270.90" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (22 samples, 0.17%)</title><rect x="440.1" y="229" width="2.0" height="15.0" fill="rgb(77,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="443.08" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (26 samples, 0.20%)</title><rect x="1006.5" y="277" width="2.4" height="15.0" fill="rgb(78,190,190)" rx="2" ry="2" />
+<text text-anchor="" x="1009.52" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (14 samples, 0.11%)</title><rect x="1031.9" y="261" width="1.3" height="15.0" fill="rgb(200,50,50)" rx="2" ry="2" />
+<text text-anchor="" x="1034.88" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vmacache_find (11 samples, 0.09%)</title><rect x="47.6" y="469" width="1.0" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="50.58" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadVarInt&lt;CDataStream, unsigned long&gt; (3 samples, 0.02%)</title><rect x="407.3" y="261" width="0.3" height="15.0" fill="rgb(95,241,95)" rx="2" ry="2" />
+<text text-anchor="" x="410.28" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>add_to_page_cache_lru (2 samples, 0.02%)</title><rect x="918.8" y="261" width="0.2" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="921.77" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libstdc++.so.6.0.24] (7 samples, 0.05%)</title><rect x="1037.3" y="389" width="0.6" height="15.0" fill="rgb(216,74,74)" rx="2" ry="2" />
+<text text-anchor="" x="1040.30" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (5 samples, 0.04%)</title><rect x="588.3" y="405" width="0.4" height="15.0" fill="rgb(202,53,53)" rx="2" ry="2" />
+<text text-anchor="" x="591.29" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CheckInputs (8 samples, 0.06%)</title><rect x="374.0" y="405" width="0.8" height="15.0" fill="rgb(72,220,72)" rx="2" ry="2" />
+<text text-anchor="" x="377.02" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prefetch_freepointer (2 samples, 0.02%)</title><rect x="436.3" y="165" width="0.2" height="15.0" fill="rgb(91,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="439.32" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (3 samples, 0.02%)</title><rect x="932.1" y="261" width="0.3" height="15.0" fill="rgb(51,166,166)" rx="2" ry="2" />
+<text text-anchor="" x="935.10" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Iterator::~Iterator (3 samples, 0.02%)</title><rect x="221.7" y="453" width="0.3" height="15.0" fill="rgb(195,195,57)" rx="2" ry="2" />
+<text text-anchor="" x="224.69" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (65 samples, 0.51%)</title><rect x="581.8" y="373" width="5.9" height="15.0" fill="rgb(203,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="584.76" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_doallocbuf (374 samples, 2.91%)</title><rect x="833.0" y="341" width="34.3" height="15.0" fill="rgb(204,56,56)" rx="2" ry="2" />
+<text text-anchor="" x="835.96" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >_I..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ThreadImport (8,766 samples, 68.26%)</title><rect x="269.8" y="501" width="805.4" height="15.0" fill="rgb(79,227,79)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >ThreadImport</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__detail::_Hashtable_alloc&lt;std::allocator&lt;std::__detail::_Hash_node&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, true&gt; &gt; &gt;::_M_allocate_node&lt;std::piecewise_construct_t const&amp;, std::tuple&lt;COutPoint const&amp;&gt;, std::tuple&lt;&gt; &gt; (10 samples, 0.08%)</title><rect x="693.0" y="389" width="0.9" height="15.0" fill="rgb(76,224,76)" rx="2" ry="2" />
+<text text-anchor="" x="696.03" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (2 samples, 0.02%)</title><rect x="201.8" y="469" width="0.1" height="15.0" fill="rgb(209,63,63)" rx="2" ry="2" />
+<text text-anchor="" x="204.75" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="221.3" y="453" width="0.3" height="15.0" fill="rgb(213,69,69)" rx="2" ry="2" />
+<text text-anchor="" x="224.32" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>queue_unplugged (5 samples, 0.04%)</title><rect x="887.3" y="149" width="0.4" height="15.0" fill="rgb(51,166,166)" rx="2" ry="2" />
+<text text-anchor="" x="890.26" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>bitcoin-msghand (22 samples, 0.17%)</title><rect x="1155.3" y="581" width="2.0" height="15.0" fill="rgb(225,87,87)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="591.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (2 samples, 0.02%)</title><rect x="337.5" y="245" width="0.2" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="340.55" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (157 samples, 1.22%)</title><rect x="1038.4" y="421" width="14.4" height="15.0" fill="rgb(223,84,84)" rx="2" ry="2" />
+<text text-anchor="" x="1041.40" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_mutate (19 samples, 0.15%)</title><rect x="218.9" y="437" width="1.8" height="15.0" fill="rgb(200,50,50)" rx="2" ry="2" />
+<text text-anchor="" x="221.93" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>memcpy_erms (5 samples, 0.04%)</title><rect x="268.0" y="453" width="0.5" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="271.00" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::EncodeFixed64 (3 samples, 0.02%)</title><rect x="233.3" y="453" width="0.2" height="15.0" fill="rgb(225,225,68)" rx="2" ry="2" />
+<text text-anchor="" x="236.27" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (11 samples, 0.09%)</title><rect x="569.8" y="325" width="1.0" height="15.0" fill="rgb(75,223,75)" rx="2" ry="2" />
+<text text-anchor="" x="572.82" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (16 samples, 0.12%)</title><rect x="549.1" y="341" width="1.4" height="15.0" fill="rgb(107,252,107)" rx="2" ry="2" />
+<text text-anchor="" x="552.05" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>handle_mm_fault (3 samples, 0.02%)</title><rect x="711.9" y="245" width="0.2" height="15.0" fill="rgb(51,165,165)" rx="2" ry="2" />
+<text text-anchor="" x="714.86" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>radix_tree_next_chunk (3 samples, 0.02%)</title><rect x="257.8" y="341" width="0.3" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="260.80" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::LookupKey::LookupKey (33 samples, 0.26%)</title><rect x="57.4" y="517" width="3.0" height="15.0" fill="rgb(226,226,68)" rx="2" ry="2" />
+<text text-anchor="" x="60.41" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_finish_plug (3 samples, 0.02%)</title><rect x="918.4" y="213" width="0.3" height="15.0" fill="rgb(63,177,177)" rx="2" ry="2" />
+<text text-anchor="" x="921.41" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Arena::AllocateNewBlock (66 samples, 0.51%)</title><rect x="717.6" y="293" width="6.0" height="15.0" fill="rgb(229,229,69)" rx="2" ry="2" />
+<text text-anchor="" x="720.56" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadCompactSize&lt;CAutoFile&gt; (14 samples, 0.11%)</title><rect x="1009.2" y="357" width="1.3" height="15.0" fill="rgb(52,202,52)" rx="2" ry="2" />
+<text text-anchor="" x="1012.18" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_cache_readahead (20 samples, 0.16%)</title><rect x="885.9" y="197" width="1.8" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="888.88" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (3 samples, 0.02%)</title><rect x="932.1" y="293" width="0.3" height="15.0" fill="rgb(239,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="935.10" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ConnectBlock (9 samples, 0.07%)</title><rect x="1075.2" y="437" width="0.9" height="15.0" fill="rgb(92,238,92)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::reserve (14 samples, 0.11%)</title><rect x="1031.9" y="277" width="1.3" height="15.0" fill="rgb(234,99,99)" rx="2" ry="2" />
+<text text-anchor="" x="1034.88" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::MemTable::KeyComparator::operator (547 samples, 4.26%)</title><rect x="136.2" y="485" width="50.3" height="15.0" fill="rgb(185,185,53)" rx="2" ry="2" />
+<text text-anchor="" x="139.24" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >level..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (22 samples, 0.17%)</title><rect x="1158.2" y="517" width="2.0" height="15.0" fill="rgb(79,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="1161.21" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ondemand_readahead (6 samples, 0.05%)</title><rect x="868.5" y="277" width="0.6" height="15.0" fill="rgb(53,168,168)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>GetLegacySigOpCount (150 samples, 1.17%)</title><rect x="353.4" y="389" width="13.7" height="15.0" fill="rgb(55,205,55)" rx="2" ry="2" />
+<text text-anchor="" x="356.35" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (60 samples, 0.47%)</title><rect x="1018.9" y="325" width="5.5" height="15.0" fill="rgb(217,75,75)" rx="2" ry="2" />
+<text text-anchor="" x="1021.92" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>DateTimeStrFormat[abi:cxx11] (34 samples, 0.26%)</title><rect x="1031.4" y="405" width="3.1" height="15.0" fill="rgb(60,209,60)" rx="2" ry="2" />
+<text text-anchor="" x="1034.42" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_write (6 samples, 0.05%)</title><rect x="830.9" y="229" width="0.6" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Hash (2 samples, 0.02%)</title><rect x="261.7" y="453" width="0.1" height="15.0" fill="rgb(182,182,52)" rx="2" ry="2" />
+<text text-anchor="" x="264.66" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (4 samples, 0.03%)</title><rect x="1167.6" y="405" width="0.3" height="15.0" fill="rgb(209,63,63)" rx="2" ry="2" />
+<text text-anchor="" x="1170.58" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::HaveCoin (9 samples, 0.07%)</title><rect x="1075.2" y="389" width="0.9" height="15.0" fill="rgb(82,229,82)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fwrite (19 samples, 0.15%)</title><rect x="1034.8" y="389" width="1.8" height="15.0" fill="rgb(222,82,82)" rx="2" ry="2" />
+<text text-anchor="" x="1037.82" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (6 samples, 0.05%)</title><rect x="1036.6" y="357" width="0.5" height="15.0" fill="rgb(201,52,52)" rx="2" ry="2" />
+<text text-anchor="" x="1039.56" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>submit_bio (2 samples, 0.02%)</title><rect x="238.0" y="405" width="0.1" height="15.0" fill="rgb(103,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="240.95" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>AddCoins (436 samples, 3.39%)</title><rect x="281.0" y="405" width="40.0" height="15.0" fill="rgb(74,222,74)" rx="2" ry="2" />
+<text text-anchor="" x="283.95" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Add..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>queue_unplugged (9 samples, 0.07%)</title><rect x="256.0" y="261" width="0.8" height="15.0" fill="rgb(57,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="258.96" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__generic_file_write_iter (4 samples, 0.03%)</title><rect x="1035.8" y="277" width="0.4" height="15.0" fill="rgb(98,209,209)" rx="2" ry="2" />
+<text text-anchor="" x="1038.83" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (4 samples, 0.03%)</title><rect x="220.0" y="389" width="0.4" height="15.0" fill="rgb(252,126,126)" rx="2" ry="2" />
+<text text-anchor="" x="223.04" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::DBImpl::Write (1,264 samples, 9.84%)</title><rect x="715.4" y="373" width="116.2" height="15.0" fill="rgb(219,219,66)" rx="2" ry="2" />
+<text text-anchor="" x="718.45" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::DBImp..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (2 samples, 0.02%)</title><rect x="1053.3" y="373" width="0.2" height="15.0" fill="rgb(68,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (6 samples, 0.05%)</title><rect x="1035.0" y="309" width="0.6" height="15.0" fill="rgb(53,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="1038.00" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (5 samples, 0.04%)</title><rect x="887.3" y="117" width="0.4" height="15.0" fill="rgb(69,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="890.26" y="127.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_file_read_iter (13 samples, 0.10%)</title><rect x="917.5" y="261" width="1.2" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="920.49" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>filemap_map_pages (3 samples, 0.02%)</title><rect x="251.5" y="341" width="0.3" height="15.0" fill="rgb(95,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="254.55" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (2 samples, 0.02%)</title><rect x="221.8" y="437" width="0.2" height="15.0" fill="rgb(204,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="224.78" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (2 samples, 0.02%)</title><rect x="887.5" y="69" width="0.2" height="15.0" fill="rgb(220,80,80)" rx="2" ry="2" />
+<text text-anchor="" x="890.53" y="79.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (3 samples, 0.02%)</title><rect x="136.0" y="453" width="0.2" height="15.0" fill="rgb(81,194,194)" rx="2" ry="2" />
+<text text-anchor="" x="138.97" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (38 samples, 0.30%)</title><rect x="567.3" y="357" width="3.5" height="15.0" fill="rgb(80,227,80)" rx="2" ry="2" />
+<text text-anchor="" x="570.34" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>smp_apic_timer_interrupt (3 samples, 0.02%)</title><rect x="1152.2" y="501" width="0.3" height="15.0" fill="rgb(79,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="1155.24" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (6 samples, 0.05%)</title><rect x="187.1" y="469" width="0.5" height="15.0" fill="rgb(210,65,65)" rx="2" ry="2" />
+<text text-anchor="" x="190.05" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (49 samples, 0.38%)</title><rect x="443.5" y="293" width="4.5" height="15.0" fill="rgb(209,64,64)" rx="2" ry="2" />
+<text text-anchor="" x="446.48" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (9 samples, 0.07%)</title><rect x="716.7" y="309" width="0.9" height="15.0" fill="rgb(236,102,102)" rx="2" ry="2" />
+<text text-anchor="" x="719.73" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (4 samples, 0.03%)</title><rect x="1052.9" y="325" width="0.4" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="1055.92" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (3 samples, 0.02%)</title><rect x="1006.2" y="261" width="0.2" height="15.0" fill="rgb(106,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="1009.15" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (2 samples, 0.02%)</title><rect x="1053.6" y="373" width="0.1" height="15.0" fill="rgb(58,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::BytewiseComparatorImpl::Compare (33 samples, 0.26%)</title><rect x="194.3" y="469" width="3.0" height="15.0" fill="rgb(217,217,65)" rx="2" ry="2" />
+<text text-anchor="" x="197.31" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sha256_sse4::Transform (3 samples, 0.02%)</title><rect x="341.6" y="309" width="0.3" height="15.0" fill="rgb(78,226,78)" rx="2" ry="2" />
+<text text-anchor="" x="344.59" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_fault (2 samples, 0.02%)</title><rect x="711.1" y="277" width="0.2" height="15.0" fill="rgb(82,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="714.13" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (37 samples, 0.29%)</title><rect x="577.7" y="357" width="3.4" height="15.0" fill="rgb(69,218,69)" rx="2" ry="2" />
+<text text-anchor="" x="580.72" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Unserialize_impl&lt;CAutoFile, 28u, unsigned char&gt; (402 samples, 3.13%)</title><rect x="872.6" y="357" width="36.9" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="875.56" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Uns..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::locale::locale&lt;boost::date_time::time_facet&lt;boost::posix_time::ptime, char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt; &gt; (14 samples, 0.11%)</title><rect x="1033.3" y="389" width="1.2" height="15.0" fill="rgb(87,234,87)" rx="2" ry="2" />
+<text text-anchor="" x="1036.25" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_map_blocks (2 samples, 0.02%)</title><rect x="919.0" y="261" width="0.1" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="921.96" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_queue_bio (2 samples, 0.02%)</title><rect x="888.9" y="197" width="0.2" height="15.0" fill="rgb(52,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="891.91" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (5 samples, 0.04%)</title><rect x="869.5" y="309" width="0.5" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="872.53" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_page_to_iter (5 samples, 0.04%)</title><rect x="917.5" y="245" width="0.4" height="15.0" fill="rgb(62,176,176)" rx="2" ry="2" />
+<text text-anchor="" x="920.49" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_insert_unique_node (8 samples, 0.06%)</title><rect x="449.2" y="293" width="0.7" height="15.0" fill="rgb(63,212,63)" rx="2" ry="2" />
+<text text-anchor="" x="452.18" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Finalize (155 samples, 1.21%)</title><rect x="935.2" y="341" width="14.3" height="15.0" fill="rgb(100,246,100)" rx="2" ry="2" />
+<text text-anchor="" x="938.22" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (2 samples, 0.02%)</title><rect x="1007.4" y="85" width="0.2" height="15.0" fill="rgb(228,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="95.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_cond_resched (2 samples, 0.02%)</title><rect x="1188.4" y="357" width="0.2" height="15.0" fill="rgb(57,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="1191.44" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CountWitnessSigOps (2 samples, 0.02%)</title><rect x="550.8" y="389" width="0.2" height="15.0" fill="rgb(52,202,52)" rx="2" ry="2" />
+<text text-anchor="" x="553.80" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (9 samples, 0.07%)</title><rect x="888.4" y="245" width="0.8" height="15.0" fill="rgb(59,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="891.36" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::GetCoin (9 samples, 0.07%)</title><rect x="1075.2" y="357" width="0.9" height="15.0" fill="rgb(60,209,60)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (148 samples, 1.15%)</title><rect x="895.8" y="309" width="13.6" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="898.80" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (2,368 samples, 18.44%)</title><rect x="49.1" y="549" width="217.6" height="15.0" fill="rgb(215,72,72)" rx="2" ry="2" />
+<text text-anchor="" x="52.14" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >[unknown]</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (36 samples, 0.28%)</title><rect x="1005.6" y="309" width="3.3" height="15.0" fill="rgb(239,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="1008.60" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (5 samples, 0.04%)</title><rect x="887.3" y="133" width="0.4" height="15.0" fill="rgb(88,200,200)" rx="2" ry="2" />
+<text text-anchor="" x="890.26" y="143.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (3 samples, 0.02%)</title><rect x="1007.2" y="165" width="0.2" height="15.0" fill="rgb(104,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="1010.16" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::SkipList&lt;char const*, leveldb::MemTable::KeyComparator&gt;::Insert (1,161 samples, 9.04%)</title><rect x="723.8" y="309" width="106.7" height="15.0" fill="rgb(219,219,66)" rx="2" ry="2" />
+<text text-anchor="" x="726.81" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::Skip..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;CTxUndo, std::allocator&lt;CTxUndo&gt; &gt;::~vector (87 samples, 0.68%)</title><rect x="588.9" y="405" width="8.0" height="15.0" fill="rgb(84,231,84)" rx="2" ry="2" />
+<text text-anchor="" x="591.93" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__handle_mm_fault (8 samples, 0.06%)</title><rect x="251.1" y="357" width="0.7" height="15.0" fill="rgb(83,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="254.09" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::time_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::put (16 samples, 0.12%)</title><rect x="1031.8" y="341" width="1.5" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="1034.78" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_file_write_iter (6 samples, 0.05%)</title><rect x="830.9" y="213" width="0.6" height="15.0" fill="rgb(98,209,209)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_mutate (9 samples, 0.07%)</title><rect x="711.3" y="325" width="0.8" height="15.0" fill="rgb(229,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="714.31" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (3 samples, 0.02%)</title><rect x="893.0" y="293" width="0.3" height="15.0" fill="rgb(241,110,110)" rx="2" ry="2" />
+<text text-anchor="" x="896.05" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_create (2 samples, 0.02%)</title><rect x="187.6" y="469" width="0.2" height="15.0" fill="rgb(252,125,125)" rx="2" ry="2" />
+<text text-anchor="" x="190.60" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>EvaluateSequenceLocks (24 samples, 0.19%)</title><rect x="545.1" y="405" width="2.2" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="548.10" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (2 samples, 0.02%)</title><rect x="255.7" y="213" width="0.2" height="15.0" fill="rgb(245,116,116)" rx="2" ry="2" />
+<text text-anchor="" x="258.68" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::MaybeScheduleProcessQueue (2 samples, 0.02%)</title><rect x="1053.6" y="421" width="0.1" height="15.0" fill="rgb(85,232,85)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (377 samples, 2.94%)</title><rect x="452.3" y="293" width="34.6" height="15.0" fill="rgb(66,215,66)" rx="2" ry="2" />
+<text text-anchor="" x="455.30" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >st..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (4 samples, 0.03%)</title><rect x="255.6" y="245" width="0.4" height="15.0" fill="rgb(93,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="258.59" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (2 samples, 0.02%)</title><rect x="250.9" y="405" width="0.2" height="15.0" fill="rgb(53,168,168)" rx="2" ry="2" />
+<text text-anchor="" x="253.91" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>memcpy@plt (2 samples, 0.02%)</title><rect x="218.7" y="437" width="0.2" height="15.0" fill="rgb(216,73,73)" rx="2" ry="2" />
+<text text-anchor="" x="221.75" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (2 samples, 0.02%)</title><rect x="1010.1" y="293" width="0.2" height="15.0" fill="rgb(203,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="1013.10" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (6 samples, 0.05%)</title><rect x="1036.6" y="373" width="0.5" height="15.0" fill="rgb(213,68,68)" rx="2" ry="2" />
+<text text-anchor="" x="1039.56" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>alloc_set_pte (2 samples, 0.02%)</title><rect x="257.6" y="341" width="0.2" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="260.61" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vp_notify (4 samples, 0.03%)</title><rect x="256.4" y="149" width="0.4" height="15.0" fill="rgb(221,81,81)" rx="2" ry="2" />
+<text text-anchor="" x="259.42" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>get_request (2 samples, 0.02%)</title><rect x="888.9" y="181" width="0.2" height="15.0" fill="rgb(70,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="891.91" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Rb_tree&lt;COutPoint const*, std::pair&lt;COutPoint const* const, CTransaction const*&gt;, std::_Select1st&lt;std::pair&lt;COutPoint const* const, CTransaction const*&gt; &gt;, DereferencingComparator&lt;COutPoint const*&gt;, std::allocator&lt;std::pair&lt;COutPoint const* const, CTransaction const*&gt; &gt; &gt;::find (2 samples, 0.02%)</title><rect x="700.9" y="389" width="0.2" height="15.0" fill="rgb(102,247,102)" rx="2" ry="2" />
+<text text-anchor="" x="703.93" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (3 samples, 0.02%)</title><rect x="1053.7" y="453" width="0.3" height="15.0" fill="rgb(242,111,111)" rx="2" ry="2" />
+<text text-anchor="" x="1056.74" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (4 samples, 0.03%)</title><rect x="255.6" y="261" width="0.4" height="15.0" fill="rgb(54,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="258.59" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (3 samples, 0.02%)</title><rect x="986.2" y="261" width="0.3" height="15.0" fill="rgb(64,178,178)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>memory_cleanse (3 samples, 0.02%)</title><rect x="437.1" y="245" width="0.3" height="15.0" fill="rgb(104,249,104)" rx="2" ry="2" />
+<text text-anchor="" x="440.14" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__list_del_entry_valid (3 samples, 0.02%)</title><rect x="424.6" y="229" width="0.3" height="15.0" fill="rgb(106,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="427.65" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>uprobe_notify_resume (69 samples, 0.54%)</title><rect x="42.5" y="501" width="6.4" height="15.0" fill="rgb(94,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="45.53" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_mutate (11 samples, 0.09%)</title><rect x="186.8" y="485" width="1.0" height="15.0" fill="rgb(246,116,116)" rx="2" ry="2" />
+<text text-anchor="" x="189.77" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>schedule (3 samples, 0.02%)</title><rect x="867.0" y="229" width="0.3" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="870.05" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator delete (3 samples, 0.02%)</title><rect x="436.5" y="261" width="0.3" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="439.50" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__handle_mm_fault (34 samples, 0.26%)</title><rect x="254.9" y="373" width="3.2" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="257.95" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::ProcessQueue (279 samples, 2.17%)</title><rect x="1160.7" y="469" width="25.6" height="15.0" fill="rgb(85,232,85)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >S..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::reserve (6 samples, 0.05%)</title><rect x="1036.6" y="389" width="0.5" height="15.0" fill="rgb(202,53,53)" rx="2" ry="2" />
+<text text-anchor="" x="1039.56" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_io_completion (3 samples, 0.02%)</title><rect x="986.2" y="229" width="0.3" height="15.0" fill="rgb(70,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (2 samples, 0.02%)</title><rect x="1053.3" y="357" width="0.2" height="15.0" fill="rgb(58,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>arch_uprobe_skip_sstep (14 samples, 0.11%)</title><rect x="45.8" y="485" width="1.3" height="15.0" fill="rgb(104,215,215)" rx="2" ry="2" />
+<text text-anchor="" x="48.83" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_IRQ (3 samples, 0.02%)</title><rect x="986.2" y="293" width="0.3" height="15.0" fill="rgb(85,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Unlock (3 samples, 0.02%)</title><rect x="263.8" y="485" width="0.2" height="15.0" fill="rgb(219,219,66)" rx="2" ry="2" />
+<text text-anchor="" x="266.77" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (2 samples, 0.02%)</title><rect x="832.0" y="293" width="0.2" height="15.0" fill="rgb(76,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="835.04" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>GetRand (4 samples, 0.03%)</title><rect x="599.9" y="389" width="0.3" height="15.0" fill="rgb(79,227,79)" rx="2" ry="2" />
+<text text-anchor="" x="602.86" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>GetP2SHSigOpCount (64 samples, 0.50%)</title><rect x="566.9" y="389" width="5.9" height="15.0" fill="rgb(63,211,63)" rx="2" ry="2" />
+<text text-anchor="" x="569.88" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::InternalKeyComparator::Compare (109 samples, 0.85%)</title><rect x="820.5" y="261" width="10.0" height="15.0" fill="rgb(216,216,65)" rx="2" ry="2" />
+<text text-anchor="" x="823.46" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_read_lock (6 samples, 0.05%)</title><rect x="417.7" y="245" width="0.5" height="15.0" fill="rgb(82,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="420.67" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Consensus::CheckTxInputs (1,854 samples, 14.44%)</title><rect x="374.8" y="405" width="170.3" height="15.0" fill="rgb(77,225,77)" rx="2" ry="2" />
+<text text-anchor="" x="377.76" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Consensus::CheckTxInputs</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_replace (16 samples, 0.12%)</title><rect x="186.6" y="501" width="1.5" height="15.0" fill="rgb(203,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="189.59" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (2 samples, 0.02%)</title><rect x="253.6" y="389" width="0.2" height="15.0" fill="rgb(246,117,117)" rx="2" ry="2" />
+<text text-anchor="" x="256.57" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_read (52 samples, 0.40%)</title><rect x="883.6" y="245" width="4.8" height="15.0" fill="rgb(79,191,191)" rx="2" ry="2" />
+<text text-anchor="" x="886.58" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (5 samples, 0.04%)</title><rect x="1036.7" y="341" width="0.4" height="15.0" fill="rgb(204,56,56)" rx="2" ry="2" />
+<text text-anchor="" x="1039.65" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (3 samples, 0.02%)</title><rect x="550.5" y="341" width="0.3" height="15.0" fill="rgb(51,201,51)" rx="2" ry="2" />
+<text text-anchor="" x="553.52" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_sgetn (2 samples, 0.02%)</title><rect x="893.3" y="309" width="0.2" height="15.0" fill="rgb(221,81,81)" rx="2" ry="2" />
+<text text-anchor="" x="896.32" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__detail::_Hashtable_alloc&lt;std::allocator&lt;std::__detail::_Hash_node&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, true&gt; &gt; &gt;::_M_deallocate_node (7 samples, 0.05%)</title><rect x="636.8" y="373" width="0.6" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="639.80" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (121 samples, 0.94%)</title><rect x="491.4" y="309" width="11.1" height="15.0" fill="rgb(221,81,81)" rx="2" ry="2" />
+<text text-anchor="" x="494.35" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Block::Iter::~Iter (9 samples, 0.07%)</title><rect x="221.1" y="469" width="0.9" height="15.0" fill="rgb(219,219,66)" rx="2" ry="2" />
+<text text-anchor="" x="224.14" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (1,128 samples, 8.78%)</title><rect x="383.3" y="325" width="103.6" height="15.0" fill="rgb(57,206,57)" rx="2" ry="2" />
+<text text-anchor="" x="386.30" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewCa..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (29 samples, 0.23%)</title><rect x="642.9" y="373" width="2.6" height="15.0" fill="rgb(85,232,85)" rx="2" ry="2" />
+<text text-anchor="" x="645.86" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (9 samples, 0.07%)</title><rect x="237.3" y="421" width="0.8" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="240.31" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_perform_write (3 samples, 0.02%)</title><rect x="1035.9" y="261" width="0.3" height="15.0" fill="rgb(51,166,166)" rx="2" ry="2" />
+<text text-anchor="" x="1038.92" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (5 samples, 0.04%)</title><rect x="869.5" y="293" width="0.5" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="872.53" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ondemand_readahead (8 samples, 0.06%)</title><rect x="1007.0" y="229" width="0.7" height="15.0" fill="rgb(98,209,209)" rx="2" ry="2" />
+<text text-anchor="" x="1009.98" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>swapgs_restore_regs_and_return_to_usermode (862 samples, 6.71%)</title><rect x="1076.1" y="565" width="79.2" height="15.0" fill="rgb(62,176,176)" rx="2" ry="2" />
+<text text-anchor="" x="1079.07" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >swapgs_re..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (132 samples, 1.03%)</title><rect x="897.3" y="293" width="12.1" height="15.0" fill="rgb(202,53,53)" rx="2" ry="2" />
+<text text-anchor="" x="900.27" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (5 samples, 0.04%)</title><rect x="250.6" y="421" width="0.5" height="15.0" fill="rgb(82,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="253.63" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop1_26 (98 samples, 0.76%)</title><rect x="328.7" y="309" width="9.0" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="331.73" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__GI___libc_write (18 samples, 0.14%)</title><rect x="1034.9" y="341" width="1.7" height="15.0" fill="rgb(216,74,74)" rx="2" ry="2" />
+<text text-anchor="" x="1037.91" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>GetLegacySigOpCount (173 samples, 1.35%)</title><rect x="551.0" y="389" width="15.9" height="15.0" fill="rgb(63,212,63)" rx="2" ry="2" />
+<text text-anchor="" x="553.98" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prepare_exit_to_usermode (22 samples, 0.17%)</title><rect x="440.1" y="245" width="2.0" height="15.0" fill="rgb(66,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="443.08" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_copy_from_user (5 samples, 0.04%)</title><rect x="434.9" y="165" width="0.5" height="15.0" fill="rgb(92,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="437.94" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (2 samples, 0.02%)</title><rect x="917.2" y="277" width="0.2" height="15.0" fill="rgb(68,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="920.21" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_finish_plug (13 samples, 0.10%)</title><rect x="255.6" y="293" width="1.2" height="15.0" fill="rgb(76,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="258.59" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>AbstractThresholdConditionChecker::GetStateFor (2 samples, 0.02%)</title><rect x="588.1" y="389" width="0.2" height="15.0" fill="rgb(92,238,92)" rx="2" ry="2" />
+<text text-anchor="" x="591.10" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::TableCache::FindTable (58 samples, 0.45%)</title><rect x="258.4" y="485" width="5.4" height="15.0" fill="rgb(192,192,56)" rx="2" ry="2" />
+<text text-anchor="" x="261.44" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::signals2::detail::signal_impl&lt;void  (3 samples, 0.02%)</title><rect x="1054.0" y="453" width="0.3" height="15.0" fill="rgb(208,208,62)" rx="2" ry="2" />
+<text text-anchor="" x="1057.02" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ActivateBestChainStep (9 samples, 0.07%)</title><rect x="1075.2" y="469" width="0.9" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewDB::GetCoin (9 samples, 0.07%)</title><rect x="1075.2" y="309" width="0.9" height="15.0" fill="rgb(88,235,88)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Unlock (4 samples, 0.03%)</title><rect x="266.3" y="517" width="0.4" height="15.0" fill="rgb(224,224,67)" rx="2" ry="2" />
+<text text-anchor="" x="269.34" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (64 samples, 0.50%)</title><rect x="717.7" y="245" width="5.9" height="15.0" fill="rgb(236,103,103)" rx="2" ry="2" />
+<text text-anchor="" x="720.74" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (12 samples, 0.09%)</title><rect x="1009.4" y="325" width="1.1" height="15.0" fill="rgb(231,95,95)" rx="2" ry="2" />
+<text text-anchor="" x="1012.37" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::thread::_State_impl&lt;std::thread::_Invoker&lt;std::tuple&lt;void  (22 samples, 0.17%)</title><rect x="1155.3" y="517" width="2.0" height="15.0" fill="rgb(94,241,94)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>radix_tree_lookup_slot (2 samples, 0.02%)</title><rect x="1007.7" y="197" width="0.2" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="1010.71" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (119 samples, 0.93%)</title><rect x="310.1" y="341" width="10.9" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="313.08" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>start_thread (8,766 samples, 68.26%)</title><rect x="269.8" y="549" width="805.4" height="15.0" fill="rgb(228,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >start_thread</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (4 samples, 0.03%)</title><rect x="251.2" y="229" width="0.3" height="15.0" fill="rgb(90,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pthread_cond_signal@@GLIBC_2.3.2 (2 samples, 0.02%)</title><rect x="1053.6" y="389" width="0.1" height="15.0" fill="rgb(211,66,66)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_create (2 samples, 0.02%)</title><rect x="220.4" y="421" width="0.2" height="15.0" fill="rgb(202,53,53)" rx="2" ry="2" />
+<text text-anchor="" x="223.40" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (3 samples, 0.02%)</title><rect x="1006.2" y="277" width="0.2" height="15.0" fill="rgb(55,170,170)" rx="2" ry="2" />
+<text text-anchor="" x="1009.15" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prevector&lt;28u, unsigned char, unsigned int, int&gt;::resize (155 samples, 1.21%)</title><rect x="895.3" y="341" width="14.2" height="15.0" fill="rgb(75,223,75)" rx="2" ry="2" />
+<text text-anchor="" x="898.25" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (12 samples, 0.09%)</title><rect x="568.7" y="325" width="1.1" height="15.0" fill="rgb(75,223,75)" rx="2" ry="2" />
+<text text-anchor="" x="571.72" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (2 samples, 0.02%)</title><rect x="1001.5" y="293" width="0.1" height="15.0" fill="rgb(230,94,94)" rx="2" ry="2" />
+<text text-anchor="" x="1004.46" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::detail::thread_data&lt;boost::_bi::bind_t&lt;void, void  (8,766 samples, 68.26%)</title><rect x="269.8" y="517" width="805.4" height="15.0" fill="rgb(181,181,52)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >boost::detail::thread_data&lt;boost::_bi::bind_t&lt;void, void </text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (10 samples, 0.08%)</title><rect x="580.2" y="341" width="0.9" height="15.0" fill="rgb(51,201,51)" rx="2" ry="2" />
+<text text-anchor="" x="583.20" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::TableCache::Get (726 samples, 5.65%)</title><rect x="197.3" y="501" width="66.7" height="15.0" fill="rgb(229,229,69)" rx="2" ry="2" />
+<text text-anchor="" x="200.34" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::SpendCoin (70 samples, 0.55%)</title><rect x="575.3" y="389" width="6.5" height="15.0" fill="rgb(70,218,70)" rx="2" ry="2" />
+<text text-anchor="" x="578.33" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>apic_timer_interrupt (2 samples, 0.02%)</title><rect x="337.5" y="293" width="0.2" height="15.0" fill="rgb(94,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="340.55" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kfree (10 samples, 0.08%)</title><rect x="441.2" y="197" width="0.9" height="15.0" fill="rgb(102,213,213)" rx="2" ry="2" />
+<text text-anchor="" x="444.19" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CChainState::ConnectTip (8,519 samples, 66.33%)</title><rect x="270.1" y="437" width="782.7" height="15.0" fill="rgb(59,208,59)" rx="2" ry="2" />
+<text text-anchor="" x="273.11" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CChainState::ConnectTip</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>bitcoin-opencon (2 samples, 0.02%)</title><rect x="1160.4" y="581" width="0.2" height="15.0" fill="rgb(226,88,88)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="591.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__schedule (2 samples, 0.02%)</title><rect x="1189.1" y="341" width="0.2" height="15.0" fill="rgb(93,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="1192.08" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_kick_cmd (6 samples, 0.05%)</title><rect x="256.2" y="181" width="0.6" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="259.24" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (32 samples, 0.25%)</title><rect x="321.5" y="373" width="2.9" height="15.0" fill="rgb(74,222,74)" rx="2" ry="2" />
+<text text-anchor="" x="324.47" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (2 samples, 0.02%)</title><rect x="1024.5" y="341" width="0.2" height="15.0" fill="rgb(87,199,199)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libstdc++.so.6.0.24] (22 samples, 0.17%)</title><rect x="1155.3" y="533" width="2.0" height="15.0" fill="rgb(220,80,80)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copyout (23 samples, 0.18%)</title><rect x="883.8" y="197" width="2.1" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="886.77" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::MaybeScheduleProcessQueue (3 samples, 0.02%)</title><rect x="1155.9" y="405" width="0.3" height="15.0" fill="rgb(83,230,83)" rx="2" ry="2" />
+<text text-anchor="" x="1158.91" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_user_enhanced_fast_string (2 samples, 0.02%)</title><rect x="434.9" y="149" width="0.2" height="15.0" fill="rgb(59,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="437.94" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>down_read (3 samples, 0.02%)</title><rect x="47.1" y="485" width="0.3" height="15.0" fill="rgb(70,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="50.12" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__select (24 samples, 0.19%)</title><rect x="1158.0" y="549" width="2.2" height="15.0" fill="rgb(220,79,79)" rx="2" ry="2" />
+<text text-anchor="" x="1161.03" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>WriteVarInt&lt;CDataStream, unsigned int&gt; (6 samples, 0.05%)</title><rect x="709.9" y="357" width="0.6" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="712.93" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (63 samples, 0.49%)</title><rect x="922.4" y="325" width="5.8" height="15.0" fill="rgb(230,93,93)" rx="2" ry="2" />
+<text text-anchor="" x="925.45" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (6 samples, 0.05%)</title><rect x="225.6" y="453" width="0.6" height="15.0" fill="rgb(240,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="228.64" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_unlock (3 samples, 0.02%)</title><rect x="232.4" y="421" width="0.3" height="15.0" fill="rgb(219,78,78)" rx="2" ry="2" />
+<text text-anchor="" x="235.44" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__add_to_page_cache_locked (2 samples, 0.02%)</title><rect x="918.8" y="245" width="0.2" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="921.77" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>filemap_fault (4 samples, 0.03%)</title><rect x="251.2" y="309" width="0.3" height="15.0" fill="rgb(57,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (4 samples, 0.03%)</title><rect x="1052.9" y="357" width="0.4" height="15.0" fill="rgb(68,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="1055.92" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>radix_tree_lookup_slot (2 samples, 0.02%)</title><rect x="869.2" y="245" width="0.1" height="15.0" fill="rgb(69,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="872.16" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (80 samples, 0.62%)</title><rect x="628.1" y="373" width="7.3" height="15.0" fill="rgb(221,81,81)" rx="2" ry="2" />
+<text text-anchor="" x="631.07" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>schedule (2 samples, 0.02%)</title><rect x="1158.9" y="421" width="0.1" height="15.0" fill="rgb(67,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="1161.85" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (8 samples, 0.06%)</title><rect x="1008.1" y="261" width="0.7" height="15.0" fill="rgb(69,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="1011.08" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (3 samples, 0.02%)</title><rect x="1036.2" y="309" width="0.3" height="15.0" fill="rgb(86,198,198)" rx="2" ry="2" />
+<text text-anchor="" x="1039.19" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ondemand_readahead (7 samples, 0.05%)</title><rect x="918.0" y="245" width="0.7" height="15.0" fill="rgb(61,175,175)" rx="2" ry="2" />
+<text text-anchor="" x="921.04" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::signals2::detail::signal_impl&lt;void  (12 samples, 0.09%)</title><rect x="1160.9" y="453" width="1.1" height="15.0" fill="rgb(183,183,53)" rx="2" ry="2" />
+<text text-anchor="" x="1163.87" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__GI___libc_write (3 samples, 0.02%)</title><rect x="830.6" y="245" width="0.2" height="15.0" fill="rgb(241,110,110)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>BlockMerkleRoot (262 samples, 2.04%)</title><rect x="325.0" y="389" width="24.0" height="15.0" fill="rgb(80,228,80)" rx="2" ry="2" />
+<text text-anchor="" x="327.96" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >B..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::_M_append (2 samples, 0.02%)</title><rect x="714.9" y="373" width="0.2" height="15.0" fill="rgb(229,93,93)" rx="2" ry="2" />
+<text text-anchor="" x="717.89" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>futex_wait (18 samples, 0.14%)</title><rect x="1187.9" y="389" width="1.6" height="15.0" fill="rgb(90,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="1190.89" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::InternalKeyComparator::Compare (37 samples, 0.29%)</title><rect x="193.9" y="485" width="3.4" height="15.0" fill="rgb(202,202,60)" rx="2" ry="2" />
+<text text-anchor="" x="196.94" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>up_read (2 samples, 0.02%)</title><rect x="48.7" y="485" width="0.2" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="51.68" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScript::IsPayToScriptHash (2 samples, 0.02%)</title><rect x="572.6" y="373" width="0.2" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="575.57" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (6 samples, 0.05%)</title><rect x="933.0" y="277" width="0.6" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="936.01" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CBlockHeader::GetHash (2 samples, 0.02%)</title><rect x="831.7" y="405" width="0.2" height="15.0" fill="rgb(95,241,95)" rx="2" ry="2" />
+<text text-anchor="" x="834.67" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>swapgs_restore_regs_and_return_to_usermode (33 samples, 0.26%)</title><rect x="266.8" y="533" width="3.0" height="15.0" fill="rgb(73,186,186)" rx="2" ry="2" />
+<text text-anchor="" x="269.80" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>find_vma (8 samples, 0.06%)</title><rect x="254.1" y="389" width="0.8" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="257.12" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (74 samples, 0.58%)</title><rect x="1017.7" y="357" width="6.8" height="15.0" fill="rgb(214,70,70)" rx="2" ry="2" />
+<text text-anchor="" x="1020.73" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (2 samples, 0.02%)</title><rect x="714.9" y="357" width="0.2" height="15.0" fill="rgb(208,63,63)" rx="2" ry="2" />
+<text text-anchor="" x="717.89" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prepare_exit_to_usermode (862 samples, 6.71%)</title><rect x="1076.1" y="549" width="79.2" height="15.0" fill="rgb(90,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="1079.07" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >prepare_e..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::posix_time::operator&lt;&lt; &lt;char, std::char_traits&lt;char&gt; &gt; (18 samples, 0.14%)</title><rect x="1031.6" y="389" width="1.7" height="15.0" fill="rgb(214,214,64)" rx="2" ry="2" />
+<text text-anchor="" x="1034.60" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::erase (7 samples, 0.05%)</title><rect x="581.1" y="373" width="0.7" height="15.0" fill="rgb(93,239,93)" rx="2" ry="2" />
+<text text-anchor="" x="584.12" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CConnman::ThreadMessageHandler (22 samples, 0.17%)</title><rect x="1155.3" y="485" width="2.0" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Unlock (17 samples, 0.13%)</title><rect x="262.2" y="453" width="1.6" height="15.0" fill="rgb(212,212,63)" rx="2" ry="2" />
+<text text-anchor="" x="265.21" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Lock (2 samples, 0.02%)</title><rect x="232.3" y="437" width="0.1" height="15.0" fill="rgb(186,186,54)" rx="2" ry="2" />
+<text text-anchor="" x="235.25" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (21 samples, 0.16%)</title><rect x="251.8" y="437" width="2.0" height="15.0" fill="rgb(216,74,74)" rx="2" ry="2" />
+<text text-anchor="" x="254.83" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (3 samples, 0.02%)</title><rect x="136.0" y="437" width="0.2" height="15.0" fill="rgb(79,191,191)" rx="2" ry="2" />
+<text text-anchor="" x="138.97" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (373 samples, 2.90%)</title><rect x="833.1" y="293" width="34.2" height="15.0" fill="rgb(232,96,96)" rx="2" ry="2" />
+<text text-anchor="" x="836.05" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >_i..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::MemTable::KeyComparator::operator (502 samples, 3.91%)</title><rect x="784.4" y="277" width="46.1" height="15.0" fill="rgb(198,198,58)" rx="2" ry="2" />
+<text text-anchor="" x="787.35" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leve..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (77 samples, 0.60%)</title><rect x="1062.7" y="421" width="7.0" height="15.0" fill="rgb(245,116,116)" rx="2" ry="2" />
+<text text-anchor="" x="1065.66" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (22 samples, 0.17%)</title><rect x="1055.0" y="437" width="2.1" height="15.0" fill="rgb(250,122,122)" rx="2" ry="2" />
+<text text-anchor="" x="1058.03" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (2 samples, 0.02%)</title><rect x="887.5" y="85" width="0.2" height="15.0" fill="rgb(254,129,129)" rx="2" ry="2" />
+<text text-anchor="" x="890.53" y="95.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>WaitForShutdown (2 samples, 0.02%)</title><rect x="1189.8" y="501" width="0.2" height="15.0" fill="rgb(71,219,71)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Unlock (3 samples, 0.02%)</title><rect x="232.4" y="437" width="0.3" height="15.0" fill="rgb(216,216,65)" rx="2" ry="2" />
+<text text-anchor="" x="235.44" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>memcmp@plt (4 samples, 0.03%)</title><rect x="186.1" y="437" width="0.4" height="15.0" fill="rgb(63,211,63)" rx="2" ry="2" />
+<text text-anchor="" x="189.13" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (2 samples, 0.02%)</title><rect x="1007.4" y="149" width="0.2" height="15.0" fill="rgb(103,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prevector&lt;28u, unsigned char, unsigned int, int&gt;::resize (2 samples, 0.02%)</title><rect x="587.9" y="389" width="0.2" height="15.0" fill="rgb(71,219,71)" rx="2" ry="2" />
+<text text-anchor="" x="590.92" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (5 samples, 0.04%)</title><rect x="831.9" y="357" width="0.4" height="15.0" fill="rgb(217,75,75)" rx="2" ry="2" />
+<text text-anchor="" x="834.86" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_fread (10 samples, 0.08%)</title><rect x="871.5" y="325" width="1.0" height="15.0" fill="rgb(253,127,127)" rx="2" ry="2" />
+<text text-anchor="" x="874.55" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>FlushStateToDisk (1,393 samples, 10.85%)</title><rect x="703.7" y="421" width="128.0" height="15.0" fill="rgb(82,229,82)" rx="2" ry="2" />
+<text text-anchor="" x="706.69" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >FlushStateToDisk</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (5 samples, 0.04%)</title><rect x="886.8" y="133" width="0.5" height="15.0" fill="rgb(68,182,182)" rx="2" ry="2" />
+<text text-anchor="" x="889.80" y="143.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Sp_counted_ptr_inplace&lt;CTransaction const, std::allocator&lt;CTransaction&gt;,  (199 samples, 1.55%)</title><rect x="1167.9" y="405" width="18.3" height="15.0" fill="rgb(78,225,78)" rx="2" ry="2" />
+<text text-anchor="" x="1170.95" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (3 samples, 0.02%)</title><rect x="932.1" y="277" width="0.3" height="15.0" fill="rgb(95,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="935.10" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>branch_emulate_op (14 samples, 0.11%)</title><rect x="45.8" y="469" width="1.3" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="48.83" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copy_user_enhanced_fast_string (3 samples, 0.02%)</title><rect x="932.4" y="213" width="0.2" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="935.37" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Version::Get (827 samples, 6.44%)</title><rect x="188.1" y="517" width="75.9" height="15.0" fill="rgb(213,213,64)" rx="2" ry="2" />
+<text text-anchor="" x="191.06" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb:..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>find_get_entry (3 samples, 0.02%)</title><rect x="869.1" y="261" width="0.2" height="15.0" fill="rgb(98,209,209)" rx="2" ry="2" />
+<text text-anchor="" x="872.07" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="895.0" y="277" width="0.3" height="15.0" fill="rgb(238,106,106)" rx="2" ry="2" />
+<text text-anchor="" x="897.98" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (30 samples, 0.23%)</title><rect x="548.0" y="357" width="2.8" height="15.0" fill="rgb(74,222,74)" rx="2" ry="2" />
+<text text-anchor="" x="551.04" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (51 samples, 0.40%)</title><rect x="376.0" y="373" width="4.6" height="15.0" fill="rgb(83,230,83)" rx="2" ry="2" />
+<text text-anchor="" x="378.95" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (117 samples, 0.91%)</title><rect x="310.3" y="325" width="10.7" height="15.0" fill="rgb(238,106,106)" rx="2" ry="2" />
+<text text-anchor="" x="313.26" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (14 samples, 0.11%)</title><rect x="1033.3" y="325" width="1.2" height="15.0" fill="rgb(251,124,124)" rx="2" ry="2" />
+<text text-anchor="" x="1036.25" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_make_request (2 samples, 0.02%)</title><rect x="832.0" y="261" width="0.2" height="15.0" fill="rgb(56,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="835.04" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>TraceThread&lt;std::function&lt;void  (2 samples, 0.02%)</title><rect x="1160.4" y="501" width="0.2" height="15.0" fill="rgb(80,227,80)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_file_read_iter (51 samples, 0.40%)</title><rect x="883.7" y="229" width="4.7" height="15.0" fill="rgb(104,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="886.68" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (9 samples, 0.07%)</title><rect x="711.3" y="309" width="0.8" height="15.0" fill="rgb(226,88,88)" rx="2" ry="2" />
+<text text-anchor="" x="714.31" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>tinyformat::detail::FormatArg::formatImpl&lt;int&gt; (2 samples, 0.02%)</title><rect x="1038.1" y="389" width="0.2" height="15.0" fill="rgb(91,237,91)" rx="2" ry="2" />
+<text text-anchor="" x="1041.12" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (2 samples, 0.02%)</title><rect x="831.7" y="357" width="0.2" height="15.0" fill="rgb(58,208,58)" rx="2" ry="2" />
+<text text-anchor="" x="834.67" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::SkipList&lt;char const*, leveldb::MemTable::KeyComparator&gt;::FindGreaterOrEqual (1,371 samples, 10.68%)</title><rect x="60.6" y="501" width="126.0" height="15.0" fill="rgb(226,226,68)" rx="2" ry="2" />
+<text text-anchor="" x="63.63" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::SkipLi..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_page_fault (4 samples, 0.03%)</title><rect x="711.8" y="277" width="0.3" height="15.0" fill="rgb(87,199,199)" rx="2" ry="2" />
+<text text-anchor="" x="714.77" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (9 samples, 0.07%)</title><rect x="1075.2" y="373" width="0.9" height="15.0" fill="rgb(103,248,103)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>PeerLogicValidation::BlockConnected (8 samples, 0.06%)</title><rect x="1160.9" y="437" width="0.7" height="15.0" fill="rgb(104,249,104)" rx="2" ry="2" />
+<text text-anchor="" x="1163.87" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (7 samples, 0.05%)</title><rect x="1037.3" y="341" width="0.6" height="15.0" fill="rgb(205,57,57)" rx="2" ry="2" />
+<text text-anchor="" x="1040.30" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (6 samples, 0.05%)</title><rect x="830.9" y="245" width="0.6" height="15.0" fill="rgb(61,175,175)" rx="2" ry="2" />
+<text text-anchor="" x="833.94" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Sp_counted_base&lt; (262 samples, 2.04%)</title><rect x="1162.2" y="437" width="24.0" height="15.0" fill="rgb(59,208,59)" rx="2" ry="2" />
+<text text-anchor="" x="1165.16" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >s..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (4 samples, 0.03%)</title><rect x="232.8" y="437" width="0.4" height="15.0" fill="rgb(207,61,61)" rx="2" ry="2" />
+<text text-anchor="" x="235.81" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (2 samples, 0.02%)</title><rect x="233.0" y="421" width="0.2" height="15.0" fill="rgb(243,112,112)" rx="2" ry="2" />
+<text text-anchor="" x="235.99" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (2 samples, 0.02%)</title><rect x="853.2" y="229" width="0.2" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="856.17" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_filemap_fault (4 samples, 0.03%)</title><rect x="251.2" y="325" width="0.3" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (2 samples, 0.02%)</title><rect x="853.2" y="245" width="0.2" height="15.0" fill="rgb(53,168,168)" rx="2" ry="2" />
+<text text-anchor="" x="856.17" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (4 samples, 0.03%)</title><rect x="251.2" y="181" width="0.3" height="15.0" fill="rgb(228,91,91)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_rehash (127 samples, 0.99%)</title><rect x="505.9" y="309" width="11.6" height="15.0" fill="rgb(93,239,93)" rx="2" ry="2" />
+<text text-anchor="" x="508.87" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::ostream::_M_insert&lt;double&gt; (2 samples, 0.02%)</title><rect x="1037.9" y="373" width="0.2" height="15.0" fill="rgb(249,121,121)" rx="2" ry="2" />
+<text text-anchor="" x="1040.94" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (4 samples, 0.03%)</title><rect x="1052.9" y="341" width="0.4" height="15.0" fill="rgb(92,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="1055.92" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::EncodeVarint32 (2 samples, 0.02%)</title><rect x="723.6" y="309" width="0.2" height="15.0" fill="rgb(229,229,69)" rx="2" ry="2" />
+<text text-anchor="" x="726.62" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (2 samples, 0.02%)</title><rect x="337.5" y="261" width="0.2" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="340.55" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>UpdateCoins (155 samples, 1.21%)</title><rect x="573.9" y="405" width="14.2" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="576.86" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_string&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::resize (3 samples, 0.02%)</title><rect x="220.7" y="453" width="0.3" height="15.0" fill="rgb(245,116,116)" rx="2" ry="2" />
+<text text-anchor="" x="223.68" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>sys_read (4 samples, 0.03%)</title><rect x="883.2" y="229" width="0.4" height="15.0" fill="rgb(87,199,199)" rx="2" ry="2" />
+<text text-anchor="" x="886.22" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>queue_unplugged (2 samples, 0.02%)</title><rect x="1007.4" y="165" width="0.2" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadCompactSize&lt;CAutoFile&gt; (19 samples, 0.15%)</title><rect x="893.5" y="341" width="1.8" height="15.0" fill="rgb(75,223,75)" rx="2" ry="2" />
+<text text-anchor="" x="896.51" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ret_from_intr (2 samples, 0.02%)</title><rect x="997.6" y="309" width="0.2" height="15.0" fill="rgb(81,193,193)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (20 samples, 0.16%)</title><rect x="377.0" y="341" width="1.8" height="15.0" fill="rgb(106,251,106)" rx="2" ry="2" />
+<text text-anchor="" x="379.96" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>schedule (2 samples, 0.02%)</title><rect x="1189.1" y="357" width="0.2" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="1192.08" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>swapgs_restore_regs_and_return_to_usermode (123 samples, 0.96%)</title><rect x="425.2" y="245" width="11.3" height="15.0" fill="rgb(80,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="428.20" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>entry_SYSCALL_64 (2 samples, 0.02%)</title><rect x="1035.6" y="325" width="0.2" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="1038.64" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (3 samples, 0.02%)</title><rect x="1036.2" y="293" width="0.3" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="1039.19" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CDataStream::read (2 samples, 0.02%)</title><rect x="406.1" y="261" width="0.2" height="15.0" fill="rgb(59,208,59)" rx="2" ry="2" />
+<text text-anchor="" x="409.09" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libboost_thread.so.1.64.0] (8,766 samples, 68.26%)</title><rect x="269.8" y="533" width="805.4" height="15.0" fill="rgb(229,93,93)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >[libboost_thread.so.1.64.0]</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (374 samples, 2.91%)</title><rect x="833.0" y="309" width="34.3" height="15.0" fill="rgb(254,129,129)" rx="2" ry="2" />
+<text text-anchor="" x="835.96" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >ma..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__radix_tree_lookup (2 samples, 0.02%)</title><rect x="869.2" y="229" width="0.1" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="872.16" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_da_write_end (2 samples, 0.02%)</title><rect x="831.2" y="165" width="0.2" height="15.0" fill="rgb(100,211,211)" rx="2" ry="2" />
+<text text-anchor="" x="834.21" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (5 samples, 0.04%)</title><rect x="868.6" y="181" width="0.5" height="15.0" fill="rgb(105,215,215)" rx="2" ry="2" />
+<text text-anchor="" x="871.61" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::SkipList&lt;char const*, leveldb::MemTable::KeyComparator&gt;::FindGreaterOrEqual (1,152 samples, 8.97%)</title><rect x="724.6" y="293" width="105.9" height="15.0" fill="rgb(214,214,64)" rx="2" ry="2" />
+<text text-anchor="" x="727.63" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::Ski..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_write@@GLIBC_2.2.5 (7 samples, 0.05%)</title><rect x="830.8" y="277" width="0.7" height="15.0" fill="rgb(217,75,75)" rx="2" ry="2" />
+<text text-anchor="" x="833.85" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_insert_unique_node (116 samples, 0.90%)</title><rect x="299.2" y="357" width="10.7" height="15.0" fill="rgb(58,207,58)" rx="2" ry="2" />
+<text text-anchor="" x="302.23" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>poll_schedule_timeout (3 samples, 0.02%)</title><rect x="1158.8" y="453" width="0.2" height="15.0" fill="rgb(94,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="1161.76" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::LRUCache::Unref (4 samples, 0.03%)</title><rect x="198.1" y="469" width="0.3" height="15.0" fill="rgb(196,196,57)" rx="2" ry="2" />
+<text text-anchor="" x="201.08" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>default_pre_xol_op (2 samples, 0.02%)</title><rect x="267.6" y="453" width="0.2" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="270.63" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__GI___libc_write (7 samples, 0.05%)</title><rect x="830.8" y="261" width="0.7" height="15.0" fill="rgb(249,122,122)" rx="2" ry="2" />
+<text text-anchor="" x="833.85" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Block::Iter::Seek (207 samples, 1.61%)</title><rect x="201.9" y="469" width="19.1" height="15.0" fill="rgb(220,220,66)" rx="2" ry="2" />
+<text text-anchor="" x="204.93" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (50 samples, 0.39%)</title><rect x="376.0" y="357" width="4.6" height="15.0" fill="rgb(104,250,104)" rx="2" ry="2" />
+<text text-anchor="" x="379.05" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CTransaction::CTransaction (740 samples, 5.76%)</title><rect x="934.1" y="373" width="68.0" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="937.12" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CTransa..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::HaveCoin (1,713 samples, 13.34%)</title><rect x="380.9" y="373" width="157.4" height="15.0" fill="rgb(108,253,108)" rx="2" ry="2" />
+<text text-anchor="" x="383.91" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewCache::Hav..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;unsigned char, std::allocator&lt;unsigned char&gt; &gt;::_M_default_append (3 samples, 0.02%)</title><rect x="709.6" y="341" width="0.2" height="15.0" fill="rgb(51,201,51)" rx="2" ry="2" />
+<text text-anchor="" x="712.57" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtscsi_queuecommand (3 samples, 0.02%)</title><rect x="887.0" y="101" width="0.3" height="15.0" fill="rgb(203,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="889.98" y="111.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_flush_plug_list (6 samples, 0.05%)</title><rect x="1007.1" y="181" width="0.5" height="15.0" fill="rgb(92,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="1010.07" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (2 samples, 0.02%)</title><rect x="997.6" y="261" width="0.2" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::CCoinsViewCache (4 samples, 0.03%)</title><rect x="599.9" y="421" width="0.3" height="15.0" fill="rgb(93,240,93)" rx="2" ry="2" />
+<text text-anchor="" x="602.86" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>start_thread (9 samples, 0.07%)</title><rect x="1075.2" y="565" width="0.9" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (149 samples, 1.16%)</title><rect x="853.4" y="277" width="13.6" height="15.0" fill="rgb(200,50,50)" rx="2" ry="2" />
+<text text-anchor="" x="856.36" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__detail::_Prime_rehash_policy::_M_need_rehash (2 samples, 0.02%)</title><rect x="309.7" y="341" width="0.2" height="15.0" fill="rgb(232,97,97)" rx="2" ry="2" />
+<text text-anchor="" x="312.71" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>uprobe_notify_resume (39 samples, 0.30%)</title><rect x="432.9" y="197" width="3.6" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="435.92" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>get_task_policy.part.33 (2 samples, 0.02%)</title><rect x="255.4" y="277" width="0.2" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="258.41" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_lock (20 samples, 0.16%)</title><rect x="264.4" y="501" width="1.9" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="267.41" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>add_to_page_cache_lru (5 samples, 0.04%)</title><rect x="237.3" y="405" width="0.5" height="15.0" fill="rgb(70,183,183)" rx="2" ry="2" />
+<text text-anchor="" x="240.31" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (2 samples, 0.02%)</title><rect x="872.2" y="309" width="0.2" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="875.19" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>copyout (3 samples, 0.02%)</title><rect x="932.4" y="229" width="0.2" height="15.0" fill="rgb(95,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="935.37" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::_M_range_insert&lt;char const*&gt; (4 samples, 0.03%)</title><rect x="715.1" y="373" width="0.3" height="15.0" fill="rgb(53,203,53)" rx="2" ry="2" />
+<text text-anchor="" x="718.08" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_finish_plug (4 samples, 0.03%)</title><rect x="251.2" y="277" width="0.3" height="15.0" fill="rgb(87,199,199)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memcmp_avx2_movbe (29 samples, 0.23%)</title><rect x="194.6" y="453" width="2.6" height="15.0" fill="rgb(249,122,122)" rx="2" ry="2" />
+<text text-anchor="" x="197.58" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_select (18 samples, 0.14%)</title><rect x="1158.4" y="469" width="1.6" height="15.0" fill="rgb(52,166,166)" rx="2" ry="2" />
+<text text-anchor="" x="1161.39" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>tinyformat::detail::FormatArg::formatImpl&lt;double&gt; (2 samples, 0.02%)</title><rect x="1037.9" y="389" width="0.2" height="15.0" fill="rgb(57,207,57)" rx="2" ry="2" />
+<text text-anchor="" x="1040.94" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>hrtimer_start_range_ns (5 samples, 0.04%)</title><rect x="1188.6" y="357" width="0.5" height="15.0" fill="rgb(98,209,209)" rx="2" ry="2" />
+<text text-anchor="" x="1191.62" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memcmp_avx2_movbe (58 samples, 0.45%)</title><rect x="825.0" y="229" width="5.3" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="827.97" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>LogPrintStr (28 samples, 0.22%)</title><rect x="1034.5" y="405" width="2.6" height="15.0" fill="rgb(109,254,109)" rx="2" ry="2" />
+<text text-anchor="" x="1037.54" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_cache_readahead (4 samples, 0.03%)</title><rect x="251.2" y="293" width="0.3" height="15.0" fill="rgb(104,214,214)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtqueue_notify (3 samples, 0.02%)</title><rect x="887.0" y="69" width="0.3" height="15.0" fill="rgb(94,205,205)" rx="2" ry="2" />
+<text text-anchor="" x="889.98" y="79.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__find_uprobe (7 samples, 0.05%)</title><rect x="45.0" y="485" width="0.6" height="15.0" fill="rgb(75,188,188)" rx="2" ry="2" />
+<text text-anchor="" x="48.01" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (3 samples, 0.02%)</title><rect x="895.0" y="261" width="0.3" height="15.0" fill="rgb(203,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="897.98" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (2 samples, 0.02%)</title><rect x="869.3" y="309" width="0.2" height="15.0" fill="rgb(86,198,198)" rx="2" ry="2" />
+<text text-anchor="" x="872.34" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (3 samples, 0.02%)</title><rect x="348.7" y="325" width="0.2" height="15.0" fill="rgb(210,65,65)" rx="2" ry="2" />
+<text text-anchor="" x="351.67" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="337.5" y="213" width="0.2" height="15.0" fill="rgb(54,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="340.55" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::Mutex::Lock (3 samples, 0.02%)</title><rect x="198.4" y="469" width="0.3" height="15.0" fill="rgb(202,202,59)" rx="2" ry="2" />
+<text text-anchor="" x="201.44" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>OpenDiskFile (408 samples, 3.18%)</title><rect x="832.5" y="389" width="37.5" height="15.0" fill="rgb(93,239,93)" rx="2" ry="2" />
+<text text-anchor="" x="835.50" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Ope..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewDB::BatchWrite (128 samples, 1.00%)</title><rect x="703.7" y="389" width="11.7" height="15.0" fill="rgb(77,225,77)" rx="2" ry="2" />
+<text text-anchor="" x="706.69" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>submit_bio (2 samples, 0.02%)</title><rect x="832.0" y="277" width="0.2" height="15.0" fill="rgb(50,165,165)" rx="2" ry="2" />
+<text text-anchor="" x="835.04" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (39 samples, 0.30%)</title><rect x="1005.5" y="325" width="3.6" height="15.0" fill="rgb(220,80,80)" rx="2" ry="2" />
+<text text-anchor="" x="1008.51" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_mpage_readpages (3 samples, 0.02%)</title><rect x="250.6" y="405" width="0.3" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="253.63" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_finish_plug (6 samples, 0.05%)</title><rect x="868.5" y="245" width="0.6" height="15.0" fill="rgb(56,170,170)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_finish_plug (10 samples, 0.08%)</title><rect x="886.8" y="181" width="0.9" height="15.0" fill="rgb(90,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="889.80" y="191.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::basic_streambuf&lt;char, std::char_traits&lt;char&gt; &gt;::xsputn (14 samples, 0.11%)</title><rect x="1031.9" y="309" width="1.3" height="15.0" fill="rgb(218,77,77)" rx="2" ry="2" />
+<text text-anchor="" x="1034.88" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_unlock (16 samples, 0.12%)</title><rect x="262.3" y="437" width="1.5" height="15.0" fill="rgb(210,65,65)" rx="2" ry="2" />
+<text text-anchor="" x="265.30" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::DBImpl::Get (2,368 samples, 18.44%)</title><rect x="49.1" y="533" width="217.6" height="15.0" fill="rgb(229,229,69)" rx="2" ry="2" />
+<text text-anchor="" x="52.14" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::DBImpl::Get</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_stringbuf&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::str (7 samples, 0.05%)</title><rect x="1037.3" y="405" width="0.6" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="1040.30" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (2 samples, 0.02%)</title><rect x="1007.4" y="133" width="0.2" height="15.0" fill="rgb(100,211,211)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="143.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::MemTable::KeyComparator::operator (3 samples, 0.02%)</title><rect x="724.4" y="293" width="0.2" height="15.0" fill="rgb(192,192,56)" rx="2" ry="2" />
+<text text-anchor="" x="727.36" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>uprobe_notify_resume (22 samples, 0.17%)</title><rect x="440.1" y="213" width="2.0" height="15.0" fill="rgb(55,169,169)" rx="2" ry="2" />
+<text text-anchor="" x="443.08" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ProcessMessage (12 samples, 0.09%)</title><rect x="1155.5" y="453" width="1.1" height="15.0" fill="rgb(90,237,90)" rx="2" ry="2" />
+<text text-anchor="" x="1158.55" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>tcp_stream_memory_free (2 samples, 0.02%)</title><rect x="1159.9" y="421" width="0.1" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="1162.86" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_free (37 samples, 0.29%)</title><rect x="1164.2" y="405" width="3.4" height="15.0" fill="rgb(251,124,124)" rx="2" ry="2" />
+<text text-anchor="" x="1167.18" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;std::shared_ptr&lt;CTransaction const&gt;, std::allocator&lt;std::shared_ptr&lt;CTransaction const&gt; &gt; &gt;::_M_default_append (72 samples, 0.56%)</title><rect x="1024.8" y="389" width="6.6" height="15.0" fill="rgb(73,221,73)" rx="2" ry="2" />
+<text text-anchor="" x="1027.80" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prepare_exit_to_usermode (322 samples, 2.51%)</title><rect x="19.3" y="533" width="29.6" height="15.0" fill="rgb(106,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="22.28" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >pr..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (12 samples, 0.09%)</title><rect x="1055.9" y="421" width="1.2" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="1058.95" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (5 samples, 0.04%)</title><rect x="1005.7" y="261" width="0.5" height="15.0" fill="rgb(70,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="1008.69" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::ShardedLRUCache::Lookup (54 samples, 0.42%)</title><rect x="258.8" y="469" width="5.0" height="15.0" fill="rgb(189,189,55)" rx="2" ry="2" />
+<text text-anchor="" x="261.81" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (64 samples, 0.50%)</title><rect x="928.2" y="373" width="5.9" height="15.0" fill="rgb(104,250,104)" rx="2" ry="2" />
+<text text-anchor="" x="931.24" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (5 samples, 0.04%)</title><rect x="1188.6" y="341" width="0.5" height="15.0" fill="rgb(57,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="1191.62" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::detail::thread_data&lt;boost::_bi::bind_t&lt;void, void  (9 samples, 0.07%)</title><rect x="1075.2" y="533" width="0.9" height="15.0" fill="rgb(198,198,58)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (9 samples, 0.07%)</title><rect x="603.0" y="389" width="0.8" height="15.0" fill="rgb(98,244,98)" rx="2" ry="2" />
+<text text-anchor="" x="605.99" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>vp_notify (3 samples, 0.02%)</title><rect x="887.0" y="53" width="0.3" height="15.0" fill="rgb(244,114,114)" rx="2" ry="2" />
+<text text-anchor="" x="889.98" y="63.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prepare_exit_to_usermode (33 samples, 0.26%)</title><rect x="266.8" y="517" width="3.0" height="15.0" fill="rgb(74,187,187)" rx="2" ry="2" />
+<text text-anchor="" x="269.80" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__libc_start_main (2 samples, 0.02%)</title><rect x="1189.8" y="549" width="0.2" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (2 samples, 0.02%)</title><rect x="1007.4" y="117" width="0.2" height="15.0" fill="rgb(91,202,202)" rx="2" ry="2" />
+<text text-anchor="" x="1010.44" y="127.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (6 samples, 0.05%)</title><rect x="225.6" y="437" width="0.6" height="15.0" fill="rgb(243,113,113)" rx="2" ry="2" />
+<text text-anchor="" x="228.64" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_emplace&lt;std::piecewise_construct_t const&amp;, std::tuple&lt;COutPoint const&amp;&gt;, std::tuple&lt;Coin&amp;&amp;&gt; &gt; (85 samples, 0.66%)</title><rect x="442.1" y="309" width="7.8" height="15.0" fill="rgb(51,201,51)" rx="2" ry="2" />
+<text text-anchor="" x="445.11" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_insert_unique_node (140 samples, 1.09%)</title><rect x="504.9" y="325" width="12.8" height="15.0" fill="rgb(94,240,94)" rx="2" ry="2" />
+<text text-anchor="" x="507.86" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (403 samples, 3.14%)</title><rect x="449.9" y="309" width="37.0" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="452.92" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >std..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_cache_readahead (8 samples, 0.06%)</title><rect x="1007.0" y="213" width="0.7" height="15.0" fill="rgb(79,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="1009.98" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__schedule (4 samples, 0.03%)</title><rect x="1052.9" y="293" width="0.4" height="15.0" fill="rgb(67,181,181)" rx="2" ry="2" />
+<text text-anchor="" x="1055.92" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (172 samples, 1.34%)</title><rect x="877.5" y="309" width="15.8" height="15.0" fill="rgb(221,80,80)" rx="2" ry="2" />
+<text text-anchor="" x="880.52" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::BloomFilterPolicy::KeyMayMatch (24 samples, 0.19%)</title><rect x="228.0" y="437" width="2.2" height="15.0" fill="rgb(200,200,59)" rx="2" ry="2" />
+<text text-anchor="" x="231.03" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::vector&lt;char const*, void&gt; (21 samples, 0.16%)</title><rect x="438.2" y="261" width="1.9" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="441.16" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (4 samples, 0.03%)</title><rect x="603.8" y="389" width="0.4" height="15.0" fill="rgb(85,232,85)" rx="2" ry="2" />
+<text text-anchor="" x="606.81" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__memmove_avx_unaligned_erms (4 samples, 0.03%)</title><rect x="920.4" y="325" width="0.4" height="15.0" fill="rgb(210,64,64)" rx="2" ry="2" />
+<text text-anchor="" x="923.43" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (3 samples, 0.02%)</title><rect x="887.0" y="117" width="0.3" height="15.0" fill="rgb(84,196,196)" rx="2" ry="2" />
+<text text-anchor="" x="889.98" y="127.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (3 samples, 0.02%)</title><rect x="867.0" y="245" width="0.3" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="870.05" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>try_to_wake_up (2 samples, 0.02%)</title><rect x="1053.3" y="277" width="0.2" height="15.0" fill="rgb(59,173,173)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (14 samples, 0.11%)</title><rect x="322.1" y="357" width="1.3" height="15.0" fill="rgb(92,238,92)" rx="2" ry="2" />
+<text text-anchor="" x="325.11" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Serialize_impl&lt;CSizeComputer, std::shared_ptr&lt;CTransaction const&gt;, std::allocator&lt;std::shared_ptr&lt;CTransaction const&gt; &gt;, std::shared_ptr&lt;CTransaction const&gt; &gt; (75 samples, 0.58%)</title><rect x="367.1" y="389" width="6.9" height="15.0" fill="rgb(83,231,83)" rx="2" ry="2" />
+<text text-anchor="" x="370.13" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (6 samples, 0.05%)</title><rect x="933.0" y="261" width="0.6" height="15.0" fill="rgb(108,218,218)" rx="2" ry="2" />
+<text text-anchor="" x="936.01" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScheduler::schedule (2 samples, 0.02%)</title><rect x="1160.7" y="437" width="0.2" height="15.0" fill="rgb(106,252,106)" rx="2" ry="2" />
+<text text-anchor="" x="1163.69" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadVarInt&lt;CDataStream, unsigned int&gt; (3 samples, 0.02%)</title><rect x="407.0" y="261" width="0.3" height="15.0" fill="rgb(91,237,91)" rx="2" ry="2" />
+<text text-anchor="" x="410.01" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (155 samples, 1.21%)</title><rect x="524.1" y="325" width="14.2" height="15.0" fill="rgb(64,213,64)" rx="2" ry="2" />
+<text text-anchor="" x="527.06" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Version::Ref (2 samples, 0.02%)</title><rect x="264.0" y="517" width="0.2" height="15.0" fill="rgb(188,188,54)" rx="2" ry="2" />
+<text text-anchor="" x="267.05" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SingleThreadedSchedulerClient::MaybeScheduleProcessQueue (8 samples, 0.06%)</title><rect x="1052.8" y="421" width="0.8" height="15.0" fill="rgb(100,246,100)" rx="2" ry="2" />
+<text text-anchor="" x="1055.82" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="1057.1" y="437" width="0.2" height="15.0" fill="rgb(206,59,59)" rx="2" ry="2" />
+<text text-anchor="" x="1060.05" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (42 samples, 0.33%)</title><rect x="577.3" y="373" width="3.8" height="15.0" fill="rgb(62,211,62)" rx="2" ry="2" />
+<text text-anchor="" x="580.26" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::PutLengthPrefixedSlice (2 samples, 0.02%)</title><rect x="710.9" y="341" width="0.1" height="15.0" fill="rgb(201,201,59)" rx="2" ry="2" />
+<text text-anchor="" x="713.85" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>handle_mm_fault (8 samples, 0.06%)</title><rect x="251.1" y="373" width="0.7" height="15.0" fill="rgb(71,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="254.09" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (22 samples, 0.17%)</title><rect x="1187.5" y="437" width="2.0" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="1190.52" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::BytewiseComparatorImpl::Compare (71 samples, 0.55%)</title><rect x="824.0" y="245" width="6.5" height="15.0" fill="rgb(199,199,59)" rx="2" ry="2" />
+<text text-anchor="" x="826.95" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (71 samples, 0.55%)</title><rect x="1024.9" y="357" width="6.5" height="15.0" fill="rgb(249,121,121)" rx="2" ry="2" />
+<text text-anchor="" x="1027.89" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (517 samples, 4.03%)</title><rect x="645.5" y="373" width="47.5" height="15.0" fill="rgb(84,231,84)" rx="2" ry="2" />
+<text text-anchor="" x="648.53" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >std:..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (3 samples, 0.02%)</title><rect x="258.1" y="453" width="0.2" height="15.0" fill="rgb(240,108,108)" rx="2" ry="2" />
+<text text-anchor="" x="261.07" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__pthread_mutex_lock (4 samples, 0.03%)</title><rect x="261.8" y="437" width="0.4" height="15.0" fill="rgb(236,102,102)" rx="2" ry="2" />
+<text text-anchor="" x="264.84" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::_M_find_before_node (11 samples, 0.09%)</title><rect x="323.4" y="357" width="1.0" height="15.0" fill="rgb(56,205,56)" rx="2" ry="2" />
+<text text-anchor="" x="326.40" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CDBWrapper::Read&lt;(anonymous namespace)::CoinEntry, Coin&gt; (9 samples, 0.07%)</title><rect x="1075.2" y="293" width="0.9" height="15.0" fill="rgb(57,206,57)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[[stap_1fcfdb179552a4f378309a2ca0a83383_14032]] (61 samples, 0.47%)</title><rect x="13.3" y="549" width="5.6" height="15.0" fill="rgb(71,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="16.31" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::find (605 samples, 4.71%)</title><rect x="637.4" y="389" width="55.6" height="15.0" fill="rgb(57,207,57)" rx="2" ry="2" />
+<text text-anchor="" x="640.44" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >std::..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>apic_timer_interrupt (2 samples, 0.02%)</title><rect x="853.2" y="277" width="0.2" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="856.17" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::GetVarint32 (7 samples, 0.05%)</title><rect x="715.8" y="309" width="0.7" height="15.0" fill="rgb(195,195,57)" rx="2" ry="2" />
+<text text-anchor="" x="718.81" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SipHashUint256Extra (20 samples, 0.16%)</title><rect x="522.2" y="325" width="1.9" height="15.0" fill="rgb(59,208,59)" rx="2" ry="2" />
+<text text-anchor="" x="525.22" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_read (9 samples, 0.07%)</title><rect x="868.5" y="309" width="0.8" height="15.0" fill="rgb(82,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsputn@@GLIBC_2.2.5 (19 samples, 0.15%)</title><rect x="1034.8" y="373" width="1.8" height="15.0" fill="rgb(213,69,69)" rx="2" ry="2" />
+<text text-anchor="" x="1037.82" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>arch_uprobe_pre_xol (2 samples, 0.02%)</title><rect x="1155.1" y="501" width="0.2" height="15.0" fill="rgb(99,210,210)" rx="2" ry="2" />
+<text text-anchor="" x="1158.09" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (55 samples, 0.43%)</title><rect x="915.4" y="325" width="5.0" height="15.0" fill="rgb(226,88,88)" rx="2" ry="2" />
+<text text-anchor="" x="918.37" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>add_to_page_cache_lru (2 samples, 0.02%)</title><rect x="932.8" y="261" width="0.2" height="15.0" fill="rgb(63,177,177)" rx="2" ry="2" />
+<text text-anchor="" x="935.83" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::date_time::date_facet&lt;boost::gregorian::date, char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::do_put_tm (16 samples, 0.12%)</title><rect x="1031.8" y="357" width="1.5" height="15.0" fill="rgb(193,193,56)" rx="2" ry="2" />
+<text text-anchor="" x="1034.78" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (11 samples, 0.09%)</title><rect x="1002.1" y="357" width="1.0" height="15.0" fill="rgb(103,248,103)" rx="2" ry="2" />
+<text text-anchor="" x="1005.11" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;std::shared_ptr&lt;CTransaction const&gt;, std::allocator&lt;std::shared_ptr&lt;CTransaction const&gt; &gt; &gt;::~vector (259 samples, 2.02%)</title><rect x="1162.4" y="421" width="23.8" height="15.0" fill="rgb(95,241,95)" rx="2" ry="2" />
+<text text-anchor="" x="1165.44" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >s..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_page_fault (8 samples, 0.06%)</title><rect x="251.1" y="405" width="0.7" height="15.0" fill="rgb(77,190,190)" rx="2" ry="2" />
+<text text-anchor="" x="254.09" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_read (4 samples, 0.03%)</title><rect x="932.4" y="277" width="0.3" height="15.0" fill="rgb(71,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="935.37" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SerializeHash&lt;CTransaction&gt; (739 samples, 5.75%)</title><rect x="934.2" y="357" width="67.9" height="15.0" fill="rgb(93,239,93)" rx="2" ry="2" />
+<text text-anchor="" x="937.21" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Seriali..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>blk_flush_plug_list (3 samples, 0.02%)</title><rect x="918.4" y="197" width="0.3" height="15.0" fill="rgb(67,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="921.41" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CRollingBloomFilter::reset (3 samples, 0.02%)</title><rect x="1155.6" y="421" width="0.3" height="15.0" fill="rgb(50,200,50)" rx="2" ry="2" />
+<text text-anchor="" x="1158.64" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CDBBatch::Write&lt;(anonymous namespace)::CoinEntry, Coin&gt; (43 samples, 0.33%)</title><rect x="708.8" y="373" width="4.0" height="15.0" fill="rgb(98,244,98)" rx="2" ry="2" />
+<text text-anchor="" x="711.83" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__insertion_sort&lt;long*, __gnu_cxx::__ops::_Iter_less_iter&gt; (3 samples, 0.02%)</title><rect x="547.0" y="389" width="0.3" height="15.0" fill="rgb(92,239,92)" rx="2" ry="2" />
+<text text-anchor="" x="550.03" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>boost::signals2::detail::signal_impl&lt;void  (2 samples, 0.02%)</title><rect x="1161.8" y="437" width="0.2" height="15.0" fill="rgb(195,195,57)" rx="2" ry="2" />
+<text text-anchor="" x="1164.79" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>prevector&lt;28u, unsigned char, unsigned int, int&gt;::change_capacity (2 samples, 0.02%)</title><rect x="587.7" y="389" width="0.2" height="15.0" fill="rgb(105,250,105)" rx="2" ry="2" />
+<text text-anchor="" x="590.73" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>poll_freewait (2 samples, 0.02%)</title><rect x="1158.6" y="453" width="0.2" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="1161.58" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;unsigned char, std::allocator&lt;unsigned char&gt; &gt;::_M_assign_aux&lt;prevector&lt;28u, unsigned char, unsigned int, int&gt;::const_iterator&gt; (9 samples, 0.07%)</title><rect x="571.7" y="357" width="0.9" height="15.0" fill="rgb(82,229,82)" rx="2" ry="2" />
+<text text-anchor="" x="574.75" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (32 samples, 0.25%)</title><rect x="321.5" y="389" width="2.9" height="15.0" fill="rgb(89,235,89)" rx="2" ry="2" />
+<text text-anchor="" x="324.47" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_write@@GLIBC_2.2.5 (18 samples, 0.14%)</title><rect x="1034.9" y="357" width="1.7" height="15.0" fill="rgb(246,116,116)" rx="2" ry="2" />
+<text text-anchor="" x="1037.91" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (19 samples, 0.15%)</title><rect x="931.9" y="325" width="1.8" height="15.0" fill="rgb(239,107,107)" rx="2" ry="2" />
+<text text-anchor="" x="934.91" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::_M_range_insert&lt;char const*&gt; (4 samples, 0.03%)</title><rect x="437.4" y="261" width="0.4" height="15.0" fill="rgb(83,230,83)" rx="2" ry="2" />
+<text text-anchor="" x="440.42" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__vfs_read (14 samples, 0.11%)</title><rect x="917.4" y="277" width="1.3" height="15.0" fill="rgb(82,194,194)" rx="2" ry="2" />
+<text text-anchor="" x="920.40" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>UpdateTip (76 samples, 0.59%)</title><rect x="1031.4" y="421" width="7.0" height="15.0" fill="rgb(87,233,87)" rx="2" ry="2" />
+<text text-anchor="" x="1034.42" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>SaltedOutpointHasher::SaltedOutpointHasher (4 samples, 0.03%)</title><rect x="599.9" y="405" width="0.3" height="15.0" fill="rgb(87,234,87)" rx="2" ry="2" />
+<text text-anchor="" x="602.86" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>exit_to_usermode_loop (322 samples, 2.51%)</title><rect x="19.3" y="517" width="29.6" height="15.0" fill="rgb(80,192,192)" rx="2" ry="2" />
+<text text-anchor="" x="22.28" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >ex..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libcrypto.so.1.1.0g] (4 samples, 0.03%)</title><rect x="599.9" y="373" width="0.3" height="15.0" fill="rgb(246,118,118)" rx="2" ry="2" />
+<text text-anchor="" x="602.86" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::_M_range_insert&lt;char const*&gt; (5 samples, 0.04%)</title><rect x="712.2" y="357" width="0.5" height="15.0" fill="rgb(52,201,52)" rx="2" ry="2" />
+<text text-anchor="" x="715.23" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Block::Iter::key (2 samples, 0.02%)</title><rect x="221.0" y="469" width="0.1" height="15.0" fill="rgb(194,194,57)" rx="2" ry="2" />
+<text text-anchor="" x="223.95" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_futex (2 samples, 0.02%)</title><rect x="1053.3" y="325" width="0.2" height="15.0" fill="rgb(70,184,184)" rx="2" ry="2" />
+<text text-anchor="" x="1056.28" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (63 samples, 0.49%)</title><rect x="922.4" y="341" width="5.8" height="15.0" fill="rgb(204,55,55)" rx="2" ry="2" />
+<text text-anchor="" x="925.45" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_syscall_64 (10 samples, 0.08%)</title><rect x="882.7" y="245" width="0.9" height="15.0" fill="rgb(64,178,178)" rx="2" ry="2" />
+<text text-anchor="" x="885.67" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (19 samples, 0.15%)</title><rect x="931.9" y="309" width="1.8" height="15.0" fill="rgb(232,97,97)" rx="2" ry="2" />
+<text text-anchor="" x="934.91" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__clone (22 samples, 0.17%)</title><rect x="1155.3" y="565" width="2.0" height="15.0" fill="rgb(211,66,66)" rx="2" ry="2" />
+<text text-anchor="" x="1158.27" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_write_trylock (2 samples, 0.02%)</title><rect x="18.6" y="533" width="0.2" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="21.64" y="543.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (5 samples, 0.04%)</title><rect x="831.9" y="389" width="0.4" height="15.0" fill="rgb(54,204,54)" rx="2" ry="2" />
+<text text-anchor="" x="834.86" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Block::NewIterator (4 samples, 0.03%)</title><rect x="232.8" y="453" width="0.4" height="15.0" fill="rgb(186,186,54)" rx="2" ry="2" />
+<text text-anchor="" x="235.81" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>iowrite16 (3 samples, 0.02%)</title><rect x="251.3" y="117" width="0.2" height="15.0" fill="rgb(86,198,198)" rx="2" ry="2" />
+<text text-anchor="" x="254.27" y="127.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (71 samples, 0.55%)</title><rect x="1024.9" y="341" width="6.5" height="15.0" fill="rgb(212,67,67)" rx="2" ry="2" />
+<text text-anchor="" x="1027.89" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::Flush (1,022 samples, 7.96%)</title><rect x="600.2" y="421" width="93.9" height="15.0" fill="rgb(91,238,91)" rx="2" ry="2" />
+<text text-anchor="" x="603.23" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewC..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_IRQ (2 samples, 0.02%)</title><rect x="997.6" y="293" width="0.2" height="15.0" fill="rgb(95,206,206)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::clear (2 samples, 0.02%)</title><rect x="693.9" y="405" width="0.2" height="15.0" fill="rgb(89,235,89)" rx="2" ry="2" />
+<text text-anchor="" x="696.95" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (11 samples, 0.09%)</title><rect x="871.5" y="341" width="1.1" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="874.55" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (12 samples, 0.09%)</title><rect x="867.3" y="293" width="1.1" height="15.0" fill="rgb(106,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="870.32" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::FetchCoin (387 samples, 3.01%)</title><rect x="13.3" y="565" width="35.6" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="16.31" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCo..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CMainSignals::UpdatedBlockTip (2 samples, 0.02%)</title><rect x="1053.6" y="453" width="0.1" height="15.0" fill="rgb(97,243,97)" rx="2" ry="2" />
+<text text-anchor="" x="1056.56" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (2 samples, 0.02%)</title><rect x="238.1" y="421" width="0.2" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="241.14" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_close (2 samples, 0.02%)</title><rect x="1024.5" y="357" width="0.2" height="15.0" fill="rgb(209,64,64)" rx="2" ry="2" />
+<text text-anchor="" x="1027.53" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_file_read_iter (9 samples, 0.07%)</title><rect x="868.5" y="293" width="0.8" height="15.0" fill="rgb(67,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_lock (2 samples, 0.02%)</title><rect x="45.6" y="485" width="0.2" height="15.0" fill="rgb(101,211,211)" rx="2" ry="2" />
+<text text-anchor="" x="48.65" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>fwrite_unlocked (11 samples, 0.09%)</title><rect x="830.6" y="309" width="1.0" height="15.0" fill="rgb(205,58,58)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>MerkleComputation (240 samples, 1.87%)</title><rect x="327.0" y="357" width="22.0" height="15.0" fill="rgb(106,251,106)" rx="2" ry="2" />
+<text text-anchor="" x="329.98" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >M..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScriptCompressor::Compress (3 samples, 0.02%)</title><rect x="709.6" y="357" width="0.2" height="15.0" fill="rgb(107,252,107)" rx="2" ry="2" />
+<text text-anchor="" x="712.57" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_int_malloc (50 samples, 0.39%)</title><rect x="923.6" y="309" width="4.6" height="15.0" fill="rgb(218,77,77)" rx="2" ry="2" />
+<text text-anchor="" x="926.64" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[libboost_thread.so.1.64.0] (9 samples, 0.07%)</title><rect x="1075.2" y="549" width="0.9" height="15.0" fill="rgb(244,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="1078.24" y="559.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Hashtable&lt;COutPoint, std::pair&lt;COutPoint const, CCoinsCacheEntry&gt;, std::allocator&lt;std::pair&lt;COutPoint const, CCoinsCacheEntry&gt; &gt;, std::__detail::_Select1st, std::equal_to&lt;COutPoint&gt;, SaltedOutpointHasher, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits&lt;true, false, true&gt; &gt;::erase (354 samples, 2.76%)</title><rect x="604.9" y="389" width="32.5" height="15.0" fill="rgb(69,218,69)" rx="2" ry="2" />
+<text text-anchor="" x="607.92" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >st..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc (2 samples, 0.02%)</title><rect x="1160.2" y="517" width="0.2" height="15.0" fill="rgb(202,54,54)" rx="2" ry="2" />
+<text text-anchor="" x="1163.23" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__check_object_size (2 samples, 0.02%)</title><rect x="1160.0" y="453" width="0.2" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="1163.05" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (4 samples, 0.03%)</title><rect x="1001.7" y="325" width="0.4" height="15.0" fill="rgb(97,243,97)" rx="2" ry="2" />
+<text text-anchor="" x="1004.74" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (9 samples, 0.07%)</title><rect x="256.0" y="229" width="0.8" height="15.0" fill="rgb(94,205,205)" rx="2" ry="2" />
+<text text-anchor="" x="258.96" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::Block::NewIterator (46 samples, 0.36%)</title><rect x="222.0" y="469" width="4.2" height="15.0" fill="rgb(184,184,53)" rx="2" ry="2" />
+<text text-anchor="" x="224.96" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CSHA256::Write (151 samples, 1.18%)</title><rect x="935.6" y="325" width="13.9" height="15.0" fill="rgb(100,246,100)" rx="2" ry="2" />
+<text text-anchor="" x="938.59" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_do_write@@GLIBC_2.2.5 (3 samples, 0.02%)</title><rect x="830.6" y="277" width="0.2" height="15.0" fill="rgb(230,94,94)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CMainSignals::BlockConnected (8 samples, 0.06%)</title><rect x="1052.8" y="453" width="0.8" height="15.0" fill="rgb(98,244,98)" rx="2" ry="2" />
+<text text-anchor="" x="1055.82" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>virtqueue_notify (4 samples, 0.03%)</title><rect x="256.4" y="165" width="0.4" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="259.42" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pagecache_get_page (3 samples, 0.02%)</title><rect x="869.1" y="277" width="0.2" height="15.0" fill="rgb(96,207,207)" rx="2" ry="2" />
+<text text-anchor="" x="872.07" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>page_fault (8 samples, 0.06%)</title><rect x="251.1" y="421" width="0.7" height="15.0" fill="rgb(61,175,175)" rx="2" ry="2" />
+<text text-anchor="" x="254.09" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_write_trylock (2 samples, 0.02%)</title><rect x="424.9" y="229" width="0.2" height="15.0" fill="rgb(65,178,178)" rx="2" ry="2" />
+<text text-anchor="" x="427.92" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>WriteCompactSize&lt;CHashWriter&gt; (13 samples, 0.10%)</title><rect x="1000.5" y="325" width="1.1" height="15.0" fill="rgb(57,206,57)" rx="2" ry="2" />
+<text text-anchor="" x="1003.45" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Unserialize&lt;CAutoFile, CTransaction&gt; (1,682 samples, 13.10%)</title><rect x="870.0" y="389" width="154.5" height="15.0" fill="rgb(53,203,53)" rx="2" ry="2" />
+<text text-anchor="" x="872.99" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >Unserialize&lt;CAutoFi..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_fault (8 samples, 0.06%)</title><rect x="251.1" y="389" width="0.7" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="254.09" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>bitcoin-schedul (318 samples, 2.48%)</title><rect x="1160.6" y="581" width="29.2" height="15.0" fill="rgb(245,115,115)" rx="2" ry="2" />
+<text text-anchor="" x="1163.60" y="591.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >bi..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__cxx11::basic_stringbuf&lt;char, std::char_traits&lt;char&gt;, std::allocator&lt;char&gt; &gt;::overflow (14 samples, 0.11%)</title><rect x="1031.9" y="293" width="1.3" height="15.0" fill="rgb(236,102,102)" rx="2" ry="2" />
+<text text-anchor="" x="1034.88" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>smp_apic_timer_interrupt (3 samples, 0.02%)</title><rect x="136.0" y="469" width="0.2" height="15.0" fill="rgb(98,209,209)" rx="2" ry="2" />
+<text text-anchor="" x="138.97" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_xsgetn (65 samples, 0.51%)</title><rect x="914.8" y="341" width="6.0" height="15.0" fill="rgb(236,103,103)" rx="2" ry="2" />
+<text text-anchor="" x="917.82" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (3 samples, 0.02%)</title><rect x="830.6" y="229" width="0.2" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="833.57" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>WriteVarInt&lt;CDataStream, unsigned int&gt; (4 samples, 0.03%)</title><rect x="407.6" y="261" width="0.3" height="15.0" fill="rgb(90,237,90)" rx="2" ry="2" />
+<text text-anchor="" x="410.56" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CBlockIndex::GetAncestor (4 samples, 0.03%)</title><rect x="321.1" y="405" width="0.4" height="15.0" fill="rgb(75,223,75)" rx="2" ry="2" />
+<text text-anchor="" x="324.10" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::time_put&lt;char, std::ostreambuf_iterator&lt;char, std::char_traits&lt;char&gt; &gt; &gt;::do_put (16 samples, 0.12%)</title><rect x="1031.8" y="325" width="1.5" height="15.0" fill="rgb(246,117,117)" rx="2" ry="2" />
+<text text-anchor="" x="1034.78" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (2 samples, 0.02%)</title><rect x="596.1" y="357" width="0.2" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="599.10" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (4 samples, 0.03%)</title><rect x="251.2" y="213" width="0.3" height="15.0" fill="rgb(106,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (18 samples, 0.14%)</title><rect x="893.6" y="325" width="1.7" height="15.0" fill="rgb(53,203,53)" rx="2" ry="2" />
+<text text-anchor="" x="896.60" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewDB::GetCoin (478 samples, 3.72%)</title><rect x="398.2" y="293" width="43.9" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="401.19" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoi..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>filemap_map_pages (13 samples, 0.10%)</title><rect x="256.9" y="357" width="1.2" height="15.0" fill="rgb(97,208,208)" rx="2" ry="2" />
+<text text-anchor="" x="259.88" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kprobe_ftrace_handler (5 samples, 0.04%)</title><rect x="1005.7" y="245" width="0.5" height="15.0" fill="rgb(58,172,172)" rx="2" ry="2" />
+<text text-anchor="" x="1008.69" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ext4_file_write_iter (4 samples, 0.03%)</title><rect x="1035.8" y="293" width="0.4" height="15.0" fill="rgb(91,203,203)" rx="2" ry="2" />
+<text text-anchor="" x="1038.83" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (15 samples, 0.12%)</title><rect x="915.8" y="293" width="1.4" height="15.0" fill="rgb(213,69,69)" rx="2" ry="2" />
+<text text-anchor="" x="918.83" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>submit_bio (3 samples, 0.02%)</title><rect x="888.9" y="229" width="0.3" height="15.0" fill="rgb(53,168,168)" rx="2" ry="2" />
+<text text-anchor="" x="891.91" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>Lloop2_26 (123 samples, 0.96%)</title><rect x="986.5" y="325" width="11.3" height="15.0" fill="rgb(92,239,92)" rx="2" ry="2" />
+<text text-anchor="" x="989.49" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Function_handler&lt;void  (2 samples, 0.02%)</title><rect x="1160.4" y="485" width="0.2" height="15.0" fill="rgb(67,215,67)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::GetLengthPrefixedSlice (356 samples, 2.77%)</title><rect x="787.8" y="261" width="32.7" height="15.0" fill="rgb(201,201,59)" rx="2" ry="2" />
+<text text-anchor="" x="790.75" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >le..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_cache_readahead (6 samples, 0.05%)</title><rect x="868.5" y="261" width="0.6" height="15.0" fill="rgb(62,176,176)" rx="2" ry="2" />
+<text text-anchor="" x="871.52" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_IRQ (2 samples, 0.02%)</title><rect x="909.2" y="261" width="0.2" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="912.22" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (15 samples, 0.12%)</title><rect x="915.8" y="277" width="1.4" height="15.0" fill="rgb(67,180,180)" rx="2" ry="2" />
+<text text-anchor="" x="918.83" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>operator new (71 samples, 0.55%)</title><rect x="1024.9" y="373" width="6.5" height="15.0" fill="rgb(207,61,61)" rx="2" ry="2" />
+<text text-anchor="" x="1027.89" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CScript::GetSigOpCount (19 samples, 0.15%)</title><rect x="570.8" y="373" width="1.8" height="15.0" fill="rgb(96,242,96)" rx="2" ry="2" />
+<text text-anchor="" x="573.83" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__clone (2 samples, 0.02%)</title><rect x="1160.4" y="565" width="0.2" height="15.0" fill="rgb(208,61,61)" rx="2" ry="2" />
+<text text-anchor="" x="1163.42" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ReadBlockFromDisk (2,172 samples, 16.91%)</title><rect x="831.9" y="405" width="199.5" height="15.0" fill="rgb(102,248,102)" rx="2" ry="2" />
+<text text-anchor="" x="834.86" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >ReadBlockFromDisk</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>PeerLogicValidation::ProcessMessages (14 samples, 0.11%)</title><rect x="1155.5" y="469" width="1.2" height="15.0" fill="rgb(65,214,65)" rx="2" ry="2" />
+<text text-anchor="" x="1158.45" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (12 samples, 0.09%)</title><rect x="867.3" y="325" width="1.1" height="15.0" fill="rgb(251,125,125)" rx="2" ry="2" />
+<text text-anchor="" x="870.32" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>uprobe_notify_resume (32 samples, 0.25%)</title><rect x="266.9" y="485" width="2.9" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="269.89" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_fault (4 samples, 0.03%)</title><rect x="251.2" y="341" width="0.3" height="15.0" fill="rgb(78,190,190)" rx="2" ry="2" />
+<text text-anchor="" x="254.18" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CAutoFile::read (59 samples, 0.46%)</title><rect x="1003.8" y="357" width="5.4" height="15.0" fill="rgb(58,208,58)" rx="2" ry="2" />
+<text text-anchor="" x="1006.76" y="367.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>irq_exit (2 samples, 0.02%)</title><rect x="997.6" y="277" width="0.2" height="15.0" fill="rgb(72,185,185)" rx="2" ry="2" />
+<text text-anchor="" x="1000.61" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (8 samples, 0.06%)</title><rect x="1035.8" y="325" width="0.8" height="15.0" fill="rgb(86,198,198)" rx="2" ry="2" />
+<text text-anchor="" x="1038.83" y="335.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_make_request (2 samples, 0.02%)</title><rect x="238.0" y="389" width="0.1" height="15.0" fill="rgb(57,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="240.95" y="399.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (36 samples, 0.28%)</title><rect x="1005.6" y="293" width="3.3" height="15.0" fill="rgb(228,92,92)" rx="2" ry="2" />
+<text text-anchor="" x="1008.60" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ComputeMerkleRoot (240 samples, 1.87%)</title><rect x="327.0" y="373" width="22.0" height="15.0" fill="rgb(99,245,99)" rx="2" ry="2" />
+<text text-anchor="" x="329.98" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >C..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ftrace_ops_assist_func (3 samples, 0.02%)</title><rect x="235.9" y="421" width="0.3" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="238.93" y="431.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>page_fault (2 samples, 0.02%)</title><rect x="711.1" y="309" width="0.2" height="15.0" fill="rgb(88,200,200)" rx="2" ry="2" />
+<text text-anchor="" x="714.13" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_request_fn (3 samples, 0.02%)</title><rect x="918.4" y="149" width="0.3" height="15.0" fill="rgb(101,212,212)" rx="2" ry="2" />
+<text text-anchor="" x="921.41" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_IO_file_underflow@@GLIBC_2.2.5 (168 samples, 1.31%)</title><rect x="877.6" y="293" width="15.4" height="15.0" fill="rgb(217,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="880.61" y="303.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::Flush (1,392 samples, 10.84%)</title><rect x="703.7" y="405" width="127.9" height="15.0" fill="rgb(94,240,94)" rx="2" ry="2" />
+<text text-anchor="" x="706.69" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CCoinsViewCache:..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::WriteBatch::Iterate (1,253 samples, 9.76%)</title><rect x="715.4" y="341" width="115.2" height="15.0" fill="rgb(216,216,65)" rx="2" ry="2" />
+<text text-anchor="" x="718.45" y="351.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >leveldb::Write..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_end_request (3 samples, 0.02%)</title><rect x="986.2" y="213" width="0.3" height="15.0" fill="rgb(107,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="989.21" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>arch_uprobe_post_xol (12 samples, 0.09%)</title><rect x="1154.0" y="501" width="1.1" height="15.0" fill="rgb(89,201,201)" rx="2" ry="2" />
+<text text-anchor="" x="1156.98" y="511.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>do_futex (18 samples, 0.14%)</title><rect x="1187.9" y="405" width="1.6" height="15.0" fill="rgb(105,216,216)" rx="2" ry="2" />
+<text text-anchor="" x="1190.89" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Sp_counted_ptr_inplace&lt;CTransaction const, std::allocator&lt;CTransaction&gt;,  (195 samples, 1.52%)</title><rect x="1057.3" y="437" width="17.9" height="15.0" fill="rgb(61,210,61)" rx="2" ry="2" />
+<text text-anchor="" x="1060.33" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::_Vector_base&lt;char, zero_after_free_allocator&lt;char&gt; &gt;::_M_deallocate (3 samples, 0.02%)</title><rect x="437.1" y="261" width="0.3" height="15.0" fill="rgb(100,246,100)" rx="2" ry="2" />
+<text text-anchor="" x="440.14" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::port::AcceleratedCRC32C (144 samples, 1.12%)</title><rect x="238.6" y="437" width="13.2" height="15.0" fill="rgb(199,199,58)" rx="2" ry="2" />
+<text text-anchor="" x="241.59" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>pagecache_get_page (2 samples, 0.02%)</title><rect x="1007.7" y="229" width="0.2" height="15.0" fill="rgb(86,198,198)" rx="2" ry="2" />
+<text text-anchor="" x="1010.71" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>malloc_consolidate.part.0 (7 samples, 0.05%)</title><rect x="1180.3" y="373" width="0.6" height="15.0" fill="rgb(233,98,98)" rx="2" ry="2" />
+<text text-anchor="" x="1183.26" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CDBWrapper::Read&lt;(anonymous namespace)::CoinEntry, Coin&gt; (474 samples, 3.69%)</title><rect x="398.6" y="277" width="43.5" height="15.0" fill="rgb(92,238,92)" rx="2" ry="2" />
+<text text-anchor="" x="401.56" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >CDBW..</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>strlen (6 samples, 0.05%)</title><rect x="418.5" y="245" width="0.5" height="15.0" fill="rgb(107,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="421.49" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_raw_spin_unlock_irqrestore (2 samples, 0.02%)</title><rect x="830.7" y="197" width="0.1" height="15.0" fill="rgb(77,189,189)" rx="2" ry="2" />
+<text text-anchor="" x="833.66" y="207.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>bitcoin-net (34 samples, 0.26%)</title><rect x="1157.3" y="581" width="3.1" height="15.0" fill="rgb(218,76,76)" rx="2" ry="2" />
+<text text-anchor="" x="1160.29" y="591.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>scsi_dispatch_cmd (2 samples, 0.02%)</title><rect x="1007.3" y="133" width="0.1" height="15.0" fill="rgb(83,195,195)" rx="2" ry="2" />
+<text text-anchor="" x="1010.25" y="143.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>add_to_page_cache_lru (6 samples, 0.05%)</title><rect x="888.4" y="229" width="0.5" height="15.0" fill="rgb(109,219,219)" rx="2" ry="2" />
+<text text-anchor="" x="891.36" y="239.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (5 samples, 0.04%)</title><rect x="886.8" y="149" width="0.5" height="15.0" fill="rgb(107,217,217)" rx="2" ry="2" />
+<text text-anchor="" x="889.80" y="159.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>generic_make_request (3 samples, 0.02%)</title><rect x="888.9" y="213" width="0.3" height="15.0" fill="rgb(84,197,197)" rx="2" ry="2" />
+<text text-anchor="" x="891.91" y="223.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>iowrite16 (4 samples, 0.03%)</title><rect x="256.4" y="133" width="0.4" height="15.0" fill="rgb(92,204,204)" rx="2" ry="2" />
+<text text-anchor="" x="259.42" y="143.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_fault (4 samples, 0.03%)</title><rect x="711.8" y="261" width="0.3" height="15.0" fill="rgb(60,174,174)" rx="2" ry="2" />
+<text text-anchor="" x="714.77" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::ostream::_M_insert&lt;long&gt; (2 samples, 0.02%)</title><rect x="1038.1" y="373" width="0.2" height="15.0" fill="rgb(225,86,86)" rx="2" ry="2" />
+<text text-anchor="" x="1041.12" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CTxMemPool::removeConflicts (22 samples, 0.17%)</title><rect x="699.1" y="405" width="2.0" height="15.0" fill="rgb(87,234,87)" rx="2" ry="2" />
+<text text-anchor="" x="702.09" y="415.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>cfree@GLIBC_2.2.5 (14 samples, 0.11%)</title><rect x="635.4" y="373" width="1.3" height="15.0" fill="rgb(210,65,65)" rx="2" ry="2" />
+<text text-anchor="" x="638.42" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::__detail::_Prime_rehash_policy::_M_need_rehash (2 samples, 0.02%)</title><rect x="517.5" y="309" width="0.2" height="15.0" fill="rgb(236,103,103)" rx="2" ry="2" />
+<text text-anchor="" x="520.54" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>[unknown] (2 samples, 0.02%)</title><rect x="1010.1" y="261" width="0.2" height="15.0" fill="rgb(238,106,106)" rx="2" ry="2" />
+<text text-anchor="" x="1013.10" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>std::vector&lt;std::shared_ptr&lt;CTransaction const&gt;, std::allocator&lt;std::shared_ptr&lt;CTransaction const&gt; &gt; &gt;::~vector (228 samples, 1.78%)</title><rect x="1054.3" y="453" width="20.9" height="15.0" fill="rgb(80,228,80)" rx="2" ry="2" />
+<text text-anchor="" x="1057.29" y="463.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>kretprobe_trampoline (3 samples, 0.02%)</title><rect x="895.0" y="245" width="0.3" height="15.0" fill="rgb(52,167,167)" rx="2" ry="2" />
+<text text-anchor="" x="897.98" y="255.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>ActivateBestChain (8,766 samples, 68.26%)</title><rect x="269.8" y="485" width="805.4" height="15.0" fill="rgb(59,208,59)" rx="2" ry="2" />
+<text text-anchor="" x="272.83" y="495.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  >ActivateBestChain</text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>trampoline_handler (12 samples, 0.09%)</title><rect x="919.2" y="277" width="1.1" height="15.0" fill="rgb(54,168,168)" rx="2" ry="2" />
+<text text-anchor="" x="922.23" y="287.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::(anonymous namespace)::PosixMmapReadableFile::Read (2 samples, 0.02%)</title><rect x="238.3" y="437" width="0.2" height="15.0" fill="rgb(199,199,59)" rx="2" ry="2" />
+<text text-anchor="" x="241.32" y="447.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>read (55 samples, 0.43%)</title><rect x="915.4" y="309" width="5.0" height="15.0" fill="rgb(254,128,128)" rx="2" ry="2" />
+<text text-anchor="" x="918.37" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>CCoinsViewCache::AccessCoin (40 samples, 0.31%)</title><rect x="567.2" y="373" width="3.6" height="15.0" fill="rgb(76,224,76)" rx="2" ry="2" />
+<text text-anchor="" x="570.15" y="383.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>uprobe_notify_resume (29 samples, 0.23%)</title><rect x="1152.6" y="517" width="2.7" height="15.0" fill="rgb(65,179,179)" rx="2" ry="2" />
+<text text-anchor="" x="1155.61" y="527.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__do_page_cache_readahead (17 samples, 0.13%)</title><rect x="255.2" y="309" width="1.6" height="15.0" fill="rgb(57,171,171)" rx="2" ry="2" />
+<text text-anchor="" x="258.22" y="319.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__softirqentry_text_start (3 samples, 0.02%)</title><rect x="1152.2" y="469" width="0.3" height="15.0" fill="rgb(105,215,215)" rx="2" ry="2" />
+<text text-anchor="" x="1155.24" y="479.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>_start (2 samples, 0.02%)</title><rect x="1189.8" y="565" width="0.2" height="15.0" fill="rgb(95,242,95)" rx="2" ry="2" />
+<text text-anchor="" x="1192.82" y="575.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>__blk_run_queue (3 samples, 0.02%)</title><rect x="918.4" y="165" width="0.3" height="15.0" fill="rgb(104,215,215)" rx="2" ry="2" />
+<text text-anchor="" x="921.41" y="175.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+<g class="func_g" onmouseover="s(this)" onmouseout="c()" onclick="zoom(this)">
+<title>leveldb::DBImpl::Get (156 samples, 1.21%)</title><rect x="422.2" y="261" width="14.3" height="15.0" fill="rgb(226,226,68)" rx="2" ry="2" />
+<text text-anchor="" x="425.17" y="271.5" font-size="12" font-family="Verdana" fill="rgb(0,0,0)"  ></text>
+</g>
+</svg>


### PR DESCRIPTION
I know this seems weird, but I want to host an example flame graph on bitcoincore.org so it can be linked to from the flame graph docs I'm trying to add in [this pull request](https://github.com/bitcoin/bitcoin/pull/12649). There is some discussion in that PR, but to summarize:

 * GitHub won't host interactive SVG files (their CDN renders them as a static image)
 * I think having a zoomable, interactive SVG file linked to in my docs makes the demo much more compelling
 * I'd prefer to host the file on an official Bitcoin site rather than my personal domain, mainly because redirecting people to my personal domain seems weird and looks sketchy

