### PR TITLE
Contact & Announcement List pages: update GPG key links & provide fingerprints

### DIFF
--- a/_includes/_references.md
+++ b/_includes/_references.md
@@ -112,9 +112,9 @@
 [slack-invite]: https://slack.bitcoincore.org/
 [software life cycle]: /en/lifecycle
 
-[laanwj-key]: https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-keys/laanwj-key.pgp
-[jonasschnelli-key]: https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-keys/jonasschnelli-key.pgp
-[sipa-key]: https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-keys/sipa-key.pgp
+[laanwj-key]: https://pgp.mit.edu/pks/lookup?op=get&search=0x71A3B16735405025D447E8F274810B012346C9A6
+[jonasschnelli-key]: https://pgp.mit.edu/pks/lookup?op=get&search=0x32EE5C4C3FA15CCADB46ABE529D4BCB6416F53EC
+[sipa-key]: https://pgp.mit.edu/pks/lookup?op=get&search=0x133EAC179436F14A5CF1B794860FEB804E669320
 
 [recent-contributors]: https://github.com/bitcoin/bitcoin/graphs/contributors?from=2017-03-01
 

--- a/_includes/dev-keys.md
+++ b/_includes/dev-keys.md
@@ -1,0 +1,21 @@
+{% capture /dev/null %}
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!! NB: for this file to render correctly, !!!
+!!! you must also include _references.md   !!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+{% case page.lang %}
+  {% else %}{% comment %}fallback to English{% endcomment %}
+    {% assign _includes_dev_keys-name = "Name" %}
+    {% assign _includes_dev_keys-fingerprint = "Fingerprint" %}
+    {% assign _includes_dev_keys-import = "You can import a key by running the following command with that individual's fingerprint: `gpg --recv-keys <fingerprint>`" %}
+{% endcase %}
+{% endcapture %}
+
+| {{_includes_dev_keys-name}} | {{_includes_dev_keys-fingerprint}}         |
+|-----------------------------|--------------------------------------------|
+| Wladimir van der Laan       | `71A3B16735405025D447E8F274810B012346C9A6` |
+| Jonas Schnelli              | `32EE5C4C3FA15CCADB46ABE529D4BCB6416F53EC` |
+| Pieter Wuille               | `133EAC179436F14A5CF1B794860FEB804E669320` |
+
+{{_includes_dev_keys-import}}

--- a/_includes/dev-keys.md
+++ b/_includes/dev-keys.md
@@ -8,14 +8,14 @@
   {% else %}{% comment %}fallback to English{% endcomment %}
     {% assign _includes_dev_keys-name = "Name" %}
     {% assign _includes_dev_keys-fingerprint = "Fingerprint" %}
-    {% assign _includes_dev_keys-import = "You can import a key by running the following command with that individual's fingerprint: `gpg --recv-keys <fingerprint>`" %}
+    {% capture _includes_dev_keys-import %}You can import a key by running the following command with that individual's fingerprint: `gpg --recv-keys "<fingerprint>"`  Ensure that you put quotes around fingerprints containing spaces.{% endcapture %}
 {% endcase %}
 {% endcapture %}
 
 | {{_includes_dev_keys-name}} | {{_includes_dev_keys-fingerprint}}         |
 |-----------------------------|--------------------------------------------|
-| Wladimir van der Laan       | `71A3B16735405025D447E8F274810B012346C9A6` |
-| Jonas Schnelli              | `32EE5C4C3FA15CCADB46ABE529D4BCB6416F53EC` |
-| Pieter Wuille               | `133EAC179436F14A5CF1B794860FEB804E669320` |
+| Wladimir van der Laan       | <code>{% include fingerprint-split.html hex="71A3B16735405025D447E8F274810B012346C9A6" %}</code> |
+| Jonas Schnelli              | <code>{% include fingerprint-split.html hex="32EE5C4C3FA15CCADB46ABE529D4BCB6416F53EC" %}</code> |
+| Pieter Wuille               | <code>{% include fingerprint-split.html hex="133EAC179436F14A5CF1B794860FEB804E669320" %}</code> |
 
 {{_includes_dev_keys-import}}

--- a/_includes/fingerprint-split.html
+++ b/_includes/fingerprint-split.html
@@ -1,0 +1,1 @@
+{{include.hex | slice: 0, 4 }}&nbsp;{{include.hex | slice: 4, 4 }}&nbsp;{{include.hex | slice: 8, 4 }}&nbsp;{{include.hex | slice: 12, 4 }}&nbsp;{{include.hex | slice: 16, 4 }}&nbsp;&nbsp;{{include.hex | slice: 20, 4 }}&nbsp;{{include.hex | slice: 24, 4 }}&nbsp;{{include.hex | slice: 28, 4 }}&nbsp;{{include.hex | slice: 32, 4 }}&nbsp;{{include.hex | slice: 36, 4 }}

--- a/_posts/en/pages/2016-03-12-contact.md
+++ b/_posts/en/pages/2016-03-12-contact.md
@@ -22,4 +22,11 @@ You can find Bitcoin Core developers on <i class="fa fa-fw fa-slack"></i> [Slack
 
 To report issue about this website please use the [website][website-issues] issue tracker.
 
+## GPG keys
+
+The following keys may be used to communicate sensitive information to
+developers:
+
+{% include dev-keys.md %}
+
 {% include _references.md %}

--- a/_posts/en/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/en/pages/list/2016-03-10-announcements-join.md
@@ -6,7 +6,7 @@ type: pages
 layout: page
 lang: en
 share: false
-version: 1
+version: 2
 ---
 Receive notification of important security announcements and releases for Bitcoin Core.
 
@@ -16,6 +16,9 @@ Enter your email address below:
     
 Low traffic for announcements only.
 
-_Emails will be GPG signed by [Wladimir van der Laan][laanwj-key], [Jonas Schnelli][jonasschnelli-key] or [Pieter Wuille][sipa-key] and DKIM signed from bitcoincore.org_.
+Emails will be DKIM signed from bitcoincore.org and GPG signed by one of
+the following keys:
+
+{% include dev-keys.md %}
 
 {% include _references.md %}

--- a/_posts/en/posts/2016-03-15-announcelist.md
+++ b/_posts/en/posts/2016-03-15-announcelist.md
@@ -5,7 +5,7 @@ lang: en
 id: en-announce-list
 name: announce-list
 tags: [bitcoin, bitcoin core, announcement list, updates]
-version: 1
+version: 2
 ---
 In an effort to increase communications, we are launching an opt-in, _announcement-only_ mailing-list for users of Bitcoin Core to receive notifications of security issues and new releases.
 
@@ -15,6 +15,9 @@ To subscribe, enter your email address below:
 
 {% include pages/list/announcement.html %}
 
-_Emails will be GPG signed by [Wladimir van der Laan][laanwj-key], [Jonas Schnelli][jonasschnelli-key] or [Pieter Wuille][sipa-key] and DKIM signed from bitcoincore.org._
+Emails will be DKIM signed from bitcoincore.org and GPG signed by one of
+the following keys:
+
+{% include dev-keys.md %}
 
 {% include _references.md %}


### PR DESCRIPTION
Closes #543 ; CC: @kallerosenbaum

Updated bottom section on Announcement list page looks like:

![2018-05-02-13_32_45_132722580](https://user-images.githubusercontent.com/61096/39539363-63c50794-4e0d-11e8-873b-03a7a2f06149.png)

---

New bottom section on updated Contact page looks like:

![2018-05-02-13_33_48_991944438](https://user-images.githubusercontent.com/61096/39539396-7d1737e4-4e0d-11e8-851d-37716187c6d9.png)

---

Translations of the two pages don't have any text changed, but the links for the three keys are redirected to the pgp.mit.edu keyserver web interface as suggested in the corresponding issues (pgp.mit.edu is slow, but at least it doesn't 404).  When those pages are re-translated with the updated content, we can remove the old links directly to the keys.

I obtained the key fingerprints from [here](https://github.com/bitcoin/bitcoin/blob/master/contrib/gitian-keys/keys.txt) but haven't otherwise validated them, so somebody who has checked them should probably review this PR.