### PR TITLE
All pages: disable Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ owner:
   facebook: #username
   google:
     plus: #username
-    analytics: UA-85008990-1
+    analytics: #UA-85008990-1
     verify:
     ad-client:
     ad-slot:


### PR DESCRIPTION
HTML diff of generated site: https://dtrt.org/tmp/analytics-diff.html

This appears to have been enabled in 0364786e04566b9b7b53f739632beaadc70032a6 without a PR or any public discussion that I can [find](https://github.com/bitcoin-core/bitcoincore.org/search?utf8=%E2%9C%93&q=analytics&type=), so I have some questions:

- Is this currently being used?  By whom and for what?  (E.g., when analytics was enabled on Bitcoin.org, it was supposed to be used as a trustworthy source of visitor statistics in order to solicit advertisers.)
- Do we really want to be sending all of our visitor data to Google?  (I.e., if we need tracking for some reason, can we get that data instead from the server logs?)
- Do we really want Google to be able to inject Javascript onto our pages?  (E.g., being able to rewrite links on the Download page?)

This PR disables the tracking in case that's what's desired, but also makes it easy to re-enable (even without a revert) in case there is some specific project that later needs to use Analytics for visitor tracking.