### PR TITLE
Readme: mention theme used and link to its documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,18 @@ pages are built and checked.
 ## Contributing
 
 Contributions welcome. Please see [CONTRIBUTING.md](/CONTRIBUTING.md) for details.
+
+## References
+
+The website uses an old version of the [Minimal Mistakes theme][].  The
+theme's website provides [documentation][mm docs], including information
+about [configuration variables][mm config], creating [pages and posts][mm
+content], adding [new Javascript][mm js], and more.  Note that
+current documentation may describe features not available in the old
+version of the theme used by the website.
+
+[minimal mistakes theme]: https://mmistakes.github.io/minimal-mistakes/
+[mm docs]: https://mmistakes.github.io/minimal-mistakes/docs/quick-start-guide/ 
+[mm config]: https://mmistakes.github.io/minimal-mistakes/docs/configuration/
+[mm content]: https://mmistakes.github.io/minimal-mistakes/docs/posts/
+[mm js]: https://mmistakes.github.io/minimal-mistakes/docs/javascript/


### PR DESCRIPTION
Closes #525 ; CC: @karel-3d 

Links to the website and documentation for the upstream of the theme we use.  We haven't upgraded the files related to the theme since the website went live in Jan 2016, so I also mention that the current documentation might not completely match the theme files/settings.