### PR TITLE
Meetings index: remove excessive whitespace

### DIFF
--- a/_includes/_meetings.html
+++ b/_includes/_meetings.html
@@ -1,20 +1,17 @@
 <ul class="meeting">
   {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'meetings' | sort:'post.date' %}
   {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'meetings' %}
-  {% for default_post in english_posts %}
+  {% for default_post in english_posts %}{% capture year_entry %}
     {% assign post=default_post %}
     {% capture year %}{{post.date | date: '%Y' }}{% endcapture %}
     {% if forloop.first == true %}<li><b>{{year}}</b><ul>{% assign old_year = year %}{% endif %}
     {% if year != old_year %}</ul><li><b>{{year}}</b><ul>{% assign old_year = year %}{% endif %}
-    {% for t_post in translated_posts %}
-      {% if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
-    {% endfor %}
-  <li>
-    <a href="{{ post.url }}">
-      {{ post.title | replace: '<br/>', '' }}
-    </a>
-    <div class="desc">{{ post.desc }}</div>
-  </li>
+    {% endcapture %}{{ year_entry | strip }}{% capture /dev/null %}
+      {% for t_post in translated_posts %}
+        {% if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
+      {% endfor %}
+    {% endcapture %}
+    <li><a href="{{ post.url }}">{{ post.title | replace: '<br/>', '' }}</a></li>
   {% endfor %}
   </ul>
 </ul>


### PR DESCRIPTION
A for loop that generates the list of meeting entries is adding an two additional empty lines to each entry for each additional entry, so the whitespace for *n* entries was growing at `n*(n+1)`.  With there currently being 96 entries, this was a modest 9k empty lines---not a real performance problem.  However it's ugly, it makes debugging harder, and it's clearly a bug, so I fixed it.

There's no rush to apply this commit: by my math, it'll take about 100 years of meetings before the page size could become an actual bottleneck.

Preview of the updated page (should look the same): http://dg3.dtrt.org/en/meetings/
HTML diff from before & after this commit: http://dg3.dtrt.org/diff.html