### PR TITLE
Fix wrong release type in 0.16.1 release note

### DIFF
--- a/_releases/0.16.1.md
+++ b/_releases/0.16.1.md
@@ -29,7 +29,7 @@ Bitcoin Core version 0.16.1 is now available from:
 
   <https://bitcoincore.org/bin/bitcoin-core-0.16.1/>
 
-This is a new major version release, including new features, various bugfixes
+This is a new minor version release, including new features, various bugfixes
 and performance improvements, as well as updated translations.
 
 Please report bugs using the issue tracker at GitHub:


### PR DESCRIPTION
Fixed the release type in 0.16.1 release notes from `major` to `minor`.