### PR TITLE
[Trivial] Download page: make expandable sections use clickable mouse cursor

### DIFF
--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -1068,3 +1068,7 @@ div.maintainers {
 .bg-blue {
 	background-color: $bg-blue;
 }
+
+details > summary {
+        cursor: pointer;
+}


### PR DESCRIPTION
Preview: http://dg1.dtrt.org/en/download/

On the live BitcoinCore.org site, if you hover your mouse over one of the expandable sections in the Download Page verification docs, it shows the default mouse cursor (mouse not pictured in image below).

![2018-06-16-12_28_15_757496108](https://user-images.githubusercontent.com/61096/41500510-ca184332-7160-11e8-8a10-e4678148e1fc.png)


With this commit, the cursor is changed to the cursor used for clicking on a link (e.g. a hand with pointer finger extended).  I've tested this works using a Chromebook running the Chrome browser (on my usual OS, nothing in any browser seems to change the cursor).

Suggested by Daniel E. Renfer, duck1123, [on Twitter](https://twitter.com/duck1123/status/1008013971830509568)