### PR TITLE
[Trivial] Releases: fix overzealous tablification in 0.16.0 notes

### DIFF
--- a/_releases/0.16.0.md
+++ b/_releases/0.16.0.md
@@ -472,7 +472,7 @@ Testing changes
 - #12079 `45173fa` Improve prioritisetransaction test coverage (promag)
 - #12150 `92a810d` Fix ListCoins test failure due to unset g_address_type, g_change_type (ryanofsky)
 - #12133 `1d2eaba` Fix rare failure in p2p-segwit.py (sdaftuar)
-- #12082 `0910cbe` Adding test case for SINGLE|ANYONECANPAY hash type in tx_valid.json (Christewart)
+- #12082 `0910cbe` Adding test case for `SINGLE|ANYONECANPAY` hash type in tx_valid.json (Christewart)
 - #11796 `4db16ec` Functional test naming convention (ajtowns)
 - #12227 `b987ca4` test_runner: Readable output if create_cache.py fails (ryanofsky)
 - #12089 `126000b` Make TestNodeCLI command optional in send_cli (MarcoFalke)


### PR DESCRIPTION
Display bug on https://bitcoincore.org/en/releases/0.16.0/ :   

![2018-07-10-09_58_05_835548937](https://user-images.githubusercontent.com/61096/42514750-240407a8-8428-11e8-8130-f1c4da98a899.png)

Fixed by putting the sighash name in `code quotes`

![2018-07-10-10_03_02_401466437](https://user-images.githubusercontent.com/61096/42514906-7d21af20-8428-11e8-9a53-92f9edad7680.png)
