### PR TITLE
[Trivial] Add required missing whitespace to 0.16.0 release notes

### DIFF
--- a/_releases/0.16.0.md
+++ b/_releases/0.16.0.md
@@ -187,6 +187,7 @@ used to create `rpcauth` credentials for a JSON-RPC user.
 ### Validateaddress improvements
 
 The `validateaddress` RPC output has been extended with a few new fields, and support for segwit addresses (both P2SH and Bech32). Specifically:
+
 * A new field `iswitness` is True for P2WPKH and P2WSH addresses ("bc1..." addresses), but not for P2SH-wrapped segwit addresses (see below).
 * The existing field `isscript` will now also report True for P2WSH addresses.
 * A new field `embedded` is present for all script addresses where the script is known and matches something that can be interpreted as a known address. This is particularly true for P2SH-P2WPKH and P2SH-P2WSH addresses. The value for `embedded` includes much of the information `validateaddress` would report if invoked directly on the embedded address.


### PR DESCRIPTION
While doing my final checks before pushing the merge of #573, I noticed another formatting error in the 0.16.0 release docs due to the difference between GitHub Markdown and this site's Kramdown Markdown.  Before this PR:

![2018-07-12-07_51_10_927161235](https://user-images.githubusercontent.com/61096/42631498-629e1022-85a8-11e8-918a-6c2715641aa3.png)

With this PR:

![2018-07-12-07_51_43_425864003](https://user-images.githubusercontent.com/61096/42631531-7631d15a-85a8-11e8-8bc4-facf6d938cf6.png)

I did a check of the *whole* document this time to make sure there are no other obvious formatting problems.  I also confirmed that the 0.16.0 release notes in the bitcoin/bitcoin repository render without these problems on GitHub.

Sorry for the noise.