### PR TITLE
Update sitemap to include releases & RPC docs

### DIFF
--- a/assets/elements/sitemaps.xml
+++ b/assets/elements/sitemaps.xml
@@ -5,7 +5,8 @@ permalink: /sitemap.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {% assign en_posts=site.posts | where:"lang", 'en' %}
+{% for collection in site.collections %}
+  {% assign en_posts = collection.docs | where: "lang", "en" %}
   {% for post in en_posts %}
     {% if post.id contains "404" or post.sitemap_exlude == true %}{% else %}
       <url>
@@ -19,4 +20,5 @@ permalink: /sitemap.xml
       </url>
     {% endif %}
   {% endfor %}
+{% endfor %}
 </urlset>


### PR DESCRIPTION
The current `sitemap.xml` is generated only using the contents of the `_posts` directory, meaning it excludes the release notes (`_releases`) and RPC docs (`_docs`).  This 4-line diff updates it to include all of the site's [Jekyll collections](https://jekyllrb.com/docs/collections/) by iterating over the `site.collections` array that includes `_posts` and everything else.

This still omits URLs on the site that aren't part of any collection and which Jekyll stores in the `site.pages` array.  Right now, this entirely consists of content not intended for direct human reading, like CSS and redirect files, which shouldn't be part of the sitemap anyway.  If that changes in the future (and I'd like it to), I'll have to update the sitemap again---but the old version of Jekyll we use now doesn't support a feature I'd like to make that work, so I'm punting for now.

Here's a quick way to check that this PR only adds URLs to the sitemap:

    diff -u \
      <( curl -s https://bitcoincore.org/sitemap.xml | grep '<loc>' | sort ) \
      <( grep '<loc>' _site/sitemap.xml | sort ) | colordiff | less -R

(Note: that will report missing files if other PRs adding new content are merged before this PR.)

Likewise, here's a quick way to verify that only additional URLs for translated content are added to the sitemap:

    diff -u \
      <( curl -s https://bitcoincore.org/sitemap.xml | grep 'alternate' | sort ) 
      <( grep 'alternate' _site/sitemap.xml | sort ) | colordiff | less -R

(Ditto on the previous note.)