### PR TITLE
HTML: xml escape page titles

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,8 +8,8 @@
 {% else %}
 {% assign title = page.title %}
 {% endif %}
-<title>{{ site.title }}{{ custom }}{% if title %} :: {{ title }}{% endif %}</title>
-{% if page.excerpt %}<meta name="description" content="{{ title | strip_html }}">{% endif %}
+<title>{{ site.title | xml_escape }}{{ custom | xml_escape }}{% if title %} :: {{ title | xml_escape }}{% endif %}</title>
+{% if page.excerpt %}<meta name="description" content="{{ title | strip_html | xml_escape }}">{% endif %}
 <meta name="keywords" content="{{ page.tags | join: ', ' }}">
 {% if page.author %}
   {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.owner %}
@@ -24,9 +24,9 @@
 {% assign posts=site.posts |where:"name", page.name %}
 {% for hrefpost in posts %}<link rel="alternate" hreflang="{{ hrefpost.lang }}" href="{{ site.url }}{{ hrefpost.permalink }}" />{% endfor %}
 {% if page.canonical != null %}<link rel="canonical" href="{{ page.canonical }}">{% else %}<link rel="canonical" href="{{ site.url }}{{ page.url }}">{% endif %}
-<link href="{{ site.url }}/{{ page.lang }}/feed.xml" type="application/atom+xml" rel="alternate" title="{{ site.title }} Blog XML Feed">
-<link href="{{ site.url }}/{{ page.lang }}/rss.xml" type="application/rss+xml" rel="alternate" title="{{ site.title }} Blog RSS Feed">
-<link href="{{ site.url }}/{{ page.lang }}/meetingrss.xml" type="application/rss+xml" rel="alternate" title="{{ site.title }} Meeting RSS Feed">
+<link href="{{ site.url }}/{{ page.lang }}/feed.xml" type="application/atom+xml" rel="alternate" title="{{ site.title | xml_escape }} Blog XML Feed">
+<link href="{{ site.url }}/{{ page.lang }}/rss.xml" type="application/rss+xml" rel="alternate" title="{{ site.title | xml_escape }} Blog RSS Feed">
+<link href="{{ site.url }}/{{ page.lang }}/meetingrss.xml" type="application/rss+xml" rel="alternate" title="{{ site.title | xml_escape }} Meeting RSS Feed">
 
 <!-- http://t.co/dKP3o1e -->
 <meta name="HandheldFriendly" content="True">

--- a/_includes/open-graph.html
+++ b/_includes/open-graph.html
@@ -1,6 +1,6 @@
 <!-- Twitter Cards -->
-<meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
-{% if page.excerpt %}<meta name="twitter:description" content="{{ page.title | strip_html }}">{% endif %}
+<meta name="twitter:title" content="{% if page.title %}{{ page.title | xml_escape }}{% else %}{{ site.title | xml_escape }}{% endif %}">
+{% if page.excerpt %}<meta name="twitter:description" content="{{ page.title | strip_html | xml_escape }}">{% endif %}
 {% if site.owner.twitter %}<meta name="twitter:site" content="@{{ site.owner.twitter }}">{% endif %}
 {% if author.twitter %}<meta name="twitter:creator" content="@{{ author.twitter }}">{% endif %}
 {% if page.image.feature %}
@@ -13,10 +13,10 @@
 <!-- Open Graph -->
 <meta property="og:locale" content="{{ page.lang}}">
 <meta property="og:type" content="article">
-<meta property="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
-{% if page.excerpt %}<meta property="og:description" content="{{ page.title | strip_html }}">{% endif %}
+<meta property="og:title" content="{% if page.title %}{{ page.title | xml_escape }}{% else %}{{ site.title | xml_escape }}{% endif %}">
+{% if page.excerpt %}<meta property="og:description" content="{{ page.title | strip_html | xml_escape }}">{% endif %}
 <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.url }}">
-<meta property="og:site_name" content="{{ site.title }}">
+<meta property="og:site_name" content="{{ site.title | xml_escape }}">
 {% if page.image.feature %}
 <meta property="og:image" content="{{ site.url }}/assets/images/{{ page.image.feature }}">
 {% else %}

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -30,7 +30,7 @@
     </div>
   </div>
   <article class="page">
-    <h1>{{ custom_title }}</h1>
+    <h1>{{ custom_title | xml_escape }}</h1>
     <div class="article-wrap">
       {% if page.btcversion != "index" %}
         {% assign groups = site.doc | where:"btcversion", page.btcversion | group_by:"btcgroup" | sort: "name" %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -18,7 +18,7 @@
     {% else %}
       "/assets/images/{{ page.image.feature }}"
     {% endif %}
-  alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title }}{% endif %} feature image">
+  alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title | xml_escape }}{% endif %} feature image">
   {% if page.image.byline %}
     <span class="image-credit">{{ page.image.byline }}</span>
   {% endif %}
@@ -33,7 +33,7 @@
     {% include author-bio.html %}
   </div>
   <article class="page">
-    <h1>{{ page.title }}</h1>
+    <h1>{{ page.title | xml_escape }}</h1>
     <div class="article-wrap">
       <!-- { % include istranslated.html % } -->
       {{ content }}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -18,7 +18,7 @@
     {% else %}
       "/assets/images/{{ page.image.feature }}"
     {% endif %}
-    alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title }}{% endif %} feature image">
+    alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title | xml_escape }}{% endif %} feature image">
   {% if page.image.byline %}
     <span class="image-credit">{{ page.image.byline }}</span>
   {% endif %}
@@ -33,7 +33,7 @@
     {% include author-bio.html %}
   </div>
   <div id="index">
-    <h1>{{ page.title }}</h1>
+    <h1>{{ page.title | xml_escape }}</h1>
     {% capture written_year %}'None'{% endcapture %}
     {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'posts' %}
     {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
@@ -49,9 +49,9 @@
       {% endif %}
       <article>
         {% if post.link %}
-          <h2 class="link-post"><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title }}"><i class="fa fa-link"></i></a></h2>
+          <h2 class="link-post"><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title | xml_escape }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title | xml_escape }}"><i class="fa fa-link"></i></a></h2>
         {% else %}
-          <h2><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h2>
+          <h2><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title }}</a></h2>
           <p>{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>
         {% endif %}
       </article>


### PR DESCRIPTION
When we use HTML directly (not through parsed Markdown), XML entities need to be escaped.  Our tests catch cases where that doesn't happen, so we don't need to be fastidious about it, but in this case I was trying to add a page with an ampersand in the title and these were the places where the tests complained.

Verified via a diff of the rendered site compared to master that this produces no changes in the rendered site for all current content.