### PR TITLE
Tests: fix ignored return value from htmlproofer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test: test-fast test-slow
 
 test-slow:
 	## Check for malformed HTML and broken internal links
-	bundle exec htmlproof --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site | cat
+	bash -c "set -o pipefail ; bundle exec htmlproof --check-html --disable-external --url-ignore '/^\/bin/.*/' ./_site | cat"
 	## Check that links on the /en/download page point to the separately-stored binaries in /bin
 	contrib/qa/test-binary-availability.sh && echo "SUCCESS checking URLs for binaries"
 


### PR DESCRIPTION
In 0e7d61a91452d7a30577831a118873355514e593, I broke the HTML proofer test.  Sorry.  It still generated warning messages but it always returned true, even when something was broken.  Happily, we didn't manage to break anything.

This fixes the test.  Unlike before, I've tested that this does actually cause make (and thus Travis) to fail on broken content.