### PR TITLE
Releases: add 0.16.2

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -137,4 +137,7 @@
 version of this site's RPC docs-->
 {% endcomment %}
 {% assign rpc_version = "0.16.1" %}
+[rpc abandontransaction]: /en/doc/{{rpc_version}}/rpc/wallet/abandontransaction/
 [rpc fundrawtransaction]: /en/doc/{{rpc_version}}/rpc/rawtransactions/fundrawtransaction/
+[rpc getblock]: /en/doc/{{rpc_version}}/rpc/blockchain/getblock/
+[rpc verifytxoutproof]: /en/doc/{{rpc_version}}/rpc/blockchain/verifytxoutproof/

--- a/_posts/en/posts/2018-07-29-release-0.16.2.md
+++ b/_posts/en/posts/2018-07-29-release-0.16.2.md
@@ -1,0 +1,47 @@
+---
+title: Bitcoin Core 0.16.2 Released
+name: blog-release-0.16.2
+id: en-blog-release-0.16.2
+lang: en
+type: posts
+layout: post
+share: true
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+excerpt: >
+  Bitcoin Core 0.16.2 is now available with new bug fixes and minor
+  updates.
+---
+Bitcoin Core version 0.16.2 is now available for [download][download
+page].  All users are encouraged to upgrade to this [maintenance
+release][] that fixes several bugs and provides backports of new minor
+features, such as:
+
+- The [verifytxoutproof RPC][rpc verifytxoutproof] is no longer
+  vulnerable to a particular [expensive attack][tx-as-internal-node]
+  against SPV proofs publicly disclosed in early June.  The attack was
+  considered unlikely given that much cheaper attacks of roughly equal
+  effectiveness are well known.  Similarly, the [getblock RPC][rpc
+  getblock] also now returns extra information that can be used to
+  defeat this attack even if the requested block has been pruned.  None
+  of this mitigates the attack for actual SPV clients.
+
+- The [`abandontransaction`][rpc abandontransaction] RPC has been fixed
+  to abandon all descendant transactions, not just children.  As before,
+  you can call this RPC when you no longer want your wallet to
+  re-broadcast an old unconfirmed transaction. Note that the RPC can not
+  force miners or other nodes to forget about the transaction.
+
+For a complete list of changes, please see the [release notes][].  If
+have any questions, please stop by our [IRC chatroom][irc] and we’ll do
+our best to help you.
+
+[release notes]: /en/releases/0.16.2/
+[IRC]: https://en.bitcoin.it/wiki/IRC_channels
+[download page]: /en/download
+[maintenance release]: /en/lifecycle/#maintenance-releases
+[tx-as-internal-node]: https://bitslog.wordpress.com/2018/06/09/leaf-node-weakness-in-bitcoin-merkle-tree-design/
+
+{% include references.md %}

--- a/_releases/0.16.2.md
+++ b/_releases/0.16.2.md
@@ -1,0 +1,144 @@
+---
+title: Bitcoin Core 0.16.2
+id: en-release-0.16.2
+name: release-0.16.2
+permalink: /en/releases/0.16.2/
+excerpt: Bitcoin Core version 0.16.2 is now available
+date: 2018-07-29
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers"
+release: [0, 16, 2]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink: "magnet:?xt=urn:btih:b64eacae7d6e5f7ba50de3da8aca4368c27f0823&dn=bitcoin-core-0.16.2&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+
+## Notes from bitcoin/bitcoin 2018-07-27 commit 2848aa808fde462c27bc36de982d7ed74e882a7b
+---
+{% include download.html %}
+{% githubify https://github.com/bitcoin/bitcoin %}
+Bitcoin Core version 0.16.2 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-0.16.2/>
+
+This is a new minor version release, with various bugfixes
+as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+The first time you run version 0.15.0 or newer, your chainstate database will be converted to a
+new format, which will take anywhere from a few minutes to half an hour,
+depending on the speed of your machine.
+
+Note that the block database format also changed in version 0.8.0 and there is no
+automatic upgrade code from before version 0.8 to version 0.15.0 or higher. Upgrading
+directly from 0.7.x and earlier without re-downloading the blockchain is not supported.
+However, as usual, old wallet versions are still supported.
+
+Downgrading warning
+-------------------
+
+Wallets created in 0.16 and later are not compatible with versions prior to 0.16
+and will not work if you try to use newly created wallets in older versions. Existing
+wallets that were created with older versions are not affected by this.
+
+Compatibility
+==============
+
+Bitcoin Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
+
+Bitcoin Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+0.16.2 change log
+------------------
+
+### Wallet
+- #13622 `c04a4a5` Remove mapRequest tracking that just effects Qt display. (TheBlueMatt)
+- #12905 `cfc6f74` [rpcwallet] Clamp walletpassphrase value at 100M seconds (sdaftuar)
+- #13437 `ed82e71` wallet: Erase wtxOrderd wtx pointer on removeprunedfunds (MarcoFalke)
+
+### RPC and other APIs
+- #13451 `cbd2f70` rpc: expose CBlockIndex::nTx in getblock(header) (instagibbs)
+- #13507 `f7401c8` RPC: Fix parameter count check for importpubkey (kristapsk)
+- #13452 `6b9dc8c` rpc: have verifytxoutproof check the number of txns in proof structure (instagibbs)
+- #12837 `bf1f150` rpc: fix type mistmatch in `listreceivedbyaddress` (joemphilips)
+- #12743 `657dfc5` Fix csBestBlock/cvBlockChange waiting in rpc/mining (sipa)
+
+### GUI
+- #12432 `f78e7f6` [qt] send: Clear All also resets coin control options (Sjors)
+- #12617 `21dd512` gui: Show messages as text not html (laanwj)
+- #12793 `cf6feb7` qt: Avoid reseting on resetguisettigs=0 (MarcoFalke)
+
+### Build system
+- #13544 `9fd3e00` depends: Update Qt download url (fanquake)
+- #12573 `88d1a64` Fix compilation when compiler do not support `__builtin_clz*` (532479301)
+
+### Tests and QA
+- #13061 `170b309` Make tests pass after 2020 (bmwiedemann)
+- #13192 `79c4fff` [tests] Fixed intermittent failure in `p2p_sendheaders.py` (lmanners)
+- #13300 `d9c5630` qa: Initialize lockstack to prevent null pointer deref (MarcoFalke)
+- #13545 `e15e3a9` tests: Fix test case `streams_serializedata_xor` Remove Boost dependency. (practicalswift)
+- #13304 `cbdabef` qa: Fix `wallet_listreceivedby` race (MarcoFalke)
+
+### Miscellaneous
+- #12887 `2291774` Add newlines to end of log messages (jnewbery)
+- #12859 `18b0c69` Bugfix: Include `<memory>` for `std::unique_ptr` (luke-jr)
+- #13131 `ce8aa54` Add Windows shutdown handler (ken2812221)
+- #13652 `20461fc` rpc: Fix that CWallet::AbandonTransaction would leave the grandchildren, etc. active (Empact)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- 532479301
+- Ben Woosley
+- Bernhard M. Wiedemann
+- Chun Kuan Lee
+- Cory Fields
+- fanquake
+- Gregory Sanders
+- joemphilips
+- John Newbery
+- Kristaps Kaupe
+- lmanners
+- Luke Dashjr
+- MarcoFalke
+- Matt Corallo
+- Pieter Wuille
+- practicalswift
+- Sjors Provoost
+- Suhas Daftuar
+- Wladimir J. van der Laan
+
+And to those that reported security issues:
+
+- Braydon Fuller
+- Himanshu Mehta
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+{% endgithubify %}


### PR DESCRIPTION
Adds release notes and a short blog post.  Previews:

- Blog: http://dg0.dtrt.org/en/2018/07/27/release-0.16.2/
- Release notes: http://dg0.dtrt.org/en/releases/0.16.2/
- Download page: http://dg0.dtrt.org/en/download/

Todo:

- [x] Update files to correct dates for release:
    - `_releases/0.16.2.md` - change date in YAML header
    - `cd _posts/en/posts/ ; rename 's/.*release/'$(date -u -I)'-release/' _posts/en/posts/2018-07-27-release-0.16.2.md ; git add .`
- [x] Add magnet URI for torrent to _releases/0.16.2.md
- [x] If release notes change, update the release file with the changes

Note: this PR is expected to fail Travis CI as it expects the binaries to be in /bin/, which they're not yet.  The CI should pass once if Travis is restarted after the binaries are in their final location.