### PR TITLE
Releases: add 0.16.3

### DIFF
--- a/_posts/en/posts/2018-09-18-release-0.16.3.md
+++ b/_posts/en/posts/2018-09-18-release-0.16.3.md
@@ -21,7 +21,7 @@ Bitcoin Core 0.14.0 and affecting all subsequent versions though to
 0.16.2.  We highly recommend users of all affected versions immediately
 upgrade to 0.16.3.
 
-Security issue: it was discovered that older versions of Bitcoin Core
+Security issue [CVE-2018-17144][]: it was discovered that older versions of Bitcoin Core
 will crash if they try to process a block containing a transaction that
 attempts to spend the same input twice.  Such blocks are invalid, so
 they can only be created by a miner willing to sacrifice their allowed
@@ -36,5 +36,6 @@ our best to help you.
 [release notes]: /en/releases/0.16.3/
 [IRC]: https://en.bitcoin.it/wiki/IRC_channels
 [download page]: /en/download
+[CVE-2018-17144]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-17144
 
 {% include references.md %}

--- a/_posts/en/posts/2018-09-18-release-0.16.3.md
+++ b/_posts/en/posts/2018-09-18-release-0.16.3.md
@@ -1,0 +1,40 @@
+---
+title: Bitcoin Core 0.16.3 Released
+name: blog-release-0.16.3
+id: en-blog-release-0.16.3
+lang: en
+type: posts
+layout: post
+share: true
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+excerpt: >
+  Bitcoin Core 0.16.3 is now available with a fix for a
+  denial-of-service vulnerability affecting earlier versions of Bitcoin
+  Core.
+---
+Bitcoin Core version 0.16.3 is now available for [download][download
+page] with a fix for a denial-of-service vulnerability introduced in
+Bitcoin Core 0.14.0 and affecting all subsequent versions though to
+0.16.2.  We highly recommend users of all affected versions immediately
+upgrade to 0.16.3.
+
+Security issue: it was discovered that older versions of Bitcoin Core
+will crash if they try to process a block containing a transaction that
+attempts to spend the same input twice.  Such blocks are invalid, so
+they can only be created by a miner willing to sacrifice their allowed
+income for creating a block of at least 12.5 BTC (about $80,000 USD as
+of this writing).  This release eliminates the crash, allowing the
+software to quietly reject such invalid blocks.
+
+For a complete list of changes, please see the [release notes][].  If
+have any questions, please stop by our [IRC chatroom][irc] and we’ll do
+our best to help you.
+
+[release notes]: /en/releases/0.16.3/
+[IRC]: https://en.bitcoin.it/wiki/IRC_channels
+[download page]: /en/download
+
+{% include references.md %}

--- a/_releases/0.16.3.md
+++ b/_releases/0.16.3.md
@@ -1,0 +1,118 @@
+---
+title: Bitcoin Core 0.16.3
+id: en-release-0.16.3
+name: release-0.16.3
+permalink: /en/releases/0.16.3/
+excerpt: Bitcoin Core version 0.16.3 is now available
+date: 2018-09-18
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers"
+release: [0, 16, 3]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+#optional_magnetlink: "magnet:?xt=urn:btih:b64eacae7d6e5f7ba50de3da8aca4368c27f0823&dn=bitcoin-core-0.16.2&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+
+## Notes from bitcoin/bitcoin 2018-09-18 commit 49e34e288
+---
+{% include download.html %}
+{% githubify https://github.com/bitcoin/bitcoin %}
+Bitcoin Core version 0.16.3 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-0.16.3/>
+
+This is a new minor version release, with various bugfixes
+as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on Mac)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+The first time you run version 0.15.0 or newer, your chainstate database will be converted to a
+new format, which will take anywhere from a few minutes to half an hour,
+depending on the speed of your machine.
+
+Note that the block database format also changed in version 0.8.0 and there is no
+automatic upgrade code from before version 0.8 to version 0.15.0 or higher. Upgrading
+directly from 0.7.x and earlier without re-downloading the blockchain is not supported.
+However, as usual, old wallet versions are still supported.
+
+Downgrading warning
+-------------------
+
+Wallets created in 0.16 and later are not compatible with versions prior to 0.16
+and will not work if you try to use newly created wallets in older versions. Existing
+wallets that were created with older versions are not affected by this.
+
+Compatibility
+==============
+
+Bitcoin Core is extensively tested on multiple operating systems using
+the Linux kernel, macOS 10.8+, and Windows Vista and later. Windows XP is not supported.
+
+Bitcoin Core should also work on most other Unix-like systems but is not
+frequently tested on them.
+
+Notable changes
+===============
+
+Denial-of-Service vulnerability
+-------------------------------
+
+A denial-of-service vulnerability exploitable by miners has been discovered in
+Bitcoin Core versions 0.14.0 up to 0.16.2. It is recommended to upgrade any of
+the vulnerable versions to 0.16.3 as soon as possible.
+
+0.16.3 change log
+------------------
+
+### Consensus
+- #14249 `696b936` Fix crash bug with duplicate inputs within a transaction (TheBlueMatt, sdaftuar)
+
+### RPC and other APIs
+- #13547 `212ef1f` Make `signrawtransaction*` give an error when amount is needed but missing (ajtowns)
+
+### Miscellaneous
+- #13655 `1cdbea7` bitcoinconsensus: invalid flags error should be set to `bitcoinconsensus_err` (afk11)
+
+### Documentation
+- #13844 `11b9dbb` correct the help output for -prune (hebasto)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Anthony Towns
+- Hennadii Stepanov
+- Matt Corallo
+- Suhas Daftuar
+- Thomas Kerin
+- Wladimir J. van der Laan
+
+And to those that reported security issues:
+
+- beardnboobies
+
+As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+{% endgithubify %}

--- a/_releases/0.16.3.md
+++ b/_releases/0.16.3.md
@@ -15,7 +15,8 @@ release: [0, 16, 3]
 ## and run: transmission-show -m <torrent file>
 #
 ## Link should be enclosed in quotes and start with: "magnet:?
-#optional_magnetlink: "magnet:?xt=urn:btih:b64eacae7d6e5f7ba50de3da8aca4368c27f0823&dn=bitcoin-core-0.16.2&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+optional_magnetlink: "magnet:?xt=urn:btih:a6015029671a445a7a07026b3e4a0fe54c2b2df3&dn=bitcoin-core-0.16.3&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&t
+r=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
 
 # Note: it is recommended to check all links to ensure they use
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)


### PR DESCRIPTION
Adds release notes (which updates Download page) and a short announcement blog post (which gets linked from the home page).  Note: tests are expected to fail because the binaries are not uploaded yet; they should pass if restarted after the binaries are available.

TODO:
- [ ] Add magnet URI to `_releases` file when available (can be done after merge)