### PR TITLE
CVE post: rephrase technical details

### DIFF
--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -29,7 +29,19 @@ However, it still remains critical that affected users upgrade and apply the lat
 Technical Details
 =================
 
-In Bitcoin Core 0.14, an optimization was added (Bitcoin Core PR #9049) which avoided a costly check during initial pre-relay block validation that multiple inputs within a single transaction did not spend the same input twice which was added in 2012 (PR #443). While the UTXO-updating logic has sufficient knowledge to check that such a condition is not violated in 0.14 it only did so in a sanity check assertion and not with full error handling (it did, however, fully handle this case twice in prior to 0.8).
+The original implementation of Bitcoin ensured that no transaction
+within a block spent an input that had already been spent on the same
+block chain.  However, it failed to ensure that the transactions it
+relayed and accepted into its memory pool only spent the same input
+once, so PR #443 was opened to add a rule that rejected transactions
+with duplicate inputs.  This became part of the 0.4 release of Bitcoin.
+
+This new rule was added to the function used to validate all
+transactions, whether they were unconfirmed transactions being relayed
+or transactions included in blocks, which meant that Bitcoin software
+was redundantly checking blocks for duplicate inputs twice.
+
+In Bitcoin Core 0.14, an optimization was added (PR #9049) which eliminated this redundancy. While the UTXO-updating logic has sufficient knowledge to check that such a condition is not violated in 0.14 it only did so in a sanity check assertion and not with full error handling (it did, however, fully handle this case twice in versions prior to 0.8).
 
 Thus, in Bitcoin Core 0.14.X, any attempts to double-spend a transaction output within a single transaction inside of a block will result in an assertion failure and a crash, as was originally reported.
 

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -39,9 +39,15 @@ with duplicate inputs.  This became part of the 0.4 release of Bitcoin.
 This new rule was added to the function used to validate all
 transactions, whether they were unconfirmed transactions being relayed
 or transactions included in blocks, which meant that Bitcoin software
-was redundantly checking blocks for duplicate inputs twice.
+was redundantly checking blocks for duplicate inputs twice:
 
-In Bitcoin Core 0.14, an optimization was added (PR #9049) which eliminated this redundancy. While the UTXO-updating logic has sufficient knowledge to check that such a condition is not violated in 0.14 it only did so in a sanity check assertion and not with full error handling (it did, however, fully handle this case twice in versions prior to 0.8).
+1. When validating each transaction in the block using the `CheckTransaction`
+   function
+
+2. When updating the transaction database using the `ConnectBlock`
+   function
+
+In Bitcoin Core 0.14, an optimization was added (PR #9049) which eliminated this redundancy. While the UTXO-updating logic has sufficient knowledge to check that such a condition is not violated in 0.14, it only did so in a sanity check assertion and not with full error handling.
 
 Thus, in Bitcoin Core 0.14.X, any attempts to double-spend a transaction output within a single transaction inside of a block will result in an assertion failure and a crash, as was originally reported.
 


### PR DESCRIPTION
This is an alternative to #602 with the background placed a bit more in time-linear order and with some additional information about the apparent motivations for bitcoin#443 and bitcoin#9049.

CC: @TheBlueMatt 