### PR TITLE
2018-09-20-notice updates

### DIFF
--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -13,7 +13,7 @@ version: 1
 excerpt: >
   A full disclosure of the impact of CVE-2018-17144, a fix for which was
   released on September 18th in Bitcoin Core versions 0.16.3 and
-  0.17.0RC4.
+  0.17.0rc4.
 ---
 
 Full disclosure

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -42,7 +42,7 @@ Timeline
 
 Timeline for September 17, 2018: (all times UTC)
 
-- 14:57 anonymous reporter reports crash bug to: Pieter Wuille, Greg Maxwell, Wladimir Van Der Laan of Bitcoin Core, deadalnix of Bitcoin ABC, and sickpig of Bitcoin Unlimited.
+- 14:57 BCH developer named awemany reports crash bug to: Pieter Wuille, Greg Maxwell, Wladimir Van Der Laan of Bitcoin Core, deadalnix of Bitcoin ABC, and sickpig of Bitcoin Unlimited.
 - 15:15 Greg Maxwell shares the original report with Cory Fields, Suhas Daftuar, Alex Morcos and Matt Corallo
 - 17:47 Matt Corallo identifies inflation bug
 - 19:15 Matt Corallo first tries to reach slushpool CEO to have a line of communication open to apply a patch quickly

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -69,6 +69,6 @@ September 19, 2018:
 
 September 20, 2018: 
 
-- 19:50 A developer by the title earlz independently discovered and reported the vulnerability to the Bitcoin Core security contact email.
+- 19:50 David Jaenson independently discovered the vulnerability, and it was reported it to the Bitcoin Core security contact email.
 
 {% include references.md %}

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -71,6 +71,7 @@ September 19, 2018:
 
 September 20, 2018: 
 
+- 16:21 This full disclosure notice was posted to bitcoincore.org
 - 19:50 David Jaenson independently discovered the vulnerability, and it was reported it to the Bitcoin Core security contact email.
 
 {% include references.md %}

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -60,6 +60,8 @@ Timeline for September 17, 2018: (all times UTC)
 September 18, 2018:
 
 - 00:24 Bitcoin Core version 0.16.3 tagged
+- 14:54 Bitcoin Knots version 0.16.3.knots20180918 tagged
+- 19:23 Bitcoin Knots release binaries and release announcements were available
 - 20:44 Bitcoin Core release binaries and release announcements were available
 - 21:47 Bitcointalk and reddit have public banners urging people to upgrade
 


### PR DESCRIPTION
* Attribute awemany (original reporter) and David Jaenson (independent discoverer reported by earlz)
* So long as other software is being reported on the timeline, might as well add Knots
* Include time bitcoincore.org notice was posted