### PR TITLE
Change announcements mailing list to RSS (at least temporarily)

### DIFF
--- a/_includes/pages/list/announcement.html
+++ b/_includes/pages/list/announcement.html
@@ -1,6 +1,1 @@
-<form action="https://sendy.bitcoincore.org/subscribe" method="POST" accept-charset="utf-8" id="mailregform">
-    <input type="hidden" name="list" value="NkAKeRXqqhq763VNq4wM8921SA"/>
-
-    <input type="text" placeholder="Your email address" name="email" id="email"/>
-    <input type="submit" name="submit" id="submit"/>
-</form>
+[RSS](/en/announcements.xml)

--- a/_posts/en/pages/2016-03-21-rss.md
+++ b/_posts/en/pages/2016-03-21-rss.md
@@ -6,8 +6,12 @@ type: pages
 layout: page
 lang: en
 share: false
-version: 1
+version: 2
 ---
+<p>
+<a href="https://bitcoincore.org/en/announcements.xml" title="Bitcoin Core Announcements RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Announcments RSS Feed"></a>
+Security announcements and release announcements feed (English-only)
+</p>
 <p>
 <a href="https://bitcoincore.org/{{ page.lang }}/rss.xml" title="Bitcoin Core Blog RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Blog RSS Feed"></a>
 Blog posts feed

--- a/_posts/en/pages/2016-03-21-rss.md
+++ b/_posts/en/pages/2016-03-21-rss.md
@@ -9,18 +9,18 @@ share: false
 version: 2
 ---
 <p>
-<a href="https://bitcoincore.org/en/announcements.xml" title="Bitcoin Core Announcements RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Announcments RSS Feed"></a>
+<a href="/en/announcements.xml" title="Bitcoin Core Announcements RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Announcments RSS Feed"></a>
 Security announcements and release announcements feed (English-only)
 </p>
 <p>
-<a href="https://bitcoincore.org/{{ page.lang }}/rss.xml" title="Bitcoin Core Blog RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Blog RSS Feed"></a>
+<a href="/{{ page.lang }}/rss.xml" title="Bitcoin Core Blog RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Blog RSS Feed"></a>
 Blog posts feed
 </p>
 <p>
-<a href="https://bitcoincore.org/{{ page.lang }}/meetingrss.xml" title="Bitcoin Core Meeting RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Meeting RSS Feed"></a>
+<a href="/{{ page.lang }}/meetingrss.xml" title="Bitcoin Core Meeting RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Meeting RSS Feed"></a>
 Meetings feed
 </p>
 <p>
-<a href="https://bitcoincore.org/{{ page.lang }}/releasesrss.xml" title="Bitcoin Core Releases RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Releases RSS Feed"></a>
+<a href="/{{ page.lang }}/releasesrss.xml" title="Bitcoin Core Releases RSS Feed"><img src="/assets/images/rss-24x24.png" alt="Bitcoin Core Releases RSS Feed"></a>
 Releases feed
 </p>

--- a/_posts/en/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/en/pages/list/2016-03-10-announcements-join.md
@@ -10,15 +10,8 @@ version: 2
 ---
 Receive notification of important security announcements and releases for Bitcoin Core.
 
-Enter your email address below:
+Subscribe to the RSS feed below.
 
 {% include pages/list/announcement.html %}
     
 Low traffic for announcements only.
-
-Emails will be DKIM signed from bitcoincore.org and GPG signed by one of
-the following keys:
-
-{% include dev-keys.md %}
-
-{% include references.md %}

--- a/_posts/en/posts/2016-03-15-announcelist.md
+++ b/_posts/en/posts/2016-03-15-announcelist.md
@@ -7,17 +7,12 @@ name: announce-list
 tags: [bitcoin, bitcoin core, announcement list, updates]
 version: 2
 ---
-In an effort to increase communications, we are launching an opt-in, _announcement-only_ mailing-list for users of Bitcoin Core to receive notifications of security issues and new releases.
+In an effort to increase communications, we are now providing opt-in, _announcement-only_ information for users of Bitcoin Core to receive notifications of security issues and new releases.
 
-While the Bitcoin Core project has a variety of communication channels, this website, Twitter [@bitcoincoreorg][], there have been a number of requests for an [announcement mailing list](/en/list/announcements/join). It is intended to be extremely low volume, focused on critical notifications as well as to announce new releases.
+While the Bitcoin Core project has a variety of communication channels, there have been a number of requests for a method of receiving only important announcements.  This new source is intended to be extremely low volume, focused on critical notifications as well as to announce new releases.
 
-To subscribe, enter your email address below:
+If you use Bitcoin Core, please consider [subscribing][subscribe].
 
-{% include pages/list/announcement.html %}
-
-Emails will be DKIM signed from bitcoincore.org and GPG signed by one of
-the following keys:
-
-{% include dev-keys.md %}
+[subscribe]: /en/list/announcements/join
 
 {% include references.md %}

--- a/_posts/en/posts/2016-03-15-announcelist.md
+++ b/_posts/en/posts/2016-03-15-announcelist.md
@@ -6,6 +6,8 @@ id: en-announce-list
 name: announce-list
 tags: [bitcoin, bitcoin core, announcement list, updates]
 version: 2
+redirect_from:
+  - /zh_CN/2016/03/15/announcement-list/
 ---
 In an effort to increase communications, we are now providing opt-in, _announcement-only_ information for users of Bitcoin Core to receive notifications of security issues and new releases.
 

--- a/_posts/en/posts/2018-02-26-release-0.16.0.md
+++ b/_posts/en/posts/2018-02-26-release-0.16.0.md
@@ -9,6 +9,9 @@ layout: post
 share: true
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   Bitcoin Core 0.16.0 has been released with default wallet support for
   segwit.

--- a/_posts/en/posts/2018-06-15-release-0.16.1.md
+++ b/_posts/en/posts/2018-06-15-release-0.16.1.md
@@ -8,6 +8,9 @@ layout: post
 share: true
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   Bitcoin Core 0.16.1 has been released with the latest bug fixes and
   minor updates

--- a/_posts/en/posts/2018-07-29-release-0.16.2.md
+++ b/_posts/en/posts/2018-07-29-release-0.16.2.md
@@ -10,6 +10,9 @@ share: true
 ## If this is a new post, reset this counter to 1.
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   Bitcoin Core 0.16.2 is now available with new bug fixes and minor
   updates.

--- a/_posts/en/posts/2018-09-18-release-0.16.3.md
+++ b/_posts/en/posts/2018-09-18-release-0.16.3.md
@@ -10,6 +10,9 @@ share: true
 ## If this is a new post, reset this counter to 1.
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   Bitcoin Core 0.16.3 is now available with a fix for a
   denial-of-service vulnerability affecting earlier versions of Bitcoin

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -10,6 +10,9 @@ share: true
 ## If this is a new post, reset this counter to 1.
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   A full disclosure of the impact of CVE-2018-17144, a fix for which was
   released on September 18th in Bitcoin Core versions 0.16.3 and

--- a/_posts/en/posts/2018-10-02-release-0.17.0.md
+++ b/_posts/en/posts/2018-10-02-release-0.17.0.md
@@ -10,6 +10,9 @@ share: true
 ## If this is a new post, reset this counter to 1.
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   We're pleased to announce the release of Bitcoin Core 0.17, a major new version
   containing many new features as well as bug fixes and other

--- a/_posts/ja/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/ja/pages/list/2016-03-10-announcements-join.md
@@ -6,16 +6,10 @@ type: pages
 layout: page
 lang: ja
 share: false
-version: 1
+version: 0
 ---
 Bitcoin Coreの重要なセキュリティのお知らせとリリースの通知を受け取ります。
-
-以下にメールアドレスを入力してください。
 
 {% include pages/list/announcement.html %}
     
 お知らせのみなので送信されるメールの量はわずかです。
-
-_メールは[Wladimir van der Laan][laanwj-key]および[Jonas Schnelli][jonasschnelli-key]、もしくは[Pieter Wuille][sipa-key]のGPGで署名され、bitcoincore.orgのDKIM署名がされています。_
-
-{% include references.md %}

--- a/_posts/zh_CN/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/zh_CN/pages/list/2016-03-10-announcements-join.md
@@ -10,12 +10,8 @@ version: 1
 ---
 接收来自比特币核心开发团队关于重要的安全通告及发布的通知。
 
-请输入您的邮箱地址：
-
 {% include pages/list/announcement.html %}
     
 仅通告低流量。
-
-_Emails will be GPG signed by [Wladimir van der Laan][laanwj-key], [Jonas Schnelli][jonasschnelli-key] or [Pieter Wullie][sipa-key] and DKIM signed from bitcoincore.org_.
 
 {% include references.md %}

--- a/en/announcements.xml
+++ b/en/announcements.xml
@@ -1,0 +1,23 @@
+---
+layout: null
+lang: en
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>{{ site.title }}</title>
+        <description>{{ site.translations[page.lang].description }}</description>
+        <link>{{ site.url }}</link>
+        <atom:link href="{{ site.url }}/{{ page.lang }}/announcements.xml" rel="self" type="application/rss+xml" />
+        {% assign posts=site.posts | where:"lang", page.lang | where:"type", 'posts' | where: "announcement", 1 %}
+        {% for post in posts limit:5 %}
+        <item>
+            <title>{{ post.title | strip_html }}</title>
+            <description>{{ post.content | xml_escape | replace: "[[", " (" | replace: "]]", ")"}}</description>
+            <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+            <link>{{ site.url }}{{ post.url }}</link>
+            <guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
+        </item>
+        {% endfor %}
+    </channel>
+</rss>


### PR DESCRIPTION
I've been unable to contact @btcdrak, the administrator of the security and releases announcement mailing list, and it doesn't seem to be sending emails (certainly not reliably).  It'd be nice to set up a replacement, but right now other existing Bitcoin mailing lists are also in flux so there's no stable hosting available without creating a new dedicated solution.

This PR provides an alternative news source by recommending users follow an RSS feed for posts on the website tagged as announcements.  This isn't as good as email, but I think it's better than nothing (and certainly it's better than recommending people join a broken list).

Preview feed: http://dg0.dtrt.org/en/announcements.xml
Preview sign up page (menu->Contact->Announcements): http://dg0.dtrt.org/en/list/announcements/join/
Feed validation: https://validator.w3.org/feed/check.cgi?url=http%3A%2F%2Fdg0.dtrt.org%2Fen%2Fannouncements.xml

Pages that previously mentioned the email list have been updated to refer to the RSS feed; for the translations, that was done by deleting whole sentences with the help of Google Translate, so the text is a bit sparse (but seems clear to me).  The initial announcement blog post of the email list was translated into Chinese; I didn't see any reason to attempt retranslating an outdated blog post from two years ago, so I deleted it and redirected its URL to the corresponding English blog post (which is updated).