### PR TITLE
Releases: 0.16.3: remove accidental newline in magnet URI

### DIFF
--- a/_releases/0.16.3.md
+++ b/_releases/0.16.3.md
@@ -15,8 +15,7 @@ release: [0, 16, 3]
 ## and run: transmission-show -m <torrent file>
 #
 ## Link should be enclosed in quotes and start with: "magnet:?
-optional_magnetlink: "magnet:?xt=urn:btih:a6015029671a445a7a07026b3e4a0fe54c2b2df3&dn=bitcoin-core-0.16.3&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&t
-r=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+optional_magnetlink: "magnet:?xt=urn:btih:a6015029671a445a7a07026b3e4a0fe54c2b2df3&dn=bitcoin-core-0.16.3&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
 
 # Note: it is recommended to check all links to ensure they use
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)


### PR DESCRIPTION
We didn't receive any user reports that the magnet URI was broken, so it seems to have worked just fine with the other trackers.  (I noticed the extra newline while prepping the 0.17.0 release notes.)