### PR TITLE
Releases: add 0.17.0.1

### DIFF
--- a/_releases/0.17.0.1.md
+++ b/_releases/0.17.0.1.md
@@ -4,7 +4,7 @@ id: en-release-0.17.0.1
 name: release-0.17.0.1
 permalink: /en/releases/0.17.0.1/
 excerpt: Bitcoin Core version 0.17.0.1 is now available
-date: 2018-10-27
+date: 2018-10-30
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers"
@@ -15,7 +15,7 @@ release: [0, 17, 0, 1]
 ## and run: transmission-show -m <torrent file>
 #
 ## Link should be enclosed in quotes and start with: "magnet:?
-#optional_magnetlink: "magnet:?xt=urn:btih:1c72f17bc1667a2ce81860b75135e491f6637d05&dn=bitcoin-core-0.17.0&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+optional_magnetlink: "magnet:?xt=urn:btih:70749cf2cf2922a21208b4ae760c9f2f9d1e7f11&dn=bitcoin-core-0.17.0.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
 
 # Note: it is recommended to check all links to ensure they use
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)

--- a/_releases/0.17.0.1.md
+++ b/_releases/0.17.0.1.md
@@ -1,0 +1,68 @@
+---
+title: Bitcoin Core 0.17.0.1
+id: en-release-0.17.0.1
+name: release-0.17.0.1
+permalink: /en/releases/0.17.0.1/
+excerpt: Bitcoin Core version 0.17.0.1 is now available
+date: 2018-10-27
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers"
+release: [0, 17, 0, 1]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+#optional_magnetlink: "magnet:?xt=urn:btih:1c72f17bc1667a2ce81860b75135e491f6637d05&dn=bitcoin-core-0.17.0&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969&tr=udp%3A%2F%2Fzer0day.ch%3A1337&tr=udp%3A%2F%2Fexplodie.org%3A6969"
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+
+## Notes from bitcoin/bitcoin 2018-10-28 commit 9e87d82e7f0696a40d08c6e4cff3f040a447ece5
+---
+{% include download.html %}
+{% githubify https://github.com/bitcoin/bitcoin %}
+Bitcoin Core version 0.17.0.1 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-0.17.0.1/>
+
+This release provides a minor bug fix for 0.17.0.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+Notable changes
+===============
+
+An issue was solved with OSX dmg generation, affecting macOS 10.12 to 10.14,
+which could cause Finder to crash on install.
+
+There are no significant changes for other operating systems.
+
+0.17.0.1 change log
+===================
+
+### Build system
+- #14416 `eb2cc84` Fix OSX dmg issue (10.12 to 10.14) (jonasschnelli)
+
+### Documentation
+- #14509 `1b5af2c` [0.17] doc: use SegWit in getblocktemplate example (Sjors)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Jonas Schnelli
+- Pieter Wuille
+- Sjors Provoost
+- Wladimir J. van der Laan
+{% endgithubify %}

--- a/_releases/0.17.0.1.md
+++ b/_releases/0.17.0.1.md
@@ -45,7 +45,8 @@ Notable changes
 An issue was solved with OSX dmg generation, affecting macOS 10.12 to 10.14,
 which could cause Finder to crash on install.
 
-There are no significant changes for other operating systems.
+There are no significant changes for other operating systems, making
+this release otherwise identical to [0.17.0](/en/releases/0.17.0/).
 
 0.17.0.1 change log
 ===================


### PR DESCRIPTION
Preview: http://dg1.dtrt.org/en/releases/0.17.0.1/ & http://dg1.dtrt.org/en/download/

Todo:

- [x] Set correct `date:` in release notes
- [x] Add magnet URI to release notes

Both can be safely done after the merge, if desired.

Release notes include an extra sentence not in the original and a link to the 0.17.0 release notes, as discussed earlier today on IRC.

Note: Travis build expected to fail until binaries have been uploaded.