### PR TITLE
Remove download references to PPA, warn about Ubuntu's security

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -80,6 +80,11 @@
 
 </div>
 
+  {% if page.version > 2 %}
+  {{page.ubuntu_warning}} <a href="https://bugs.launchpad.net/snapstore/+bug/1803914">1</a>,
+  <a href="https://bugs.launchpad.net/launchpad/+bug/1331914">2</a>
+  {% endif %}
+
   <h2 style="text-align: center">{{ page.patient }}</h2>
   <p>{{ page.notesync | replace: '$(DATADIR_SIZE)', site.data.stats.datadir_gb | replace: '$(PRUNED_SIZE)', site.data.stats.pruned_gb | replace: '$(MONTHLY_RANGE_GB)', site.data.stats.monthly_storage_increase_range_gb }} {{ page.full_node_guide }}</p>
 

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -64,12 +64,6 @@
             	<a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-arm-linux-gnueabihf.tar.gz" class="dl" id="lin32arm">32 bit</a></span>
         </span>
       </div>
-      <div>
-        <img src="/assets/images/os/med_ubuntu.svg" alt="ubuntu">
-        <span>
-          <a href="https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin">Ubuntu (PPA)</a>
-        </span>
-      </div>
     </div>
     <p class="downloadmore">
       <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc" class="dl">{{ page.downloadsig }}</a><br>
@@ -222,14 +216,6 @@
     </ol>
   </details>
 
-  <details>
-    <summary><strong>{{page.ubuntu_ppa_instructions}}</strong></summary>
-
-    <p>{{page.ubuntu_notice}}</p>
-
-    <blockquote>{{page.ubuntu_ppa_quote}}</blockquote>
-  </details>
-
   <h2 style="text-align: center">{{page.build_reproduction}}</h2>
 
   <p>{{page.additional_steps}}</p>
@@ -253,7 +239,6 @@ if (navigator.userAgent.indexOf('Mac') != -1) var os = 'mac'
 else if (navigator.userAgent.indexOf('Linux') != -1) {
 	var os='linux32';
 	if (navigator.userAgent.indexOf('x86_64') != -1) var os = 'linux64';
-	if (navigator.userAgent.indexOf('Ubuntu') != -1) var os = 'ubuntu';
 }
 else if (navigator.userAgent.indexOf('WOW64') != -1 || navigator.userAgent.indexOf('Win64') != -1) var os='windows64';
 var but = document.getElementById('downloadbutton');
@@ -290,10 +275,6 @@ case 'linux32':
 	but.getElementsByTagName('IMG')[0].src = '/assets/images/os/but_linux.png';
 	but.href = hreflin32;
 	linklin.href = hreflin32;
-break;
-case 'ubuntu':
-	but.getElementsByTagName('IMG')[0].src = '/assets/images/os/but_ubuntu.svg';
-	but.href = 'https://launchpad.net/~bitcoin/+archive/ubuntu/bitcoin';
 break;
 case 'mac':
 	but.getElementsByTagName('IMG')[0].src = '/assets/images/os/but_mac.svg';

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -81,8 +81,7 @@
 </div>
 
   {% if page.version > 2 %}
-  {{page.ubuntu_warning}} <a href="https://bugs.launchpad.net/snapstore/+bug/1803914">1</a>,
-  <a href="https://bugs.launchpad.net/launchpad/+bug/1331914">2</a>
+  {{page.ubuntu_warning}} <a href="https://bugs.launchpad.net/snapstore/+bug/1803914">1</a>.
   {% endif %}
 
   <h2 style="text-align: center">{{ page.patient }}</h2>

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -56,11 +56,15 @@ releasekeys: "Bitcoin Core Release Signing Keys"
 
 pgp_key_fingerprint: "PGP key fingerprint"
 verify_download: "Verify your download"
-verification_recommended: "Download verification is optional but highly recommended.  Click one of the lines below to view verification instructions for that platform."
+verification_recommended: >
+  Download verification is optional but highly recommended.
+  Click one of the lines below to view verification instructions for that platform.
+  Note that due to a <a href=\"https://bugs.launchpad.net/snapstore/+bug/1803914\">series</a>
+  <a href=\"https://bugs.launchpad.net/launchpad/+bug/1331914\">of</a> mishandlings of security issues
+  by Canonical/Ubuntu, use of Bitcoin wallets on Ubuntu is strongly discouraged.
 windows_instructions: "Windows verification instructions"
 macos_instructions: "MacOS verification instructions"
-linux_instructions: "Linux verification instructions (not for Ubuntu PPA)"
-ubuntu_ppa_instructions: "Ubuntu PPA verification instructions"
+linux_instructions: "Linux verification instructions"
 download_release: "Click the link in the list above to download the release for your platform and wait for the file to finish downloading."
 download_checksums: "Download the list of cryptographic checksums:"
 cd_to_downloads: "Open a terminal (command line prompt) and Change Directory (cd) to the folder you use for downloads.  For example:"
@@ -100,17 +104,6 @@ ensure_checksum_matches: >
   running the following command:
 
 generate_checksum: "Run the following command to generate a checksum of the release file you downloaded.  Replace '$(FILE)' with the name of the file you actually downloaded."
-
-ubuntu_notice: >
-  Ubuntu PPAs are not built using the same reproducible method used for
-  the other Bitcoin Core packages listed on this page, so the Bitcoin
-  Core project does not have the information necessary to help you
-  verify the Bitcoin Core Ubuntu PPA packages.  This situation is also
-  described by the PPA itself:
-
-ubuntu_ppa_quote: >
-  "Note that you should prefer to use the official binaries, where
-  possible, to limit trust in Launchpad/the PPA owner."
 
 build_reproduction: "Additional verification with reproducible builds"
 additional_steps: >

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -61,9 +61,9 @@ verification_recommended: >
   Click one of the lines below to view verification instructions for that platform.
 
 ubuntu_warning: >
-  <b>Warning:</b>  We strongly discourage using Bitcoin wallets on
-  Ubuntu.  This is the result of Canonical Ltd and the Ubuntu
-  development team mishandling multiple security issues:
+  <b>Warning:</b>  Never download Bitcoin wallets using the Ubuntu
+  Software Center.  It has been known to contain buggy software and
+  nothing prevents the distribution of malware via it:
 
 windows_instructions: "Windows verification instructions"
 macos_instructions: "MacOS verification instructions"

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -5,7 +5,7 @@ type: pages
 layout: page
 lang: en
 share: false
-version: 2
+version: 3
 
 ## These strings need to be localized.  In the listing below, the
 ## comment above each entry contains the English text.  The key before the
@@ -59,9 +59,12 @@ verify_download: "Verify your download"
 verification_recommended: >
   Download verification is optional but highly recommended.
   Click one of the lines below to view verification instructions for that platform.
-  Note that due to a <a href=\"https://bugs.launchpad.net/snapstore/+bug/1803914\">series</a>
-  <a href=\"https://bugs.launchpad.net/launchpad/+bug/1331914\">of</a> mishandlings of security issues
-  by Canonical/Ubuntu, use of Bitcoin wallets on Ubuntu is strongly discouraged.
+
+ubuntu_warning: >
+  <b>Warning:</b>  We strongly discourage using Bitcoin wallets on
+  Ubuntu.  This is the result of Canonical Ltd and the Ubuntu
+  development team mishandling multiple security issues:
+
 windows_instructions: "Windows verification instructions"
 macos_instructions: "MacOS verification instructions"
 linux_instructions: "Linux verification instructions"

--- a/_posts/ja/pages/2017-01-01-download.md
+++ b/_posts/ja/pages/2017-01-01-download.md
@@ -58,8 +58,7 @@ verify_download: "ダウンロード後の検証"
 verification_recommended: "ダウンロード後の検証はオプションですが、強く推奨します。以下の行のいずれかをクリックすると、そのプラットフォームの検証手順が表示されます。"
 windows_instructions: "Windowsの検証手順"
 macos_instructions: "MacOSの検証手順"
-linux_instructions: "Linuxの検証手順 (Ubuntu PPAではない場合)"
-ubuntu_ppa_instructions: "Ubuntu PPAの検証手順"
+linux_instructions: "Linuxの検証手順"
 download_release: "上記リストのリンクをクリックしてご使用のプラットフォーム用のリリースをダウンロードし、ファイルのダウンロードが完了するまで待ちます。"
 download_checksums: "暗号チェックサムのリストをダウンロードします:"
 cd_to_downloads: "ターミナル（コマンドラインプロンプト）を開き、ダウンロードしたフォルダにディレクトリを変更（cd）します。例:"
@@ -97,16 +96,6 @@ ensure_checksum_matches: >
   次のコマンドを実行するとダウンロードしたチェックサムが表示されます:
 
 generate_checksum: "次のコマンドを実行してダウンロードしたファイルのチェックサムを生成します。 ファイル名 '$(FILE)' の部分を実際にダウンロードしたファイルの名前に置き換えてください。"
-
-ubuntu_notice: >
-  Ubuntu PPAは、このページに記載されている他のBitcoin Coreパケージと同じ
-  再現性のある方法で作成されていないため、Bitcoin Coreプロジェクトは
-  Bitcoin Core Ubuntu PPAパッケージを検証するのに必要な情報を提供できません。
-  この状況はPPA自体にも記載されています:
-
-ubuntu_ppa_quote: >
-  "Launchpad/PPAオーナーへの信頼を制限するには、可能であれば、公式のバイナリを
-  使用することをお勧めします。"
 
 build_reproduction: "再現可能なビルドによる追加検証"
 additional_steps: >


### PR DESCRIPTION
I'm kinda tired of Ubuntu not seeming to care about having sensible privacy/security defaults for their users, and I really don't think we should be encouraging users to use Bitcoin Core on it, when there are so many perfectly good Linux distros out there. I'll obviously keep updating the PPA for those who use it, but it just doesn't make sense to encourage people to use it.