### PR TITLE
Download page: remove link to laanwj's key; mention --refresh-keys

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -80,7 +80,8 @@
     </p>
     <p class="downloadkeys">
       <span>{{ page.releasekeys }}</span>
-      <a href="/keys/laanwj-releases.asc">v0.11.0+</a> <code title="{{page.pgp_key_fingerprint}}">{{SIGNING_KEY_FINGERPRINT}}</code>
+      v0.11.0+ <code title="{{page.pgp_key_fingerprint}}">{{SIGNING_KEY_FINGERPRINT}}</code><br>
+      {% if page.version > 2 %}<i>{{page.key_refresh}}</i> <code>gpg --refresh-keys</code>{% endif %}
     </p>
   </div>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -5,7 +5,7 @@ type: pages
 layout: page
 lang: en
 share: false
-version: 2
+version: 3
 
 ## These strings need to be localized.  In the listing below, the
 ## comment above each entry contains the English text.  The key before the
@@ -141,6 +141,7 @@ verifying_and_reproducing: >
 
 gitian_repository: "trusted build process signatures"
 
+key_refresh: "Refresh expired keys using:"
 
 ---
 


### PR DESCRIPTION
Recently, @laanwj's release signing key expired.  He has uploaded to key servers an updated key with a future expiration date, but the copy of the key hosted on this server is still the expired version.  Instead of updating it, this drops the link to it on the Download page and also adds a tiny note about `gpg --refresh-keys`  Preview (bottom text):

![2019-02-15-15_40_34_052057138](https://user-images.githubusercontent.com/61096/52883516-3db9e280-3139-11e9-90bc-9ef3d9b1d5d5.png)

The verification instructions on the page all mention getting the key with `--recv-keys` and there are no other links to the key on this site, so I think this is an acceptable solution.  However, this PR leaves the actual expired key on the site in case any third party scripts are grabbing it automatically and just ignoring its expired status.