### PR TITLE
Announcements: add 0.17.1 to announcements RSS feed

### DIFF
--- a/_posts/en/posts/2018-12-25-release-0.17.1.md
+++ b/_posts/en/posts/2018-12-25-release-0.17.1.md
@@ -10,6 +10,9 @@ share: true
 ## If this is a new post, reset this counter to 1.
 version: 1
 
+## Only true if release announcement or security annoucement.  English posts only
+announcement: 1
+
 excerpt: >
   Bitcoin Core 0.17.1, a maintenance release bringing bug fixes and minor
   improvements, is now available.


### PR DESCRIPTION
Just adds 0.17.1 to the [new feed](https://bitcoincore.org/en/announcements.xml).  This should've been done as part of the final rebase of #610 but I forgot to git commit it.  :man_facepalming: 