### PR TITLE
releases: Change windows default to win64

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -18,7 +18,7 @@
 <link rel="alternate" type="application/rss+xml" href="/en/releasesrss.xml" title="Bitcoin Core releases">
 <div class="download">
   <h2>{{ page.latestversion }} {{CURRENT_RELEASE}} <a type="application/rss+xml" href="/en/releasesrss.xml"><img src="/assets/images/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h2>
-  <div class="mainbutton"><a id="downloadbutton" href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win32exe }}"><img src="/assets/images/os/but_windows.svg" alt="icon"><span>{{ page.download }}</span></a></div>
+  <div class="mainbutton"><a id="downloadbutton" href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win64exe }}"><img src="/assets/images/os/but_windows.svg" alt="icon"><span>{{ page.download }}</span></a></div>
   <div class="downloadbox">
     <p>{{ page.downloados }}</p>
     <div>


### PR DESCRIPTION
Set win64 as default for windows users.
It has better performance, supports higher dbcache values, and so on.
Surprised this wasn't the case already.