### PR TITLE
Tests: handle offsite URLs that use HTTP/2 with recent versions of curl

### DIFF
--- a/contrib/qa/test-binary-availability.sh
+++ b/contrib/qa/test-binary-availability.sh
@@ -25,5 +25,5 @@ do
     curl -sI "https://bitcoincore.org${url}"
   else
     curl -sI "$url"
-  fi | grep -q '200 OK' || echo "Error: Could not retrieve $url"
+  fi | egrep -q '(200 OK|HTTP/2 200)' || echo "Error: Could not retrieve $url"
 done | if grep . ; then sed 1iERROR ; false ; else true ; fi


### PR DESCRIPTION
While testing #653, I discovered that the `test-binary-availability.sh` test failed locally even though it succeeded on Travis.  The test was looking for HTTP/1.1 success codes but my local `curl` was retrieving the Snapcraft page via HTTP/2 and printing a slightly different success message.  This updates the test to accept either success message.