### PR TITLE
Add templates for github issues and PRs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+This issue tracker is for issues with the Bitcoin Core project website at
+[bitcoincore.org](https://bitcoincore.org).
+
+[bitcoin.org](https://bitcoin.org) is not connected with or maintained by the
+Bitcoin Core project contributors. Issues with that website should be reported
+at [the bitcoin.org
+repository](https://github.com/bitcoin-dot-org/bitcoin.org/issues).
+
+General bitcoin questions and/or support requests are best directed to the
+Bitcoin StackExchange at https://bitcoin.stackexchange.com.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+Use this page to open Pull requests for changes to the Bitcoin Core project
+website at [bitcoincore.org](https://bitcoincore.org).
+
+[bitcoin.org](https://bitcoin.org) is not connected with or maintained by the
+Bitcoin Core project contributors. Pull requests for changes to that website
+should be opened at [the bitcoin.org
+repository](https://github.com/bitcoin-dot-org/bitcoin.org/pulls).
+
+General bitcoin questions and/or support requests are best directed to the
+Bitcoin StackExchange at https://bitcoin.stackexchange.com.


### PR DESCRIPTION
People sometimes mistakenly open issues against this repo for requested changes to bitcoin.org, eg:

- https://github.com/bitcoin-core/bitcoincore.org/issues/660
- https://github.com/bitcoin-core/bitcoincore.org/issues/652

Add templates for github issues and PRs to direct people to the right place.