### PR TITLE
Add torrent link to release page

### DIFF
--- a/_includes/download_release.html
+++ b/_includes/download_release.html
@@ -1,0 +1,8 @@
+{% capture RELEASE %}{% for subver in page.release %}{{subver}}{% unless forloop.last %}.{% endunless %}{% endfor %}{% endcapture %}
+{% capture PATH_PREFIX %}/bin/bitcoin-core-{{RELEASE}}{% endcapture %}
+{% capture FILE_PREFIX %}bitcoin-{{RELEASE}}{% endcapture %}
+{% assign magnet=page.optional_magnetlink %}
+<https://bitcoincore.org{{ PATH_PREFIX }}/>
+
+<a href="https://bitcoincore.org{{ PATH_PREFIX }}/{{ FILE_PREFIX }}.torrent" class="dl">Download torrent</a>
+  {% if magnet %} <a href="{{ magnet | replace: '&', '\&amp;'}}" class="magnetlink" data-proofer-ignore></a>{% endif %}<br>

--- a/_releases/0.17.1.md
+++ b/_releases/0.17.1.md
@@ -27,7 +27,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:c56c87ccfaa8e6fbccc90d549121e61efd97cb
 {% githubify https://github.com/bitcoin/bitcoin %}
 Bitcoin Core version 0.17.1 is now available from:
 
-  <https://bitcoincore.org/bin/bitcoin-core-0.17.1/>
+{% include download_release.html %}
 
 This is a new minor version release, with various bugfixes
 and performance improvements, as well as updated translations.

--- a/_releases/0.18.1.md
+++ b/_releases/0.18.1.md
@@ -27,7 +27,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:c3ba0cfee3ef8413098ac5e81db08a2670e9da
 {% githubify https://github.com/bitcoin/bitcoin %}
 Bitcoin Core version 0.18.1 is now available from:
 
-  <https://bitcoincore.org/bin/bitcoin-core-0.18.1/>
+{% include download_release.html %}
 
 This is a new minor version release, including new features, various bug
 fixes and performance improvements, as well as updated translations.

--- a/_releases/0.19.0.1.md
+++ b/_releases/0.19.0.1.md
@@ -30,7 +30,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:436859e8dddf4d8bd22d9ecc826139b6749a9a
 
 Bitcoin Core version 0.19.0.1 is now available from:
 
-  <https://bitcoincore.org/bin/bitcoin-core-0.19.0.1/>
+{% include download_release.html %}
 
 This release includes new features, various bug fixes and performance
 improvements, as well as updated translations.

--- a/_sass/download.scss
+++ b/_sass/download.scss
@@ -122,7 +122,7 @@
         position:relative;
         top:4px;
 }
-.downloadbox .magnetlink{
+.magnetlink{
         display:inline-block;
         width:16px;
         height:16px;


### PR DESCRIPTION
We currently only show the torrent link on the download page, which only covers the most recent version.

This adds a torrent link on each release page:

<img width="535" alt="Schermafbeelding 2019-11-25 om 17 04 46" src="https://user-images.githubusercontent.com/10217/69556832-c6f22580-0fa5-11ea-9e18-52aadd5a4c9e.png">

I applied this to 0.19.0.1, 0.18.1 and 0.17.1; probably not worth doing it for older versions.