### PR TITLE
Repair broken links

### DIFF
--- a/_posts/en/meetings/2016-09-15-meeting.md
+++ b/_posts/en/meetings/2016-09-15-meeting.md
@@ -24,7 +24,7 @@ version: 1
  
 - 0.13.1 release
 
-## 0.13.1 release
+## 0.13.1 release {#release}
 
 ### background
 

--- a/_posts/zh_CN/posts/2016-01-28-clarification.md
+++ b/_posts/zh_CN/posts/2016-01-28-clarification.md
@@ -11,7 +11,7 @@ excerpt: 在哪里可以找到关于比特币核心的官方信息，以及如�
 ---
 最初，bitcoin.org是用作放置[比特币白皮书](https://bitcoin.org/bitcoin.pdf)，并成为[比特币主程序](https://bitcoin.org/en/download)的主页。后来，该网站提供了比特币教学资料，但这与现在的Bitcoin Core计划[并无关系](https://bitcoin.org/en/bitcoin-core/about-site)。 Bitcoin Core的正式网站是bitcoincore.org，而虽然其它网站仍会提供有关Bitcoin Core的资讯，他们的观点并不代表Bitcoin Core。我们明白这可能令人感到混淆，因此我们正在努力地清楚说明这些关系。
 
-在开发方面，Bitcoin Core主要使用Freenode IRC上的#bitcoin-core-dev，[Github](https://github.com/bitcoin/bitcoin)，以及[bitcoin-dev 电邮列表](http://lists .linuxfoundation.org/pipermail/bitcoin-dev/)。
+在开发方面，Bitcoin Core主要使用Freenode IRC上的#bitcoin-core-dev，[Github](https://github.com/bitcoin/bitcoin)，以及[bitcoin-dev 电邮列表](http://lists.linuxfoundation.org/pipermail/bitcoin-dev/)。
 
 另一方面，在网络上有很多和比特币有关的论坛，当中可能有Bitcoin Core的贡献者参与，但Bitcoin Core对这些论坛的政策并不负责，并对比特币社群应使用哪些论坛没有正式立场。我们始终坚信比特币社群应该可以自由地讨论和批评与比特币相关的所有事情。
 

--- a/_posts/zh_CN/posts/2016-08-23-release-0-13-0.md
+++ b/_posts/zh_CN/posts/2016-08-23-release-0-13-0.md
@@ -167,8 +167,8 @@ excerpt: 我们很高兴地宣布比特币核心0.13.0版本正式发布了
   
 这些二进制可执行文件是为使用 GNU libc6的Linux操作系统准备的；他们无法在安卓或者其他操作系统上默认运行.
 
-新编译版本还在试验当中，请 [报告使用中遇到的任何问题](href="https://github.com/bitcoin/bitcoin/issues/new). 
   
+新编译版本还在试验当中，请 [报告使用中遇到的任何问题](https://github.com/bitcoin/bitcoin/issues/new).
 **更多信息**
 
 - [版本发布说明][release notes arm]

--- a/_releases/0.13.0.md
+++ b/_releases/0.13.0.md
@@ -389,7 +389,7 @@ Low-level ZMQ changes
   PR #7762.
 
 
-0.13.0 Change log
+0.13.0 Change log {#change-log}
 =================
 
 Detailed release notes follow. This overview includes changes that affect


### PR DESCRIPTION
Split from #686.

In anticipation of updating HTML proofer.

```
- ./_site/en/2016/08/23/release-0.13.0/index.html
  *  linking to internal hash #change-log that does not exist (line 3698)
     <a href="/en/releases/0.13.0/#change-log">hundreds of notable improvements</a>
- ./_site/en/meetings/2016/09/22/index.html
  *  linking to internal hash #release that does not exist (line 3723)
     <a href="/en/meetings/2016/09/15/#release">last weeks meeting</a>
- ./_site/zh_CN/2016/01/28/clarification/index.html
  *  http://lists .linuxfoundation.org/pipermail/bitcoin-dev/ is an invalid URL (line 3687)
     <a href="http://lists%20.linuxfoundation.org/pipermail/bitcoin-dev/">bitcoin-dev 电邮列表</a>
- ./_site/zh_CN/2016/08/23/release-0.13.0/index.html
  *  href="https://github.com/bitcoin/bitcoin/issues/new is an invalid URL (line 3915)
     <a href="href=%22https://github.com/bitcoin/bitcoin/issues/new">报告使用中遇到的任何问题</a>
  *  linking to internal hash #change-log that does not exist (line 3692)
     <a href="/en/releases/0.13.0/#change-log">几百个显著改进</a>
htmlproofer 3.14.1 | Error:  HTML-Proofer found 5 failures!
```
