### PR TITLE
Sort RPC docs by descending version

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -34,7 +34,7 @@
                                   <a href="{{article.url}}">RPC Docs</a>
                                 {% endif %}
                               {% endfor %}
-                              {% assign groups = site.doc | group_by:"btcversion" | sort: "name" %}
+                              {% assign groups = site.doc | group_by:"btcversion" | sort_by: "btcversion" | reverse %}
                               <ul>
                                 {% for group in groups %}
                                   {% if group.name != "index" %}
@@ -79,5 +79,3 @@
 		</nav>
 	</div><!-- /.top-navigation -->
 </div><!-- /.navigation-wrapper -->
-
-

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -66,7 +66,7 @@
           Select a command group in the menu.
         {% else %}
           Following docs are available:
-          {% assign groups = site.doc | group_by:"btcversion" | sort: "name" %}
+          {% assign groups = site.doc | sort: "btcversion" | reverse | group_by:"btcversion" %}
           <ul>
             {% for group in groups %}
               {% if group.name != "index" %}
@@ -87,7 +87,7 @@
 <div class="footer-wrap">
   <footer>
     {% include footer.html %}
-  </footer> 
+  </footer>
 </div><!-- /.footer-wrap -->
 
 {% include scripts.html %}


### PR DESCRIPTION
Split from #686 

<img width="257" alt="Schermafbeelding 2019-11-26 om 11 28 50" src="https://user-images.githubusercontent.com/10217/69621721-efc6f900-103f-11ea-9a2a-78052a7e1d67.png">

Also fixes the menu (this didn't work in a earlier version)