### PR TITLE
Fix segwit example links

### DIFF
--- a/_posts/en/pages/2016-01-18-segwit-wallet-dev.md
+++ b/_posts/en/pages/2016-01-18-segwit-wallet-dev.md
@@ -69,7 +69,7 @@ A wallet MUST implement all the features in this section, in order to be conside
     * There is a new signature generation algorithm described in [BIP143][] for segwit scripts. Developers should follow the instructions carefully, and make use of the P2SH-P2WPKH example in [BIP143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#P2SHP2WPKH) to make sure they are able to reproduce the <code>sighash</code>.
     * The [BIP143][] signature generating algorithm covers the value of the input being spent, which simplifies the design of air-gapped light-weight wallets and hardware wallets.
     * Please note that for a P2SH-P2WPKH, the <code>scriptCode</code> is always 26 bytes including the leading size byte, as <code>0x1976a914{20-byte keyhash}88ac</code>, NOT the <code>redeemScript</code> nor <code>scriptPubKey</code>
-    * [Example](http://n.bitcoin.ninja/checktx?txid=8139979112e894a14f8370438a471d23984061ff83a9eba0bc7a34433327ec21)
+    * [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=8139979112e894a14f8370438a471d23984061ff83a9eba0bc7a34433327ec21)
     
 #### Network Services (optional)
 
@@ -135,7 +135,7 @@ If a wallet supports script types other than just single signature, such as mult
         * For any unusual scripts containing OP_CODESEPARATOR, please refer to [BIP143][] for the exact semantics
     * Any witness stack items before the <code>witnessScript</code> are used as the input stack for script evaluation. The input stack is not interpreted as script. For example, there is no need to use a <code>0x4c</code> (OP_PUSHDATA1) to "push" a big item.
     * To verify the correctness of signature generation and stack serialization, please always test against the examples in [BIP143][]
-    * [Example](http://n.bitcoin.ninja/checktx?txid=954f43dbb30ad8024981c07d1f5eb6c9fd461e2cf1760dd1283f052af746fc88)
+    * [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=954f43dbb30ad8024981c07d1f5eb6c9fd461e2cf1760dd1283f052af746fc88)
 
 ### Segwit native addresses (optional) {#advanced-designs}
 
@@ -146,14 +146,14 @@ The following functions are not required for initial segwit support.
 * Native P2WPKH is a <code>scriptPubKey</code> of 22 bytes. It starts with a <code>OP_0</code>, followed by a canonical push of the <code>keyhash</code> (i.e. <code>0x0014{20-byte keyhash}</code>)
 * Same as P2SH-P2WPKH, <code>keyhash</code> is RIPEMD160(SHA256) of a compressed public key.
 * When spending a native P2WPKH, the <code>scriptSig</code> MUST be empty, and the witness stack format and signature generating rules are same as P2SH-P2WPKH (including the requirement of using compressed public key)
-* [Example](http://n.bitcoin.ninja/checktx?txid=d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c)
+* [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c)
 
 #### Native Pay-to-Witness-Script-Hash (P2WSH)
 
 * Native P2WSH is a <code>scriptPubKey</code> of 34 bytes. It starts with a <code>OP_0</code>, followed by a canonical push of the <code>scripthash</code> (i.e. <code>0x0020{32-byte scripthash}</code>)
 * Same as P2SH-P2WSH, <code>scripthash</code> is SHA256 of the <code>witnessScript</code>.
 * When spending a native P2WSH, the <code>scriptSig</code> MUST be empty, and the witness stack format and signature generating rules are same as P2SH-P2WSH (including the requirement of using compressed public key)
-* [Example](http://n.bitcoin.ninja/checktx?txid=78457666f82c28aa37b74b506745a7c7684dc7842a52a457b09f09446721e11c)
+* [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=78457666f82c28aa37b74b506745a7c7684dc7842a52a457b09f09446721e11c)
 
 #### Why and How to Use Native (Bech32) P2WPKH and P2WSH?
 
@@ -167,7 +167,7 @@ The following functions are not required for initial segwit support.
 
 ### Scripts and Transactions Examples
 
-* [Examples of different witness transaction types and transaction validity checking tool](http://n.bitcoin.ninja/checktx)
+* [Examples of different witness transaction types and transaction validity checking tool](https://blockchainprogramming.azurewebsites.net/checktx)
 * [BIP141][]
 * [BIP143][]
 * [BIP173][]

--- a/_posts/ja/pages/2016-01-18-segwit-wallet-dev.md
+++ b/_posts/ja/pages/2016-01-18-segwit-wallet-dev.md
@@ -70,7 +70,7 @@ version: 1
     * segwit scriptのための新しい署名生成アルゴリズムが[BIP143][]に定義されています。開発者は注意深くその指示に従い、[BIP143](https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#P2SHP2WPKH)のexampleを参考に<code>sighash</code>を再現できるか確認する必要があります。
     * [BIP143][]の署名生成アルゴリズムは、使用される入力のコインの量をカバーしており、軽量ウォレットやハードウェアウォレットの設計のエアギャップを簡素化します。
     * P2SH-P2WPKHの場合、<code>scriptCode</code>は先頭のバイトを含めて常に26バイトで、<code>0x1976a914{20-byte keyhash}88ac</code>となります。<code>redeemScript</code>でも<code>scriptPubKey</code>でもないので注意してください。
-    * [Example](http://n.bitcoin.ninja/checktx?txid=8139979112e894a14f8370438a471d23984061ff83a9eba0bc7a34433327ec21)
+    * [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=8139979112e894a14f8370438a471d23984061ff83a9eba0bc7a34433327ec21)
     
 #### ネットワークサービス（オプション） {#network-services}
 
@@ -139,7 +139,7 @@ version: 1
         * あまり一般的ではありませんがOP_CODESEPARATORを含むスクリプトについては、[BIP143][]を参照ください。
     * <code>witnessScript</code>より前のwitnessスタックアイテムはスクリプトを評価する際の入力スタックとして使われます。入力スタックはスクリプトとしては解釈されません。そのため、例えば大きなデータをプッシュするのに<code>0x4c</code> (OP_PUSHDATA1) を使う必要はありません。
     * 署名の生成とスタック上のシリアライズされた署名が正しいか検証するには、[BIP143][]のexampleを参考にテストしてください。
-    * [Example](http://n.bitcoin.ninja/checktx?txid=954f43dbb30ad8024981c07d1f5eb6c9fd461e2cf1760dd1283f052af746fc88)
+    * [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=954f43dbb30ad8024981c07d1f5eb6c9fd461e2cf1760dd1283f052af746fc88)
 
 ### 高度な設計 {#advanced-designs}
 
@@ -150,14 +150,14 @@ version: 1
 * Native P2WPKHは22バイトの<code>scriptPubKey</code>です。この<code>scriptPubKey</code>は<code>OP_0</code>で始まり、その後に<code>keyhash</code>がプッシュされます。（例：<code>0x0014{20-byte keyhash}</code>）
 * P2SH-P2WPKHと同様、<code>keyhash</code>は圧縮公開鍵をRIPEMD160(SHA256)した値です。
 * Native P2WPKHを使用する際は、<code>scriptSig</code>は必ず空で、witnessスタックの形式と署名の生成ルールはP2SH-P2WPKHと同じです（圧縮公開鍵を使用する要件含め）。
-* [Example](http://n.bitcoin.ninja/checktx?txid=d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c)
+* [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=d869f854e1f8788bcff294cc83b280942a8c728de71eb709a2c29d10bfe21b7c)
 
 #### Native Pay-to-Witness-Script-Hash (P2WSH) {#native-pay-to-witness-script-hash}
 
 * Native P2WSHは34バイトの<code>scriptPubKey</code>です。この<code>scriptPubKey</code>は<code>OP_0</code>から始まり、その後に<code>scripthash</code>がプッシュされます。（例：<code>0x0020{32-byte scripthash}</code>）
 * P2SH-P2WSHと同様、<code>scripthash</code>は<code>witnessScript</code>をSHA256した値です。
 * Native P2WSHを使用する際は、<code>scriptSig</code>は必ず空で、witnessスタックの形式と署名の生成ルールはP2SH-P2WSHと同じです（圧縮公開鍵を使用する要件含め）。
-* [Example](http://n.bitcoin.ninja/checktx?txid=78457666f82c28aa37b74b506745a7c7684dc7842a52a457b09f09446721e11c)
+* [Example](https://blockchainprogramming.azurewebsites.net/checktx?txid=78457666f82c28aa37b74b506745a7c7684dc7842a52a457b09f09446721e11c)
 
 #### Native P2WPKHやP2WSHはどうやって使うのか? {#why-and-how-to-use-native-p2wpkh-and-p2wsh}
 
@@ -169,7 +169,7 @@ version: 1
 
 ### スクリプトとトランザクションの例 {#scripts-and-transactions-example}
 
-* [Examples of different witness transaction types and transaction validity checking tool](http://n.bitcoin.ninja/checktx)
+* [Examples of different witness transaction types and transaction validity checking tool](https://blockchainprogramming.azurewebsites.net/checktx)
 * [BIP141][]
 * [BIP143][]
 * [Script tests](https://github.com/bitcoin/bitcoin/blob/master/src/test/data/script_tests.json)


### PR DESCRIPTION
Fix #692 I will eventually solve the certificate issue on the real website, but in any case `blockchainprogramming.azurewebsites.net` should be more stable, as the site is actually hosted there.