### PR TITLE
Add Onion-Location meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,7 @@
 <title>{{ site.title | xml_escape }}{{ custom | xml_escape }}{% if title %} :: {{ title | xml_escape }}{% endif %}</title>
 {% if page.excerpt %}<meta name="description" content="{{ title | strip_html | xml_escape }}">{% endif %}
 <meta name="keywords" content="{{ page.tags | join: ', ' }}">
+<meta http-equiv="onion-location" content="http://6hasakffvppilxgehrswmffqurlcjjjhd76jgvaqmsg6ul25s7t3rzyd.onion{{ page.url }}" />
 {% if page.author %}
   {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = site.owner %}
 {% endif %}


### PR DESCRIPTION
Starting with the release of [Tor Browser 9.5](https://blog.torproject.org/new-release-tor-browser-95), websites can have their alternate .onion addresses advertised to Tor desktop users who have the 'Onion Location' option enabled.

Sites that add the .onion address advertisement HTTP header can prompt their visitors to switch to a version delivered using the Onion service for improved security.

Final result:
![ezgif-2-354636e604ed](https://user-images.githubusercontent.com/46527252/83661669-bced5700-a5c6-11ea-9416-789ff30e52ef.gif)
