### PR TITLE
Fixed missing capitalization on the twitter impersonation page title

### DIFF
--- a/_posts/en/pages/2017-01-01-twitter-impersonation.md
+++ b/_posts/en/pages/2017-01-01-twitter-impersonation.md
@@ -1,5 +1,5 @@
 ---
-title: Twitter impersonation
+title: Twitter Impersonation
 name: twitter-impersonation
 permalink: /en/twitter-impersonation/
 type: pages


### PR DESCRIPTION
This is a very simple merge. I noticed missing capitalization and just made a quick update.