### PR TITLE
Meetings: add times for multiple meetings; move summaries to new page

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -5,11 +5,33 @@ lang: en
 title: IRC Meetings
 name: meetings
 permalink: /en/meetings/
-version: 2
+version: 3
 ---
-The project usually holds IRC meetings every Thursday at 19:00 UTC in `#bitcoin-core-dev` on irc.freenode.net.
-Everyone is welcome to attend.
+The project holds several recurring meetings in `#bitcoin-core-dev` on
+irc.freenode.net.  Everyone is welcome to attend.  Logs and
+automatically-generated meeting minutes may be found [here][meetbot].
 
-The following summaries list may not be complete due to constraints on volunteers' time. To view more recent logs, all meeting logs and raw minutes can be found [here](http://www.erisian.com.au/meetbot/bitcoin-core-dev/).
+Current meeting schedule:
 
-{% include meetings.html %}
+- General developer meeting: Thursday 19:00 UTC (every week)
+- Wallet developer meeting: Friday 19:00 UTC (every second week)
+- P2P developer meeting: Tuesday 15:00 UTC (every second week)
+
+Meeting times are also listed on [this Google calendar][meeting
+calendar].
+
+If you have any questions about the date or time of an upcoming meeting,
+please ask in `#bitcoin-core-dev` on Freenode.
+
+Anyone interested in contributing to Bitcoin Core is also
+encouraged to attend the weekly Bitcoin Core PR Review Club meetings,
+which are held in a different chatroom.  See [the review club
+website][review club] for details.
+
+Summaries of old meetings from 2015 to 2018 are now [listed on a
+separate page][summaries].
+
+[meetbot]: http://www.erisian.com.au/meetbot/bitcoin-core-dev/
+[meeting calendar]: https://calendar.google.com/calendar?cid=MTFwcXZkZ3BkOTlubGliZjliYTg2MXZ1OHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
+[review club]: https://bitcoincore.reviews/
+[summaries]: /en/meeting-summaries/

--- a/_posts/en/pages/2020-08-01-meeting-summaries.md
+++ b/_posts/en/pages/2020-08-01-meeting-summaries.md
@@ -1,0 +1,16 @@
+---
+type: pages
+layout: page
+lang: en
+title: IRC Meeting Summaries
+name: meetings
+permalink: /en/meeting-summaries/
+version: 1
+---
+From 2015 to 2018, several volunteers wrote summaries of Bitcoin
+Core development meetings.  This page links to those summaries.  For
+information about recent meetings, see the [meetings page][].
+
+{% include meetings.html %}
+
+[meetings page]: /en/meetings/


### PR DESCRIPTION
Adds information about the project's multiple meetings to the existing meetings page (linked from the Development item on the top-bar navigation).  Moves the historic meeting summaries to a new page.