### PR TITLE
About page: link to all contributors, not just recent

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -131,6 +131,7 @@
 [sipa-key]: https://pgp.mit.edu/pks/lookup?op=get&search=0x133EAC179436F14A5CF1B794860FEB804E669320
 
 [recent-contributors]: https://github.com/bitcoin/bitcoin/graphs/contributors?from=2017-03-01
+[github-contributors]: https://github.com/bitcoin/bitcoin/graphs/contributors
 
 [website-issues]: https://github.com/bitcoin-core/bitcoincore.org/issues
 

--- a/_posts/en/pages/2016-01-01-about.md
+++ b/_posts/en/pages/2016-01-01-about.md
@@ -5,7 +5,7 @@ permalink: /en/about/
 type: pages
 layout: page
 lang: en
-version: 2
+version: 3
 redirect_from:
   - /zh_TW/about/
   - /en/team/
@@ -35,6 +35,6 @@ Project maintainers have commit access and are responsible for merging patches f
 Everyone is free to propose code changes and to test, review and comment on open Pull Requests.
 Anyone who contributes code, review, test, translation or documentation to the Bitcoin Core project is considered a contributor.
 The release notes for each Bitcoin Core software release contain a credits section to recognize all those who have contributed to the project over the previous release cycle.
-A list of code contributors for the last year can be found on [Github][recent-contributors].
+A list of code contributors can be found on [Github][github-contributors].
 
 {% include references.md %}


### PR DESCRIPTION
Closes #718 

This creates a new link definition, rather than changing the old one, because the old one is used in two translations.