### PR TITLE
Add search bar for rpc docs

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -45,3 +45,10 @@
 <link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/images/apple-touch-icon-72x72-precomposed.png"><!-- 72x72 (precomposed) for 1st generation iPad, iPad 2 and iPad mini -->
 <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/images/apple-touch-icon-114x114-precomposed.png"><!-- 114x114 (precomposed) for iPhone 4, 4S, 5 and post-2011 iPod Touch -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/images/apple-touch-icon-144x144-precomposed.png"><!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
+
+<!-- Hide Searchbar if nojs -->
+<noscript>
+  <style>
+      #searchbar { display:none; }
+  </style>
+</noscript>

--- a/_includes/js/main.js
+++ b/_includes/js/main.js
@@ -64,3 +64,34 @@ $(function() {
     drawer.toggleClass("js-hidden");
   });
 });
+
+// Search functionality
+var toggleDrawers = function(show){
+  $(".toc header").each(function(){
+    var header = $(this);
+    var drawer = header.find(".toc-drawer");
+    if (show) {
+      drawer.removeClass("js-hidden");
+    } else {
+      drawer.addClass("js-hidden");
+    }
+  });
+};
+
+$(function() {
+  $("#searchbar").on('input', function(){
+    var query = $(this).val();
+    if (query.length > 1) {
+      toggleDrawers(true);
+      $(".leaf-article").each(function(){
+        $(this).show();
+        if ($(this).text().indexOf(query) == -1) {
+          $(this).hide();
+        }
+      });
+    } else {
+      $(".leaf-article").each(function(){ $(this).show(); });
+      toggleDrawers(false);
+    }
+  })
+});

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -35,6 +35,7 @@
       {% if page.btcversion != "index" %}
         {% assign groups = site.doc | where:"btcversion", page.btcversion | group_by:"btcgroup" | sort: "name" %}
         <section class="toc">
+        <input id="searchbar" type="text" value="" placeholder="Search..."/>
         {% for group in groups %}
           {% if group.name != "index" %}
             <header>
@@ -45,7 +46,7 @@
               <div class="toc-drawer js-hide-on-start">
                 <ul>
                   {% for article in group.items %}
-                    <li><a href="{{article.url}}">{{article.name}}</a></li>
+                    <li class="leaf-article"><a href="{{article.url}}">{{article.name}}</a></li>
                   {% endfor %}
                 </ul>
               </div>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -35,7 +35,7 @@
       {% if page.btcversion != "index" %}
         {% assign groups = site.doc | where:"btcversion", page.btcversion | group_by:"btcgroup" | sort: "name" %}
         <section class="toc">
-        <input id="searchbar" type="text" value="" placeholder="Search..."/>
+        <input id="searchbar" type="text" value="" placeholder="Search ..."/>
         {% for group in groups %}
           {% if group.name != "index" %}
             <header>

--- a/_sass/elements.scss
+++ b/_sass/elements.scss
@@ -164,3 +164,12 @@ svg:not(:root) {
 	@include rounded(4px);
 	@include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.05));
 }
+
+/*
+   Searchbar
+   ========================================================================== */
+
+#searchbar {
+  background-color: #d3d3d3;
+  border-color: #2b2b2b;
+}


### PR DESCRIPTION
This PR is addressing the problem of finding docs for one specific rpc command by its name. In the website one can not simply find his/her desired command in the menu. One should open all the parent categories (`Blockchain`, `Control`, etc) and then use Ctrl+F to find the command.

I have added a little javascript code to handle the string search between all commands and make this process much easier.