### PR TITLE
Edit 0.14.1 release notes to separate multiple PRs with "," instead of "/"

### DIFF
--- a/_plugins/githubify.rb
+++ b/_plugins/githubify.rb
@@ -26,9 +26,17 @@ require 'yaml'
       ## Convert #1234 into URL for the pull request
       ## If #1234 links to an issue, GitHub automatically redirects
       #
-      ## Require at least two digits to reduce false positive matches
-      output.gsub!(/#([0-9][0-9][0-9]*)/){ |s|
-        '<a href="' + @repository_url + '/pull/' + $1 + '">' + s + '</a>'
+      ## Main repository; forbid prefix of "/" to avoid conflation with
+      ## other monotree repos like bitcoin-core/gui.  Require at least a
+      ## double-digit number to reduce false positive matches (e.g. "fix thing,
+      ## try #2")
+      output.gsub!(/(^|[^\/])#([0-9]+)/){ |s|
+        $1 + '<a href="' + @repository_url + '/pull/' + $2 + '">#' + $2 + '</a>'
+      }
+
+      ## Other monotree repos; for repo "bitcoin-core/foo", PR format is "foo/#123"
+      output.gsub!(/([a-z]+)\/#([0-9]+)/){ |s|
+        '<a href="https://github.com/bitcoin-core/' + $1 + '/pull/' + $2 + '">' + s + '</a>'
       }
 
       ## Convert `123abcd` into URL for the commit

--- a/_releases/0.14.1.md
+++ b/_releases/0.14.1.md
@@ -117,7 +117,7 @@ git merge commit are mentioned.
 - #10133 `ab864d3` Clean up calculations of pcoinsTip memory usage (morcos)
 
 ### P2P protocol and network code
-- #9953/#10013 `d2548a4` Fix shutdown hang with >= 8 -addnodes set (TheBlueMatt)
+- #9953,#10013 `d2548a4` Fix shutdown hang with >= 8 -addnodes set (TheBlueMatt)
 - #10176 `30fa231` net: gracefully handle NodeId wrapping (theuni)
 
 ### Build system
@@ -127,8 +127,8 @@ git merge commit are mentioned.
 - #10060 `ddc2dd1` Ensure an item exists on the rpcconsole stack before adding (achow101)
 
 ### Mining
-- #9955/#10006 `569596c` Don't require segwit in getblocktemplate for segwit signalling or mining (sdaftuar)
-- #9959/#10127 `b5c3440` Prevent slowdown in CreateNewBlock on large mempools (sdaftuar)
+- #9955,#10006 `569596c` Don't require segwit in getblocktemplate for segwit signalling or mining (sdaftuar)
+- #9959,#10127 `b5c3440` Prevent slowdown in CreateNewBlock on large mempools (sdaftuar)
 
 ### Tests and QA
 - #10157 `55f641c` Fix the `mempool_packages.py` test (sdaftuar)


### PR DESCRIPTION
As mentioned today in #bitcoin-core-dev IRC, the release notes for 0.21.0 will include at least one reference to a PR that was merged in the new GUI repository.  laanwj said he'll put this in the notes as "gui/#nnnn", so this PR updates the plugin to handle that appropriately.

To eliminate conflicts, one historic release note is updated to change from using `/` as a separator between PRs to using `,` as the separator.  The comma is consistent with other release notes, such as that for 0.14.0.

This change should be forward compatible for other possible monotree repos as long as they're part of the bitcoin-core organization and the release notes use the format `<repo-name>/#<pr-number>`, e.g. `wallet/#123`.