### PR TITLE
Plugins: fix monotree repo ref from gui/#123 to gui#123

### DIFF
--- a/_plugins/githubify.rb
+++ b/_plugins/githubify.rb
@@ -26,16 +26,17 @@ require 'yaml'
       ## Convert #1234 into URL for the pull request
       ## If #1234 links to an issue, GitHub automatically redirects
       #
-      ## Main repository; forbid prefix of "/" to avoid conflation with
+      ## Main repository; forbid any lowercase alphabetical prefix to avoid conflation with
       ## other monotree repos like bitcoin-core/gui.  Require at least a
       ## double-digit number to reduce false positive matches (e.g. "fix thing,
       ## try #2")
-      output.gsub!(/(^|[^\/])#([0-9]+)/){ |s|
+      output.gsub!(/(^|[^a-z])#([0-9][0-9]+)/){ |s|
         $1 + '<a href="' + @repository_url + '/pull/' + $2 + '">#' + $2 + '</a>'
       }
 
-      ## Other monotree repos; for repo "bitcoin-core/foo", PR format is "foo/#123"
-      output.gsub!(/([a-z]+)\/#([0-9]+)/){ |s|
+      ## Other monotree repos; for repo "bitcoin-core/foo", PR format is "foo#123".
+      ## Must start at word boundary
+      output.gsub!(/\b([a-z]+)#([0-9]+)/){ |s|
         '<a href="https://github.com/bitcoin-core/' + $1 + '/pull/' + $2 + '">' + s + '</a>'
       }
 


### PR DESCRIPTION
There was a slight miscommunication about the expected format in #733, this uses the format from #734 as tested on the actual release notes:

![2021-01-14-05_34_49_583462950](https://user-images.githubusercontent.com/61096/104612399-3f90c700-562a-11eb-82a3-3de2af4ac4de.png)

I also quickly checked the HTML diff from before and after this change and I only saw one unwanted change (a link to an issue was dropped).  I think that's acceptable to keep the pattern simple.

![2021-01-14-05_28_39_838430961](https://user-images.githubusercontent.com/61096/104612600-7961cd80-562a-11eb-8fa0-839eba950f62.png)
