### PR TITLE
Change all local links to be relative

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,12 +1,12 @@
 <div>
     <span>
         <a href="https://twitter.com/bitcoincoreorg" target="_blank" class=""><i class="fa fa-fw fa-twitter"></i>Twitter</a><br />
-        <a href="/en/legal/">Legal</a> | <a href="/en/legal/privacy">Privacy Policy</a> | <a href="/{{ page.lang }}/rss/">RSS <img src="/assets/images/rss-24x24.png" alt="rss feeds" width="14" height="14"></a>
+        <a href="{{ ROOT_PATH }}/en/legal/">Legal</a> | <a href="{{ ROOT_PATH }}/en/legal/privacy">Privacy Policy</a> | <a href="{{ ROOT_PATH }}/{{ page.lang }}/rss/">RSS <img src="{{ ROOT_PATH }}/assets/images/rss-24x24.png" alt="rss feeds" width="14" height="14"></a>
     </span>
 </div>
 <div>
-    <img src="/assets/images/bitcoin_core_logo.png" alt="bitcoin core logo" width="160"><br />
+    <img src="{{ ROOT_PATH }}/assets/images/bitcoin_core_logo.png" alt="bitcoin core logo" width="160"><br />
     <span class="copyright">&copy; {{ site.time | date: '%Y' }} {{ site.owner.name }}</span>
 </div>
 
-<link rel="stylesheet" href="/assets/css/fonts.css">
+<link rel="stylesheet" href="{{ ROOT_PATH }}/assets/css/fonts.css">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -35,16 +35,16 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <!-- For all browsers -->
-<link rel="stylesheet" href="/assets/css/main.css">
+<link rel="stylesheet" href="{{ ROOT_PATH }}/assets/css/main.css">
 <meta http-equiv="cleartype" content="on">
 
 <!-- Icons -->
-<link rel="shortcut icon" href="/assets/images/favicon.ico"><!-- 16x16 -->
-<link rel="shortcut icon" href="/assets/images/favicon.png"><!-- 32x32 -->
-<link rel="apple-touch-icon-precomposed" href="/assets/images/apple-touch-icon-precomposed.png"><!-- 57x57 (precomposed) for iPhone 3GS, pre-2011 iPod Touch and older Android devices -->
-<link rel="apple-touch-icon-precomposed" sizes="72x72" href="/assets/images/apple-touch-icon-72x72-precomposed.png"><!-- 72x72 (precomposed) for 1st generation iPad, iPad 2 and iPad mini -->
-<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/assets/images/apple-touch-icon-114x114-precomposed.png"><!-- 114x114 (precomposed) for iPhone 4, 4S, 5 and post-2011 iPod Touch -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/assets/images/apple-touch-icon-144x144-precomposed.png"><!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
+<link rel="shortcut icon" href="{{ ROOT_PATH }}/assets/images/favicon.ico"><!-- 16x16 -->
+<link rel="shortcut icon" href="{{ ROOT_PATH }}/assets/images/favicon.png"><!-- 32x32 -->
+<link rel="apple-touch-icon-precomposed" href="{{ ROOT_PATH }}/assets/images/apple-touch-icon-precomposed.png"><!-- 57x57 (precomposed) for iPhone 3GS, pre-2011 iPod Touch and older Android devices -->
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ ROOT_PATH }}/assets/images/apple-touch-icon-72x72-precomposed.png"><!-- 72x72 (precomposed) for 1st generation iPad, iPad 2 and iPad mini -->
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ ROOT_PATH }}/assets/images/apple-touch-icon-114x114-precomposed.png"><!-- 114x114 (precomposed) for iPhone 4, 4S, 5 and post-2011 iPod Touch -->
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ ROOT_PATH }}/assets/images/apple-touch-icon-144x144-precomposed.png"><!-- 144x144 (precomposed) for iPad 3rd and 4th generation -->
 
 <!-- Hide Searchbar if nojs -->
 <noscript>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,26 +1,26 @@
 <div class="navigation-wrapper">
 	<div class="site-name">
         {% assign homelink = site.data.navigation[page.lang]['home'] %}
-		<a href="{{ homelink.url }}"><img src="/assets/images/bitcoin_core_logo_colored_reversed.png" alt="bitcoin core logo"></a>
+		<a href="{{ ROOT_PATH }}{{ homelink.url }}"><img src="{{ ROOT_PATH }}/assets/images/bitcoin_core_logo_colored_reversed.png" alt="bitcoin core logo"></a>
 	</div><!-- /.site-name -->
 	<div class="top-navigation">
 		<nav role="navigation" id="site-nav" class="nav">
 		    <ul>
 		        {% for link in site.data.navigation[page.lang] %}
                     {% if link[0] != 'home' and link[1].submenu != true and link[1].disabled != true %}
-                      <li><a href="{{ link[1].url }}">{{ link[1].title }}</a></li>
+                      <li><a href="{{ ROOT_PATH }}{{ link[1].url }}">{{ link[1].title }}</a></li>
                     {% elsif link[1].submenu == true and link[1].disabled != true %}
-                      <li>{% if link[1].url %}<a href="{{ link[1].url }}">{{ link[1].title }}</a>{% else %}<a href="javascript:;">{{ link[1].title }}</a>{% endif %}
+                      <li>{% if link[1].url %}<a href="{{ ROOT_PATH }}{{ link[1].url }}">{{ link[1].title }}</a>{% else %}<a href="javascript:;">{{ link[1].title }}</a>{% endif %}
                           <ul>
                           {% for sublink in link[1].tree %}
 
                               {% if sublink[0] != 'home' and sublink[1].submenu != true and sublink[1].disabled != true %}
-                              <li><a href="{{ sublink[1].url }}">{{ sublink[1].title }}</a></li>
+                              <li><a href="{{ ROOT_PATH }}{{ sublink[1].url }}">{{ sublink[1].title }}</a></li>
                               {% elsif sublink[1].submenu == true and sublink[1].disabled != true %}
-                              <li>{% if sublink[1].url %}<a href="{{ sublink[1].url }}">{{ sublink[1].title }}</a>{% else %}<a href="javascript:;">{{ sublink[1].title }}</a>{% endif %}
+                              <li>{% if sublink[1].url %}<a href="{{ ROOT_PATH }}{{ sublink[1].url }}">{{ sublink[1].title }}</a>{% else %}<a href="javascript:;">{{ sublink[1].title }}</a>{% endif %}
                                   <ul>
                                       {% for sublink2 in sublink[1].tree %}
-                                      <li><a href="{{ sublink2[1].url }}">{{ sublink2[1].title }}</a></li>
+                                      <li><a href="{{ ROOT_PATH }}{{ sublink2[1].url }}">{{ sublink2[1].title }}</a></li>
                                       {% endfor %}
                                   </ul>
                               </li>
@@ -31,7 +31,7 @@
                             <li>
                               {% for article in site.doc %}
                                 {% if article.btcversion == "index" %}
-                                  <a href="{{article.url}}">RPC Docs</a>
+                                  <a href="{{ ROOT_PATH }}{{article.url}}">RPC Docs</a>
                                 {% endif %}
                               {% endfor %}
                               {% assign groups = site.doc | group_by:"btcversion" | sort_by: "btcversion" | reverse %}
@@ -40,7 +40,7 @@
                                   {% if group.name != "index" %}
                                     {% for article in group.items %}
                                       {% if article.name == "index" %}
-                                        <li><a href="{{article.url}}">{{group.name}}</a></li>
+                                        <li><a href="{{ ROOT_PATH }}{{article.url}}">{{group.name}}</a></li>
                                       {% endif %}
                                     {% endfor %}
                                   {% endif %}
@@ -57,9 +57,9 @@
 
                 <li id="langselect" class="lang">
                     <select onchange="window.location=this.value;">
-                        <option value="{{ post.url }}">{{ site.data.languages[page.lang] }}</option>
+                        <option value="{{ ROOT_PATH }}{{ post.url }}">{{ site.data.languages[page.lang] }}</option>
                         {% for post in posts %}
-                        {% if post.lang != page.lang %}<option value="{{ post.url }}">{{ site.data.languages[post.lang] }}</option>{% endif %}
+                        {% if post.lang != page.lang %}<option value="{{ ROOT_PATH }}{{ post.url }}">{{ site.data.languages[post.lang] }}</option>{% endif %}
                         {% endfor %}
                         {% for release in releases %}
                         {% if release.lang != page.lang %}<option value="{{ release.url }}">{{ site.data.languages[release.lang] }}</option>{% endif %}

--- a/_includes/related.html
+++ b/_includes/related.html
@@ -3,10 +3,10 @@
 <div class="related-articles">
     {% assign translations = site.data.translations[page.lang] %}
     {% assign navigation = site.data.navigation[page.lang] %}
-    <h4>{{ translations.related }} <small class="pull-right">(<a href="{{ navigation.blog.url }}">{{ translations.viewallposts }}</a>)</small></h4>
+    <h4>{{ translations.related }} <small class="pull-right">(<a href="{{ ROOT_PATH }}{{ navigation.blog.url }}">{{ translations.viewallposts }}</a>)</small></h4>
     <ul>
         {% for post in related_posts limit:3 %}
-        <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
+        <li><a href="{{ ROOT_PATH }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
         {% endfor %}
     </ul>
     <hr />

--- a/_includes/releases.html
+++ b/_includes/releases.html
@@ -1,3 +1,4 @@
+{% include root_path.html %}
 <ul class="releases">
   {% assign english_posts = site.releases | sort: 'release' | reverse %}
   {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'releases' %}
@@ -7,7 +8,7 @@
       {% if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
     {% endfor %}
   <li>
-    <a href="{{ post.url }}">
+    <a href="{{ ROOT_PATH }}{{ post.url }}">
       {{ post.title | replace: '<br/>', '' }}
     </a>
     <div class="desc">{{ post.desc }}</div>

--- a/_includes/root_path.html
+++ b/_includes/root_path.html
@@ -1,0 +1,18 @@
+{% assign ROOT_PATH = ''
+%}{% assign depth = page.url | split: '/' | size | minus: 1
+%}{% if depth < 1
+%}{% assign ROOT_PATH = '.'
+%}{% elsif depth == 1
+%}{% assign ROOT_PATH = '..'
+%}{% elsif depth == 2
+%}{% assign ROOT_PATH = '../..'
+%}{% elsif depth == 3
+%}{% assign ROOT_PATH = '../../..'
+%}{% elsif depth == 4
+%}{% assign ROOT_PATH = '../../../..'
+%}{% elsif depth == 5
+%}{% assign ROOT_PATH = '../../../../..'
+%}{% elsif depth == 6
+%}{% assign ROOT_PATH = '../../../../../..'
+%}{% endif
+%}

--- a/_includes/root_path.html
+++ b/_includes/root_path.html
@@ -1,6 +1,8 @@
 {% assign ROOT_PATH = ''
 %}{% assign depth = page.url | split: '/' | size | minus: 1
-%}{% if depth < 1
+%}{% if page.permalink == '/404.html'
+%}{% assign ROOT_PATH = ''
+%}{% elsif depth < 1
 %}{% assign ROOT_PATH = '.'
 %}{% elsif depth == 1
 %}{% assign ROOT_PATH = '..'

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,4 +1,4 @@
-<script src="/assets/js/scripts.js"></script>
+<script src="{{ ROOT_PATH }}/assets/js/scripts.js"></script>
 {% if site.owner.google.analytics %}
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -1,3 +1,4 @@
+{% include root_path.html %}
 {% capture /dev/null %}<!-- suppress render of this part -->
 <!-- Copyright 2013 - 2016 The Bitcoin.org Project.
      Copyright 2017 - 2020 The BitcoinCore.org Project
@@ -6,7 +7,7 @@
 {% assign VERSION_SORTED_RELEASES = site.releases | sort: 'release' | reverse %}
 {% capture CURRENT_RELEASE %}{% for subver in VERSION_SORTED_RELEASES[0].release %}{{subver}}{% unless forloop.last %}.{% endunless %}{% endfor %}{% endcapture %}
 {% assign magnet = VERSION_SORTED_RELEASES[0].optional_magnetlink %}
-{% capture PATH_PREFIX %}/bin/bitcoin-core-{{CURRENT_RELEASE}}{% endcapture %}
+{% capture PATH_PREFIX %}{{ ROOT_PATH }}/bin/bitcoin-core-{{CURRENT_RELEASE}}{% endcapture %}
 {% capture FILE_PREFIX %}bitcoin-{{CURRENT_RELEASE}}{% endcapture %}
 {% assign SIGNING_KEY_FINGERPRINT = "01EA5486DE18A882D4C2684590C8019E36C2E964" %}
 {% capture SIGNING_KEY_FINGERPRINT_EXPLODED %}{% include fingerprint-split.html hex=SIGNING_KEY_FINGERPRINT %}{% endcapture %}
@@ -15,15 +16,15 @@
 {% assign GPG_WINDOWS_DOWNLOAD_URL = "https://gpg4win.org/download.html" %}
 {% assign GITIAN_REPOSITORY_URL = "https://github.com/bitcoin-core/gitian.sigs" %}
 {% endcapture %}
-<link rel="alternate" type="application/rss+xml" href="/en/releasesrss.xml" title="Bitcoin Core releases">
+<link rel="alternate" type="application/rss+xml" href="{{ ROOT_PATH }}/en/releasesrss.xml" title="Bitcoin Core releases">
 <div class="download">
-  <h2>{{ page.latestversion }} {{CURRENT_RELEASE}} <a type="application/rss+xml" href="/en/releasesrss.xml"><img src="/assets/images/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h2>
-  <div class="mainbutton"><a id="downloadbutton" href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win64exe }}"><img src="/assets/images/os/but_windows.svg" alt="icon"><span>{{ page.download }}</span></a></div>
+  <h2>{{ page.latestversion }} {{CURRENT_RELEASE}} <a type="application/rss+xml" href="{{ ROOT_PATH }}/en/releasesrss.xml"><img src="{{ ROOT_PATH }}/assets/images/icons/icon_rss.svg" alt="rss" class="rssicon"></a></h2>
+  <div class="mainbutton"><a id="downloadbutton" href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win64exe }}"><img src="{{ ROOT_PATH }}/assets/images/os/but_windows.svg" alt="icon"><span>{{ page.download }}</span></a></div>
   <div class="downloadbox">
     <p>{{ page.downloados }}</p>
     <div>
       <div>
-        <img src="/assets/images/os/med_win.png" alt="windows">
+        <img src="{{ ROOT_PATH }}/assets/images/os/med_win.png" alt="windows">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win64exe }}" class="dl" id="downloadwinexe">Windows</a>
           <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.win64exe }}" class="dl" id="win64exe">exe</a> -
@@ -31,7 +32,7 @@
         </span>
       </div>
       <div>
-        <img src="/assets/images/os/med_osx.png" alt="osx">
+        <img src="{{ ROOT_PATH }}/assets/images/os/med_osx.png" alt="osx">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ site.data.binaries.macdmg }}">Mac OS X</a>
           <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ site.data.binaries.macdmg }}" class="dl" id="macdmg">dmg</a> -
@@ -39,7 +40,7 @@
         </span>
       </div>
       <div>
-        <img src="/assets/images/os/med_linux.png" alt="linux">
+        <img src="{{ ROOT_PATH }}/assets/images/os/med_linux.png" alt="linux">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.lin64 }}" class="dl" id="lin64">Linux (tgz)</a>
         </span>
@@ -47,7 +48,7 @@
     </div>
     <div>
       <div>
-        <img src="/assets/images/os/arm.png" alt="ARM Linux">
+        <img src="{{ ROOT_PATH }}/assets/images/os/arm.png" alt="ARM Linux">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-arm-linux-gnueabihf.tar.gz" class="dl">ARM Linux</a>
           	<span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-aarch64-linux-gnu.tar.gz" class="dl" id="lin64arm">64 bit</a> -
@@ -55,14 +56,14 @@
         </span>
       </div>
       <div>
-        <img src="/assets/images/os/but_riscv.svg" alt="RISC-V Linux">
+        <img src="{{ ROOT_PATH }}/assets/images/os/but_riscv.svg" alt="RISC-V Linux">
         <span>
           <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.riscv64 }}.tar.gz" class="dl">RISC-V Linux</a>
             <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.riscv64 }}.tar.gz" class="dl" id="lin64riscv">64 bit</a></span>
         </span>
       </div>
       <div>
-        <img src="/assets/images/os/med_snap.svg" alt="Snap Store Linux">
+        <img src="{{ ROOT_PATH }}/assets/images/os/med_snap.svg" alt="Snap Store Linux">
         <span>
           <a href="https://snapcraft.io/bitcoin-core" class="dl">Snap Store Linux</a>
         </span>
@@ -73,7 +74,7 @@
       <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}.torrent" class="dl">{{ page.downloadtorrent }}</a>
         {% if magnet %} <a href="{{ magnet | replace: '&', '\&amp;'}}" class="magnetlink" data-proofer-ignore></a>{% endif %}<br>
       <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX}}.tar.gz" class="dl">{{ page.source }}</a><br>
-      <a href="/en/releases">{{ page.versionhistory }}</a>
+      <a href="{{ ROOT_PATH }}/en/releases">{{ page.versionhistory }}</a>
     </p>
     <p class="downloadkeys">
       <span>{{ page.releasekeys }}</span>
@@ -261,18 +262,18 @@ var hrefmactar = document.getElementById('mactar').href;
 var hreflin64 = document.getElementById('lin64').href;
 switch (os) {
 case 'windows64':
-	but.getElementsByTagName('IMG')[0].src = '/assets/images/os/but_windows.svg';
+	but.getElementsByTagName('IMG')[0].src = '{{ ROOT_PATH }}/assets/images/os/but_windows.svg';
 	but.href = hrefwin64exe;
 	linkwinexe.href = hrefwin64exe;
 	linkwinzip.href = hrefwin64zip;
 break;
 case 'linux64':
-	but.getElementsByTagName('IMG')[0].src = '/assets/images/os/but_linux.png';
+	but.getElementsByTagName('IMG')[0].src = '{{ ROOT_PATH }}/assets/images/os/but_linux.png';
 	but.href = hreflin64;
 	linklin.href = hreflin64;
 break;
 case 'mac':
-	but.getElementsByTagName('IMG')[0].src = '/assets/images/os/but_mac.svg';
+	but.getElementsByTagName('IMG')[0].src = '{{ ROOT_PATH }}/assets/images/os/but_mac.svg';
 	but.href = hrefmacdmg;
 break;
 }

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,4 +1,5 @@
 <!doctype html>
+{% include root_path.html %}
 {% include browser_magic.html %}
 <head>
 {% if page.name != "index" and page.name != "rpcindex" %}
@@ -46,7 +47,7 @@
               <div class="toc-drawer js-hide-on-start">
                 <ul>
                   {% for article in group.items %}
-                    <li class="leaf-article"><a href="{{article.url}}">{{article.name}}</a></li>
+                    <li class="leaf-article"><a href="{{ ROOT_PATH }}{{article.url}}">{{article.name}}</a></li>
                   {% endfor %}
                 </ul>
               </div>
@@ -73,7 +74,7 @@
               {% if group.name != "index" %}
                 {% for article in group.items %}
                   {% if article.name == "index" %}
-                    <li><a href="{{article.url}}">{{group.name}}</a></li>
+                    <li><a href="{{ ROOT_PATH }}{{article.url}}">{{group.name}}</a></li>
                   {% endif %}
                 {% endfor %}
               {% endif %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,4 +1,5 @@
 <!doctype html>
+{% include root_path.html %}
 {% include browser_magic.html %}
 <head>
 {% include head.html %}
@@ -14,9 +15,9 @@
   <div class="image-wrap">
   <img src=
     {% if page.image.feature contains 'http' %}
-      "{{ page.image.feature }}"
+      {{ ROOT_PATH }}/"{{ page.image.feature }}"
     {% else %}
-      "/assets/images/{{ page.image.feature }}"
+      "{{ ROOT_PATH }}/assets/images/{{ page.image.feature }}"
     {% endif %}
     alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title }}{% endif %} feature image">
   {% if page.image.byline %}
@@ -34,7 +35,7 @@
   </div>
   <div id="index">
     {% assign navigation = site.data.navigation[page.lang] %}
-    <h3><a href="{{ navigation.blog.url }}">Recent Posts</a></h3>
+    <h3><a href="{{ ROOT_PATH }}{{ navigation.blog.url }}">Recent Posts</a></h3>
     <!-- h3><a href="{{ navigation.blog.url }}">Recent Posts</a></h3 -->
       {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'posts' %}
       {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
@@ -45,9 +46,9 @@
       {% endfor %}
     <article>
       {% if post.link %}
-        <h2 class="link-post"><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title }}"><i class="fa fa-link"></i></a></h2>
+        <h2 class="link-post"><a href="{{ ROOT_PATH }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title }}"><i class="fa fa-link"></i></a></h2>
       {% else %}
-        <h2><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h2>
+        <h2><a href="{{ ROOT_PATH }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h2>
         <p>{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>
       {% endif %}
     </article>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,4 +1,5 @@
 <!doctype html>
+{% include root_path.html %}
 {% include browser_magic.html %}
 <head>
 {% include head.html %}
@@ -14,9 +15,9 @@
   <div class="image-wrap">
   <img src=
     {% if page.image.feature contains 'http' %}
-      "{{ page.image.feature }}"
+      "{{ ROOT_PATH }}/{{ page.image.feature }}"
     {% else %}
-      "/assets/images/{{ page.image.feature }}"
+      "{{ ROOT_PATH }}/assets/images/{{ page.image.feature }}"
     {% endif %}
   alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title | xml_escape }}{% endif %} feature image">
   {% if page.image.byline %}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -1,4 +1,5 @@
 <!doctype html>
+{% include root_path.html %}
 {% include browser_magic.html %}
 <head>
 {% include head.html %}
@@ -14,9 +15,9 @@
   <div class="image-wrap">
   <img src=
     {% if page.image.feature contains 'http' %}
-      "{{ page.image.feature }}"
+      "{{ ROOT_PATH }}/{{ page.image.feature }}"
     {% else %}
-      "/assets/images/{{ page.image.feature }}"
+      "{{ ROOT_PATH }}/assets/images/{{ page.image.feature }}"
     {% endif %}
     alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title | xml_escape }}{% endif %} feature image">
   {% if page.image.byline %}
@@ -49,9 +50,9 @@
       {% endif %}
       <article>
         {% if post.link %}
-          <h2 class="link-post"><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title | xml_escape }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title | xml_escape }}"><i class="fa fa-link"></i></a></h2>
+          <h2 class="link-post"><a href="{{ ROOT_PATH }}{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title | xml_escape }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title | xml_escape }}"><i class="fa fa-link"></i></a></h2>
         {% else %}
-          <h2><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title }}</a></h2>
+          <h2><a href="{{ ROOT_PATH }}{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title }}</a></h2>
           <p>{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>
         {% endif %}
       </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,4 +1,5 @@
 <!doctype html>
+{% include root_path.html %}
 {% include browser_magic.html %}
 <head>
 {% include head.html %}
@@ -35,9 +36,9 @@
   <article class="post h-entry">
     <div class="headline-wrap">
       {% if page.link %}
-        <h1 class="p-name"><a href="{{ page.link }}">{{ page.title }}</a></h1>
+        <h1 class="p-name"><a href="{{ ROOT_PATH }}{{ page.link }}">{{ page.title }}</a></h1>
       {% else %}
-        <h1 class="p-name"><a href="{{ page.url }}" rel="bookmark" title="{{ page.title }}">{{ page.title }}</a></h1>
+        <h1 class="p-name"><a href="{{ ROOT_PATH }}{{ page.url }}" rel="bookmark" title="{{ page.title }}">{{ page.title }}</a></h1>
       {% endif %}
       {% if page.author %}
         {% assign author = site.data.authors[page.author] %}{% else %}{% assign author = "" %}

--- a/_sass/download.scss
+++ b/_sass/download.scss
@@ -88,7 +88,7 @@
 .downloadbox p.downloadkeys a{
         display:inline-block;
         padding: 5px 10px 0 20px;
-        background:url(/assets/images/icons/mini_ico_key.svg) left 8px no-repeat;
+        background:url(../../../assets/images/icons/mini_ico_key.svg) left 8px no-repeat;
 }
 .downloadbox div a{
         display:inline-block;
@@ -128,7 +128,7 @@
         height:16px;
         position:relative;
         bottom:-1px;
-        background:url(/assets/images/icons/mini_ico_magnet.svg) no-repeat;
+        background:url(../../../assets/images/icons/mini_ico_magnet.svg) no-repeat;
 }
 
 @media handheld, only screen and ( max-width: 60em ), only screen and ( max-device-width: 60em ){

--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -20,7 +20,7 @@ body {
 	text-transform: uppercase;
 	@include clearfix;
 	background-color: $black;
-	background-image: url("/assets/images/nav_background.png");
+	background-image: url("../../../assets/images/nav_background.png");
 	background-position: left bottom;
 	background-size: 1px 100px;
 	background-repeat: repeat-x;

--- a/assets/css/fonts.scss
+++ b/assets/css/fonts.scss
@@ -5,29 +5,29 @@ sitemap: false
   font-family: 'PT Sans Narrow';
   font-style: normal;
   font-weight: 400;
-  src: local('PT Sans Narrow'), local('PTSans-Narrow'), url(/assets/fonts/PTSans-Narrow.ttf) format('truetype');
+  src: local('PT Sans Narrow'), local('PTSans-Narrow'), url(../fonts/PTSans-Narrow.ttf) format('truetype');
 }
 @font-face {
   font-family: 'PT Sans Narrow';
   font-style: normal;
   font-weight: 700;
-  src: local('PT Sans Narrow Bold'), local('PTSans-NarrowBold'), url(/assets/fonts/PTSans-NarrowBold.ttf) format('truetype');
+  src: local('PT Sans Narrow Bold'), local('PTSans-NarrowBold'), url(../fonts/PTSans-NarrowBold.ttf) format('truetype');
 }
 @font-face {
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 400;
-  src: local('PT Serif'), local('PTSerif-Regular'), url(/assets/fonts/PTSerif-Regular.ttf) format('truetype');
+  src: local('PT Serif'), local('PTSerif-Regular'), url(../fonts/PTSerif-Regular.ttf) format('truetype');
 }
 @font-face {
   font-family: 'PT Serif';
   font-style: normal;
   font-weight: 700;
-  src: local('PT Serif Bold'), local('PTSerif-Bold'), url(/assets/fonts/PTSerif-Bold.ttf) format('truetype');
+  src: local('PT Serif Bold'), local('PTSerif-Bold'), url(../fonts/PTSerif-Bold.ttf) format('truetype');
 }
 @font-face {
   font-family: 'PT Serif';
   font-style: italic;
   font-weight: 400;
-  src: local('PT Serif Italic'), local('PTSerif-Italic'), url(/assets/fonts/PTSerif-Italic.ttf) format('truetype');
+  src: local('PT Serif Italic'), local('PTSerif-Italic'), url(../fonts/PTSerif-Italic.ttf) format('truetype');
 }


### PR DESCRIPTION
In order for the static website to work when hosted under nested paths/directories, e.g. `https://some-ipfs-gateway.com/ipfs/some-content-hash/`, all links and source file paths need to be relative to the respective documents, instead of absolute from the root.

(This branch may need some more adjustments before it can be merged, as I have not familiarized myself with the site release process yet.)

refs #739