### PR TITLE
Solve redirecting GitHub links

### DIFF
--- a/_posts/en/pages/2016-01-01-about.md
+++ b/_posts/en/pages/2016-01-01-about.md
@@ -17,7 +17,7 @@ Bitcoin Core is an [open source](https://opensource.org/) project which maintain
 
 It is a direct descendant of the original Bitcoin software client released by Satoshi Nakamoto after he published the famous Bitcoin whitepaper.
 
-Bitcoin Core consists of both "full-node" software for fully validating the blockchain as well as a bitcoin wallet. The project also currently maintains related software such as the cryptography library [libsecp256k1](https://github.com/bitcoin/secp256k1) and others located at [GitHub](https://github.com/bitcoin).
+[Bitcoin Core](https://github.com/bitcoin/bitcoin) consists of both "full-node" software for fully validating the blockchain as well as a bitcoin wallet. The project also currently maintains related software such as the cryptography library [libsecp256k1](https://github.com/bitcoin-core/secp256k1) and others located at [GitHub](https://github.com/bitcoin-core).
 
 Anyone can [contribute to Bitcoin Core](/en/contribute/).
 


### PR DESCRIPTION
Fix #748, by replacing /bitcoin links with /bitcoin-core links, because everything Bitcoin Core related except the main repo has been moved to /bitcoin-core.