### PR TITLE
RPC doc generating script: always connect to regtest

### DIFF
--- a/contrib/doc-gen/generate.go
+++ b/contrib/doc-gen/generate.go
@@ -20,6 +20,7 @@ import (
 )
 
 const BITCOIN_COMMAND = "bitcoin-cli"
+const BITCOIN_CHAINOPTION = "-regtest"
 
 type Command struct {
 	Name        string
@@ -158,9 +159,10 @@ func open(path string) io.Writer {
 }
 
 func run(args ...string) string {
+	args = append([]string{BITCOIN_CHAINOPTION}, args...)
 	out, err := exec.Command(BITCOIN_COMMAND, args...).CombinedOutput()
 	if err != nil {
-		log.Fatalf("Cannot run bitcoin-cli: %s, is bitcoind running?", err.Error())
+		log.Fatalf("Cannot run bitcoin-cli: %s, is bitcoind (regtest) running?", err.Error())
 	}
 
 	return string(out)


### PR DESCRIPTION
See Bitcoin Core PR https://github.com/bitcoin/bitcoin/pull/20987, in particular the discussion https://github.com/bitcoin/bitcoin/pull/20987#discussion_r562762266.

The recommended network for generating RPC docs is regtest, as stated in the script's file header comments:
```// (2) install bitcoin core, set it up to use regtest```

To achieve this, the user previosly needed to manually put `regtest=1` into
`~/.bitcoin/bitcoin.conf` -- the script didn't specify a concrete network, so
without config file setting, mainnet was used. With the change in this commit,
we will always connect to regtest by passing the `-regtest` option to the
`bitcoin-cli` invokation.

With this change, [harding's well-described way to use the script involving file editing via mighty vi(m)](https://github.com/bitcoin/bitcoin/pull/20987#discussion_r562808635) will be reduced to just running the following commands:
```
$ bitcoind -regtest -daemon
$ go run generate.go
$ bitcoin-cli -regtest stop
```

Note that I'm far from a golang expert and just tried to wrap my head around variadic functions and slices. Prepending the arguments slice with the chainoption (`-regtest`) seemed the easiest solution to me, but curious to hear how a more "gothonic" (does that word exist?) approach would look like.