### PR TITLE
posts: Move P2P meeting to 21:00 UTC

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -15,7 +15,7 @@ Current meeting schedule:
 
 - General developer meeting: Thursday 19:00 UTC (every week)
 - Wallet developer meeting: Friday 19:00 UTC (every second week)
-- P2P developer meeting: Tuesday 15:00 UTC (every second week)
+- P2P developer meeting: Tuesday 21:00 UTC (every second week)
 
 Meeting times are also listed on [this Google calendar][meeting
 calendar].


### PR DESCRIPTION
From what I understand, the P2P meeting will be held at 21:00 UTC from now on.