### PR TITLE
Make contributing page up to date

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -117,7 +117,9 @@
 [BIP174]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
 
 [@bitcoincoreorg]: https://twitter.com/bitcoincoreorg
-[#bitcoin-core-dev]: https://webchat.freenode.net?channels=%23bitcoin-core-dev&uio=MTY9dHJ1ZSYxMT0yMTU87
+[#bitcoin-core-dev]: https://webchat.freenode.net?channels=%23bitcoin-core-dev
+[#bitcoin-builds]: https://webchat.freenode.net?channels=%23bitcoin-builds
+[##bitcoin-core-gui]: https://webchat.freenode.net?channels=%23%23bitcoin-core-gui
 [issues]: https://github.com/bitcoin/bitcoin/issues
 [pulls]: https://github.com/bitcoin/bitcoin/pulls
 [BitcoinCoreDocBips]: https://github.com/bitcoin/bitcoin/blob/master/doc/bips.md

--- a/_posts/en/pages/2016-01-01-contribute.md
+++ b/_posts/en/pages/2016-01-01-contribute.md
@@ -6,7 +6,7 @@ permalink: /en/contribute/
 type: pages
 layout: page
 lang: en
-version: 3
+version: 4
 redirect_from:
   - /zh_TW/contribute/
 ---
@@ -25,7 +25,13 @@ Feel free to report [issues][issues] and open [pull requests][pulls], but please
 
 **Discussion**
 
-Most Bitcoin Core related discussion happens in the [#bitcoin-core-dev] IRC channel on irc.freenode.net or [bitcoin-core-dev][] mailing list. There is also a mailing list for Bitcoin protocol discussion [bitcoin-dev][] and a general Bitcoin discussion [bitcoin-discuss][].
+Most Bitcoin Core related discussion happens in the following IRC channels on irc.freenode.net:
+
+- [#bitcoin-core-dev] - Main discussion
+- [#bitcoin-builds] - Build system and release discussion
+- [##bitcoin-core-gui] - Graphical User Interface discussion
+
+There is also a mailing list for Bitcoin protocol discussion [bitcoin-dev][].
 
 **Contribute to this website**
 


### PR DESCRIPTION
- Remove mention of (retired) bitcoin-discuss list
- Remove mention of bitcoin-core-dev list under "discussion", as it has been changed into an [announcements list](https://bitcoincore.org/en/list/announcements/join/) and there was never any discussion there in the first place
- Add mention of other relevant IRC channels