### PR TITLE
Rename the meeting summary page to fix duplicate names

### DIFF
--- a/_posts/en/pages/2020-08-01-meeting-summaries.md
+++ b/_posts/en/pages/2020-08-01-meeting-summaries.md
@@ -3,7 +3,7 @@ type: pages
 layout: page
 lang: en
 title: IRC Meeting Summaries
-name: meetings
+name: meeting-summaries
 permalink: /en/meeting-summaries/
 version: 1
 ---


### PR DESCRIPTION
Since the name of the meeting page and summary page are the same `meetings`, multiple english pages will be displayed when opened in other languages.

This PR fix duplicate names.