### PR TITLE
Change freenode to libera

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -117,9 +117,9 @@
 [BIP174]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
 
 [@bitcoincoreorg]: https://twitter.com/bitcoincoreorg
-[#bitcoin-core-dev]: https://webchat.freenode.net?channels=%23bitcoin-core-dev
-[#bitcoin-builds]: https://webchat.freenode.net?channels=%23bitcoin-builds
-[##bitcoin-core-gui]: https://webchat.freenode.net?channels=%23%23bitcoin-core-gui
+[#bitcoin-core-dev]: https://kiwiirc.com/nextclient/#irc://irc.libera.chat/#bitcoin-core-dev
+[#bitcoin-core-builds]: https://kiwiirc.com/nextclient/#irc://irc.libera.chat/#bitcoin-core-builds
+[#bitcoin-core-gui]: https://kiwiirc.com/nextclient/#irc://irc.libera.chat/#bitcoin-core-gui
 [issues]: https://github.com/bitcoin/bitcoin/issues
 [pulls]: https://github.com/bitcoin/bitcoin/pulls
 [BitcoinCoreDocBips]: https://github.com/bitcoin/bitcoin/blob/master/doc/bips.md

--- a/_posts/en/pages/2016-01-01-contribute.md
+++ b/_posts/en/pages/2016-01-01-contribute.md
@@ -6,7 +6,7 @@ permalink: /en/contribute/
 type: pages
 layout: page
 lang: en
-version: 4
+version: 5
 redirect_from:
   - /zh_TW/contribute/
 ---
@@ -25,11 +25,11 @@ Feel free to report [issues][issues] and open [pull requests][pulls], but please
 
 **Discussion**
 
-Most Bitcoin Core related discussion happens in the following IRC channels on irc.freenode.net:
+Most Bitcoin Core related discussion happens in the following IRC channels on irc.libera.chat:
 
 - [#bitcoin-core-dev] - Main discussion
-- [#bitcoin-builds] - Build system and release discussion
-- [##bitcoin-core-gui] - Graphical User Interface discussion
+- [#bitcoin-core-builds] - Build system and release discussion
+- [#bitcoin-core-gui] - Graphical User Interface discussion
 
 There is also a mailing list for Bitcoin protocol discussion [bitcoin-dev][].
 

--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -5,7 +5,7 @@ lang: en
 title: IRC Meetings
 name: meetings
 permalink: /en/meetings/
-version: 3
+version: 4
 ---
 The project holds several recurring meetings in `#bitcoin-core-dev` on
 irc.freenode.net.  Everyone is welcome to attend.  Logs and
@@ -23,7 +23,7 @@ calendar].
 [Here as ical format][meeting calendar ical] to subscribe via a calendar app.
 
 If you have any questions about the date or time of an upcoming meeting,
-please ask in `#bitcoin-core-dev` on Freenode.
+please ask in `#bitcoin-core-dev` on irc.libera.chat.
 
 Anyone interested in contributing to Bitcoin Core is also
 encouraged to attend the weekly Bitcoin Core PR Review Club meetings,

--- a/_posts/en/posts/2016-01-28-clarification.md
+++ b/_posts/en/posts/2016-01-28-clarification.md
@@ -6,12 +6,12 @@ type: posts
 layout: post
 lang: en
 permalink: /en/2016/01/28/clarification/
-version: 1
+version: 2
 excerpt: Where to find official information about Bitcoin Core and how you can interact with other Bitcoin Core users and developers.
 ---
 Initially, bitcoin.org was used to host the original Bitcoin paper and became the homepage for the [Bitcoin program](https://bitcoin.org/en/download). The site evolved into a general educational resource for Bitcoin, and is [not affiliated](https://bitcoin.org/en/bitcoin-core/about-site) with the modern Bitcoin Core project. The Bitcoin Core project's official website is bitcoincore.org and while other websites continue to host information about Bitcoin Core, their views do not represent Bitcoin Core. We know that the Bitcoin ecosystem can be confusing, and we are working hard to make these relationships more clear.
 
-For development work, Bitcoin Core mainly uses the `#bitcoin-core-dev` IRC channel on Freenode, [Github](https://github.com/bitcoin/bitcoin), and [the bitcoin-dev mailing list](http://lists.linuxfoundation.org/pipermail/bitcoin-dev/).
+For development work, Bitcoin Core mainly uses the `#bitcoin-core-dev` IRC channel on irc.libera.chat, [Github](https://github.com/bitcoin/bitcoin), and [the bitcoin-dev mailing list](http://lists.linuxfoundation.org/pipermail/bitcoin-dev/).
 
 While there are many forums in which the Bitcoin community and, indeed, Bitcoin Core contributors engage, Bitcoin Core is not responsible for those forums or their policies, nor does Bitcoin Core take official positions on the community's decisions to use them. Still, we believe it is critical that the Bitcoin community be able to freely discuss and critique every aspect of Bitcoin.
 


### PR DESCRIPTION
Update website for the change of IRC servers. Change occurences of freenode in active (non-historical) documents to libera.chat. As libera has no official webchat, change the references to their main page for now.