### PR TITLE
meetings log: temp fix for meetings link #772

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -9,7 +9,7 @@ version: 4
 ---
 The project holds several recurring meetings in the `#bitcoin-core-dev` IRC
 channel on Libera Chat ([webchat][bitcoin-core-dev-IRC-webchat]).  Everyone is welcome to attend.  Logs and
-automatically-generated meeting minutes may be found [here][meetbot].
+automatically-generated meeting minutes may be found [here][meetbot] and [here][schnelli].
 
 Current meeting schedule:
 
@@ -35,6 +35,7 @@ separate page][summaries].
 
 [bitcoin-core-dev-IRC-webchat]: https://web.libera.chat/#bitcoin-core-dev
 [meetbot]: http://www.erisian.com.au/meetbot/bitcoin-core-dev/
+[schnelli]: https://bitcoin.jonasschnelli.ch/ircmeetings/logs/bitcoin-core-dev/
 [meeting calendar]: https://calendar.google.com/calendar?cid=MTFwcXZkZ3BkOTlubGliZjliYTg2MXZ1OHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
 [meeting calendar ical]: https://calendar.google.com/calendar/ical/11pqvdgpd99nlibf9ba861vu8s%40group.calendar.google.com/public/basic.ics
 [review club]: https://bitcoincore.reviews/


### PR DESCRIPTION
A long term fix will require some restructuring - I like the idea of mirroring in #772.
This can be accomplished thru a gh workflow for automation and easier maintenance.
In the mean time at least there will be a link to current meeting logs.
