### PR TITLE
Recent posts to show published date

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -49,6 +49,9 @@
       {% else %}
         <h2><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h2>
         <p>{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>
+        <p class="dt-published" datetime="{{ page.date | date_to_xmlschema }}">
+          <small>Published on {{ post.date | date: "%B %d, %Y" }}</small>
+        </p>
       {% endif %}
     </article>
     {% endfor %}


### PR DESCRIPTION
### Recent posts to show published date
Fixes #488 

- Added published date to the recent posts

<img width="808" alt="Screen Shot 2021-09-04 at 12 20 47 PM" src="https://user-images.githubusercontent.com/13100108/132085658-4ec08d80-9a1e-4f5a-8c01-685379cf4e93.png">
