### PR TITLE
Downloads: hide verification instructions

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -87,7 +87,7 @@
   <h2 style="text-align: center">{{ page.patient }}</h2>
   <p>{{ page.notesync | replace: '$(DATADIR_SIZE)', site.data.stats.datadir_gb | replace: '$(PRUNED_SIZE)', site.data.stats.pruned_gb | replace: '$(MONTHLY_RANGE_GB)', site.data.stats.monthly_storage_increase_range_gb }} {{ page.full_node_guide }}</p>
 
-{% if page.version > 1 %}
+{% if page.version > 4 %}
   <h2 style="text-align: center" id="{{page.verify_download | slugify}}">{{page.verify_download}}</h2>
   <p>{{page.verification_recommended}}</p>
   <details>


### PR DESCRIPTION
This one-character patch temporarily hides the verification instructions, which have become out of date with the release of 22.0 and combined signature files.  See controlling issue #793 

An update to the instructions will require bumping the page version number and so automatically show the instructions again.