### PR TITLE
Update binary verification instructions for multiple signers

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -77,8 +77,6 @@
       <a href="/en/releases">{{ page.versionhistory }}</a>
     </p>
     <p class="downloadkeys">
-      <span>{{ page.releasekeys }}</span>
-      v0.11.0+ <code title="{{page.pgp_key_fingerprint}}">{{SIGNING_KEY_FINGERPRINT}}</code><br>
       {% if page.version > 2 %}<i>{{page.key_refresh}}</i><br><code>gpg{{site.strings.gpg_keyserver}} --refresh-keys</code>{% endif %}
     </p>
   </div>

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -8,8 +8,14 @@
 {% assign magnet = VERSION_SORTED_RELEASES[0].optional_magnetlink %}
 {% capture PATH_PREFIX %}/bin/bitcoin-core-{{CURRENT_RELEASE}}{% endcapture %}
 {% capture FILE_PREFIX %}bitcoin-{{CURRENT_RELEASE}}{% endcapture %}
-{% capture SIGNING_KEY_FINGERPRINT_EXPLODED %}{% include fingerprint-split.html hex=page.example_builder_key %}{% endcapture %}
-{% capture SHORT_BUILDER_KEY %}{{page.example_builder_key | slice: 0, 4}}  {{ page.example_builder_key | slice: 4, 4 }}...{% endcapture %}
+{% assign builder_line_arr = page.example_builders_line | split: ' ' %}
+{% assign example_builder_key = builder_line_arr[0] %}
+{% capture SIGNING_KEY_FINGERPRINT_EXPLODED %}
+  {% include fingerprint-split.html hex=example_builder_key %}
+{% endcapture %}
+{% capture SHORT_BUILDER_KEY %}
+  {{example_builder_key | slice: 0, 4}}  {{ example_builder_key | slice: 4, 4 }}..
+.{% endcapture %}
 {% capture BUILDER_KEYS_TXT_URL %}{{page.builder_keys_url}}/keys.txt{% endcapture %}
 
 {% capture OBTAIN_RELEASE_KEY %}
@@ -134,7 +140,7 @@
 
       <li><p>{{OBTAIN_RELEASE_KEY}}</p>
 
-        <pre class="highlight"><code>{{GPG}}{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
+        <pre class="highlight"><code>{{GPG}}{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
 
@@ -182,7 +188,7 @@
 
       <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
 
-        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
+        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
 
@@ -224,7 +230,7 @@
 
       <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
 
-        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
+        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
 

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -10,6 +10,15 @@
 {% capture FILE_PREFIX %}bitcoin-{{CURRENT_RELEASE}}{% endcapture %}
 {% capture SIGNING_KEY_FINGERPRINT_EXPLODED %}{% include fingerprint-split.html hex=page.example_builder_key %}{% endcapture %}
 {% capture SHORT_BUILDER_KEY %}{{page.example_builder_key | slice: 0, 4}}  {{ page.example_builder_key | slice: 4, 4 }}...{% endcapture %}
+{% capture BUILDER_KEYS_TXT_URL %}{{page.builder_keys_url}}/keys.txt{% endcapture %}
+
+{% capture OBTAIN_RELEASE_KEY %}
+  {{page.obtain_release_key | 
+    replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | 
+    replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line | 
+    replace: '$(BUILDER_KEYS_TXT_URL)', BUILDER_KEYS_TXT_URL}}
+{% endcapture %}
+
 {% assign GPG_DOWNLOAD_URL = "https://www.gnupg.org/download/index.en.html#binary" %}
 {% assign GPG_MACOS_DOWNLOAD_URL = "https://gpgtools.org/" %}
 {% assign GPG_WINDOWS_DOWNLOAD_URL = "https://gpg4win.org/download.html" %}
@@ -123,7 +132,7 @@
       {{page.gpg_download_other}}
       <a href="{{GPG_DOWNLOAD_URL}}">{{page.gpg_download_options}}</a></p></li>
 
-      <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
+      <li><p>{{OBTAIN_RELEASE_KEY}}</p>
 
         <pre class="highlight"><code>{{GPG}}{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
 

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -8,8 +8,8 @@
 {% assign magnet = VERSION_SORTED_RELEASES[0].optional_magnetlink %}
 {% capture PATH_PREFIX %}/bin/bitcoin-core-{{CURRENT_RELEASE}}{% endcapture %}
 {% capture FILE_PREFIX %}bitcoin-{{CURRENT_RELEASE}}{% endcapture %}
-{% assign SIGNING_KEY_FINGERPRINT = "01EA5486DE18A882D4C2684590C8019E36C2E964" %}
-{% capture SIGNING_KEY_FINGERPRINT_EXPLODED %}{% include fingerprint-split.html hex=SIGNING_KEY_FINGERPRINT %}{% endcapture %}
+{% capture SIGNING_KEY_FINGERPRINT_EXPLODED %}{% include fingerprint-split.html hex=page.example_builder_key %}{% endcapture %}
+{% capture SHORT_BUILDER_KEY %}{{page.example_builder_key | slice: 0, 4}}  {{ page.example_builder_key | slice: 4, 4 }}...{% endcapture %}
 {% assign GPG_DOWNLOAD_URL = "https://www.gnupg.org/download/index.en.html#binary" %}
 {% assign GPG_MACOS_DOWNLOAD_URL = "https://gpgtools.org/" %}
 {% assign GPG_WINDOWS_DOWNLOAD_URL = "https://gpg4win.org/download.html" %}
@@ -69,7 +69,8 @@
       </div>
     </div>
     <p class="downloadmore">
-      <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc" class="dl">{{ page.downloadsig }}</a><br>
+      <a href="{{ PATH_PREFIX }}/SHA256SUMS" class="dl">{{ page.download_sha }}</a><br>
+      <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc" class="dl">{{ page.download_sig }}</a><br>
       <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}.torrent" class="dl">{{ page.downloadtorrent }}</a>
         {% if magnet %} <a href="{{ magnet | replace: '&', '\&amp;'}}" class="magnetlink" data-proofer-ignore></a>{% endif %}<br>
       <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX}}.tar.gz" class="dl">{{ page.source }}</a><br>
@@ -87,6 +88,10 @@
   <h2 style="text-align: center">{{ page.patient }}</h2>
   <p>{{ page.notesync | replace: '$(DATADIR_SIZE)', site.data.stats.datadir_gb | replace: '$(PRUNED_SIZE)', site.data.stats.pruned_gb | replace: '$(MONTHLY_RANGE_GB)', site.data.stats.monthly_storage_increase_range_gb }} {{ page.full_node_guide }}</p>
 
+
+  <h2 style="text-align: center">{{ page.verify_title }}</h2>
+  <p>{{ page.verify_steps }}</p>
+
 {% if page.version > 4 %}
   <h2 style="text-align: center" id="{{page.verify_download | slugify}}">{{page.verify_download}}</h2>
   <p>{{page.verification_recommended}}</p>
@@ -96,7 +101,9 @@
     <ol>
       <li><p>{{page.download_release}}</p></li>
 
-      <li><p>{{page.download_checksums}} <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">SHA256SUMS.asc</a></p></li>
+      <li><p>{{page.download_checksums}} <a href="{{ PATH_PREFIX }}/SHA256SUMS">SHA256SUMS</a></p></li>
+
+      <li><p>{{page.download_checksums_sigs}} <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">SHA256SUMS.asc</a></p></li>
 
       <li><p>{{page.cd_to_downloads}}</p>
 
@@ -111,18 +118,20 @@
 
       <li><p>{{page.ensure_checksum_matches}}</p>
 
-        <pre class="highlight"><code>type SHA256SUMS.asc</code></pre></li>
+        <pre class="highlight"><code>type SHA256SUMS</code></pre></li>
 
       <li><p>{{page.install_gpg}} <a
       href="{{GPG_WINDOWS_DOWNLOAD_URL}}">{{page.gpg_download_page}}</a>
       {{page.gpg_download_other}}
       <a href="{{GPG_DOWNLOAD_URL}}">{{page.gpg_download_options}}</a></p></li>
 
-      <li><p>{{page.obtain_release_key}}</p>
+      <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
 
-        <pre class="highlight"><code>{{GPG}}{{site.strings.gpg_keyserver}} --recv-keys {{SIGNING_KEY_FINGERPRINT}}</code></pre>
+        <pre class="highlight"><code>{{GPG}}{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
+
+      <li><p>{{page.choosing_builders | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url }}</p></li>
 
       <li>{{page.verify_checksums_file}}
 
@@ -133,7 +142,7 @@
           <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
         </ol>
 
-        <p>{{page.gpg_trust_warning}}</p></li>
+        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}</p></li>
 
     </ol>
   </details>
@@ -143,7 +152,9 @@
     <ol>
       <li><p>{{page.download_release}}</p></li>
 
-      <li><p>{{page.download_checksums}} <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">SHA256SUMS.asc</a></p></li>
+      <li><p>{{page.download_checksums}} <a href="{{ PATH_PREFIX }}/SHA256SUMS">SHA256SUMS</a></p></li>
+
+      <li><p>{{page.download_checksums_sigs}} <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">SHA256SUMS.asc</a></p></li>
 
       <li><p>{{page.cd_to_downloads}}</p>
 
@@ -153,7 +164,7 @@
 
       <li><p>{{page.verify_download_checksum}}</p>
 
-        <pre class="highlight"><code>shasum -a 256 --check SHA256SUMS.asc</code></pre>
+        <pre class="highlight"><code>shasum -a 256 --check SHA256SUMS</code></pre>
 
         <p>{{page.checksum_warning_and_ok | replace, "$(SHASUMS_OK)", page.localized_checksum_ok}} <code>{{FILE_PREFIX}}{{site.data.binaries.macdmg}}: {{page.localized_checksum_ok}}</code></p></li>
 
@@ -162,11 +173,13 @@
       {{page.gpg_download_other}}
       <a href="{{GPG_DOWNLOAD_URL}}">{{page.gpg_download_options}}</a></p></li>
 
-      <li><p>{{page.obtain_release_key}}</p>
+      <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
 
-        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{SIGNING_KEY_FINGERPRINT}}</code></pre>
+        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
+
+      <li><p>{{page.choosing_builders | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url }}</p></li>
 
       <li>{{page.verify_checksums_file}}
 
@@ -177,7 +190,7 @@
           <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
         </ol>
 
-        <p>{{page.gpg_trust_warning}}</p></li>
+        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}</p></li>
     </ol>
   </details>
 
@@ -186,7 +199,9 @@
     <ol>
       <li><p>{{page.download_release}}</p></li>
 
-      <li><p>{{page.download_checksums}} <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">SHA256SUMS.asc</a></p></li>
+      <li><p>{{page.download_checksums}} <a href="{{ PATH_PREFIX }}/SHA256SUMS">SHA256SUMS</a></p></li>
+
+      <li><p>{{page.download_checksums_sigs}} <a href="{{ PATH_PREFIX }}/SHA256SUMS.asc">SHA256SUMS.asc</a></p></li>
 
       <li><p>{{page.cd_to_downloads}}</p>
 
@@ -196,15 +211,17 @@
 
       <li><p>{{page.verify_download_checksum}}</p>
 
-        <pre class="highlight"><code>sha256sum --ignore-missing --check SHA256SUMS.asc</code></pre>
+        <pre class="highlight"><code>sha256sum --ignore-missing --check SHA256SUMS</code></pre>
 
         <p>{{page.checksum_warning_and_ok | replace, "$(SHASUMS_OK)", page.localized_checksum_ok}} <code>{{FILE_PREFIX}}-{{site.data.binaries.lin64}}: {{page.localized_checksum_ok}}</code></p></li>
 
-      <li><p>{{page.obtain_release_key}}</p>
+      <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
 
-        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{SIGNING_KEY_FINGERPRINT}}</code></pre>
+        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{page.example_builder_key}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
+
+      <li><p>{{page.choosing_builders | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url }}</p></li>
 
       <li>{{page.verify_checksums_file}}
 
@@ -215,7 +232,7 @@
           <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
         </ol>
 
-        <p>{{page.gpg_trust_warning}}</p></li>
+        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}</p></li>
 
     </ol>
   </details>

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -4,7 +4,7 @@ permalink: /en/download/
 type: pages
 layout: page
 lang: en
-version: 4
+version: 5
 
 ## These strings need to be localized.  In the listing below, the
 ## comment above each entry contains the English text.  The key before the
@@ -21,8 +21,10 @@ latestversion: "Latest version:"
 download: "Download Bitcoin Core"
 # downloados: "Or choose your operating system"
 downloados: "Or choose your operating system"
-# downloadsig: "Verify release signatures"
-downloadsig: "Verify release signatures"
+# download_sha: "SHA256 binary hashes"
+download_sha: "SHA256 binary hashes"
+# download_sig: "SHA256 hash signatures"
+download_sig: "SHA256 hash signatures"
 # downloadtorrent: "Download torrent"
 downloadtorrent: "Download torrent"
 # source: "Source code"
@@ -62,6 +64,7 @@ linux_instructions: "Linux verification instructions"
 snap_instructions: "Snap package verification instructions"
 download_release: "Click the link in the list above to download the release for your platform and wait for the file to finish downloading."
 download_checksums: "Download the list of cryptographic checksums:"
+download_checksums_sigs: "Download the signatures attesting to validity of the checksums:"
 cd_to_downloads: "Open a terminal (command line prompt) and Change Directory (cd) to the folder you use for downloads.  For example:"
 cd_example_linux: "cd Downloads/"
 cd_example_windows: >
@@ -69,18 +72,44 @@ cd_example_windows: >
 
 verify_download_checksum: "Verify that the checksum of the release file is listed in the checksums file using the following command:"
 checksum_warning_and_ok: 'In the output produced by the above command, you can safely ignore any warnings and failures, but you must ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
-obtain_release_key: "Obtain a copy of the release signing key by running the following command:"
+
+example_builder_key: "E777299FC265DD04793070EB944D35F9AC3DB76A"
+example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
+builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"
+
+obtain_release_key: >
+  Bitcoin releases are signed by a number of individuals, each with a unique public
+  key. In order to recognize the validity of signatures, you must use GPG to load these
+  public keys locally. You can find many developer keys listed in the <a
+  href='$(BUILDER_KEYS_URL)'>bitcoin/bitcoin repository</a>, which you can then load
+  into your GPG key database. For example, if you saw the line <pre
+  class='highlight'><code>$(EXAMPLE_BUILDERS_LINE)</code></pre>you could load that key
+  using this command:
+
+choosing_builders: >
+  It is recommended that you choose a few individuals from this list who you find
+  trustworthy and import their keys as above, or import all the keys per the
+  instructions in the <a href="$(BUILDER_KEYS_URL)"><code>contrib/builder-key</code>
+  README</a>. You will later use their keys to check the signature attesting to the
+  validity of the checksums you use to check the binaries.
+
 release_key_obtained: "The output of the command above should say that one key was imported, updated, has new signatures, or remained unchanged."
+
 verify_checksums_file: "Verify that the checksums file is PGP signed by the release signing key:"
-check_gpg_output: "Check the output from the above command for the following text:"
+
+check_gpg_output: >
+  The command above will output a series of signature checks for each of the public
+  keys that signed the checksums. Each signature will show the following text:
+
 line_starts_with: "A line that starts with:"
 complete_line_saying: "A complete line saying:"
+
 gpg_trust_warning: >
-  The output from the verify command may contain a warning that
-  the "key is not certified with a trusted signature." This means that
-  to fully verify your download, you need to ask people you trust to
-  confirm that the key fingerprint printed above belongs to the Bitcoin
-  Core Project's release signing key.
+  The output from the verify command may contain warnings that the "key is not
+  certified with a trusted signature." This means that to fully verify your download,
+  you need to confirm that the signing key's fingerprint (e.g.
+  <code>$(SHORT_BUILDER_KEY)</code>) listed in the second line above matches what
+  you had expected for the signers public key.
 
 localized_checksum_ok: "OK"
 localized_gpg_good_sig: "Good signature"
@@ -140,4 +169,3 @@ key_refresh: "Refresh expired keys using:"
 ---
 
 {% include templates/download.html %}
-

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -55,7 +55,15 @@ patient: "Check your bandwidth and space"
 
 pgp_key_fingerprint: "PGP key fingerprint"
 verify_download: "Verify your download"
-verification_recommended: "Download verification is optional but highly recommended.  Click one of the lines below to view verification instructions for that platform."
+
+verification_recommended: >
+  <p>Download verification is optional but highly recommended. Performing the
+  verification steps here ensures that you have not downloaded an unexpected or
+  tampered version of Bitcoin, which may result in loss of funds.</p> 
+
+  <p>Click one of the lines below to view verification instructions for that
+  platform.</p>
+
 windows_instructions: "Windows verification instructions"
 macos_instructions: "MacOS verification instructions"
 linux_instructions: "Linux verification instructions"

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -84,13 +84,16 @@ example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (f
 builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"
 
 obtain_release_key: >
-  Bitcoin releases are signed by a number of individuals, each with a unique public
+  <p>Bitcoin releases are signed by a number of individuals, each with a unique public
   key. In order to recognize the validity of signatures, you must use GPG to load these
   public keys locally. You can find many developer keys listed in the <a
   href='$(BUILDER_KEYS_URL)'>bitcoin/bitcoin repository</a>, which you can then load
-  into your GPG key database. For example, if you saw the line <pre
-  class='highlight'><code>$(EXAMPLE_BUILDERS_LINE)</code></pre>you could load that key
-  using this command:
+  into your GPG key database.</p>
+
+  <p>For example, given the <a href='$(BUILDER_KEYS_TXT_URL)'><code>
+  builders-key/keys.txt</code></a> line
+  <pre class='highlight'><code>$(EXAMPLE_BUILDERS_LINE)</code></pre>you could load that
+  key using this command:</p>
 
 choosing_builders: >
   It is recommended that you choose a few individuals from this list who you find

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -52,8 +52,6 @@ notesync: >
 full_node_guide: "For more information about setting up Bitcoin Core, please read the <a href=\"https://bitcoin.org/en/full-node\">full node guide</a>."
 # patient: "Check your bandwidth and space"
 patient: "Check your bandwidth and space"
-# releasekeys: "Bitcoin Core Release Signing Keys"
-releasekeys: "Bitcoin Core Release Signing Keys"
 
 pgp_key_fingerprint: "PGP key fingerprint"
 verify_download: "Verify your download"

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -79,7 +79,6 @@ cd_example_windows: >
 verify_download_checksum: "Verify that the checksum of the release file is listed in the checksums file using the following command:"
 checksum_warning_and_ok: 'In the output produced by the above command, you can safely ignore any warnings and failures, but you must ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
 
-example_builder_key: "E777299FC265DD04793070EB944D35F9AC3DB76A"
 example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
 builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"
 


### PR DESCRIPTION
Fixes https://github.com/bitcoin-core/bitcoincore.org/issues/793.

This updates the binary verification instructions to account for the new process, which uses multiple builder signatures on the `SHA256SUMS` file. See https://github.com/bitcoin/bitcoin/issues/22634 for more details.

![image](https://user-images.githubusercontent.com/73197/133864620-c6046d0e-34eb-448c-8769-2e22beb4563e.png)

### Possible follow-ups

- [ ] include instructions on how to elevate GPG trust of imported public keys.
- [ ] include a reference to https://github.com/bitcoin/bitcoin/pull/23020, pending its merge.