### PR TITLE
download: fix outdated use of page.obtain_release_key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,5 @@ test-slow:
 test-fast:
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
+	## Ensure that no template strings leak through liquid rendering
+	! find _site/ -name '*.html' | xargs grep '\$$(.*)'

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -186,7 +186,7 @@
       {{page.gpg_download_other}}
       <a href="{{GPG_DOWNLOAD_URL}}">{{page.gpg_download_options}}</a></p></li>
 
-      <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
+      <li><p>{{OBTAIN_RELEASE_KEY}}</p>
 
         <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
 
@@ -228,7 +228,7 @@
 
         <p>{{page.checksum_warning_and_ok | replace, "$(SHASUMS_OK)", page.localized_checksum_ok}} <code>{{FILE_PREFIX}}-{{site.data.binaries.lin64}}: {{page.localized_checksum_ok}}</code></p></li>
 
-      <li><p>{{page.obtain_release_key | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line}}</p>
+      <li><p>{{OBTAIN_RELEASE_KEY}}</p>
 
         <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
 


### PR DESCRIPTION
Ironically, @harding's comment in https://github.com/bitcoin-core/bitcoincore.org/pull/803#discussion_r712468502 was spot on. This fixes a lingering reference to `$(BUILDER_KEYS_TXT_URL)` in the macOS and Linux instructions.