### PR TITLE
Make Markdown linguist-detectable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.md linguist-detectable


### PR DESCRIPTION
Before this change, repository gets detected as:

HTML 95.5%
SCSS 2.9%
Python 0.5%
Shell 0.5%
JavaScript 0.3%
Go 0.2%
Other 0.1%

After this change, repository gets detected as:

Markdown 60.5%
HTML 37.6%
SCSS 1.2%
Python 0.2%
Shell 0.2%
JavaScript 0.1%
Other 0.2%

This change was added for a cosmetic effect on GitHub. It might be
good to go away once this repository is no longer hosted at GitHub, or
if GitHub ceases to use the line, or GitHub ceases to exist.
