### PR TITLE
Link to guix.sigs repo rather than gitian sigs

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -28,7 +28,7 @@
 {% assign GPG_DOWNLOAD_URL = "https://www.gnupg.org/download/index.en.html#binary" %}
 {% assign GPG_MACOS_DOWNLOAD_URL = "https://gpgtools.org/" %}
 {% assign GPG_WINDOWS_DOWNLOAD_URL = "https://gpg4win.org/download.html" %}
-{% assign GITIAN_REPOSITORY_URL = "https://github.com/bitcoin-core/gitian.sigs" %}
+{% assign GUIX_REPOSITORY_URL = "https://github.com/bitcoin-core/guix.sigs" %}
 {% endcapture %}
 <link rel="alternate" type="application/rss+xml" href="/en/releasesrss.xml" title="Bitcoin Core releases">
 <div class="download">
@@ -278,7 +278,7 @@
     <li><p><em>{{page.verified_reproduction}}</em> {{page.independently_reproducing}}</p></li>
   </ul>
 
-  <p>{{page.verifying_and_reproducing}} <a href="{{GITIAN_REPOSITORY_URL}}">{{page.gitian_repository}}</a>.</p>
+  <p>{{page.verifying_and_reproducing}} <a href="{{GUIX_REPOSITORY_URL}}">{{page.guix_repository}}</a>.</p>
 {% endif %}{% comment %}END VERSION > 1 CONTENT{% endcomment %}
 
 <hr>

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -170,7 +170,7 @@ verifying_and_reproducing: >
   provide you with the highest level of assurance currently available.
   For more information, visit the project's repository of
 
-gitian_repository: "trusted build process signatures"
+guix_repository: "trusted build process signatures"
 
 key_refresh: "Refresh expired keys using:"
 

--- a/_posts/ja/pages/2017-01-01-download.md
+++ b/_posts/ja/pages/2017-01-01-download.md
@@ -119,7 +119,7 @@ verifying_and_reproducing: >
   また、自分でバイナリを再生成することで、現在利用可能な最高レベルの保証が提供されます。
   詳細はプロジェクトの
 
-gitian_repository: " trusted build process signaturesリポジトリを参照ください。"
+guix_repository: " trusted build process signaturesリポジトリを参照ください。"
 
 ---
 


### PR DESCRIPTION
Guix is now the release process, and linking to gitian is at least
causing confusion, see https://github.com/bitcoin-core/docs/issues/76.