### PR TITLE
Fix wrong link in translation es

### DIFF
--- a/_posts/es/posts/2021-09-29-release-0.21.2.md
+++ b/_posts/es/posts/2021-09-29-release-0.21.2.md
@@ -3,6 +3,7 @@ title: Bitcoin Core 0.21.2 liberado
 name: blog-release-0.21.2
 id: es-blog-release-0.21.2
 lang: es
+permalink: /es/2021/09/29/release-0.21.2/
 type: posts
 layout: post
 


### PR DESCRIPTION
Before this change, "Espanol" > "Bitcoin Core 0.21.2 liberado" links
a wrong page, the Japanese release notice.

Should fix issue #844.
