### PR TITLE
Replace outdated "Mac OS X" with a modern "macOS"

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -48,7 +48,7 @@
       <div>
         <img src="/assets/images/os/med_osx.png" alt="osx">
         <span>
-          <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ site.data.binaries.macdmg }}">Mac OS X</a>
+          <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ site.data.binaries.macdmg }}">macOS</a>
           <span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}{{ site.data.binaries.macdmg }}" class="dl" id="macdmg">dmg</a> -
             <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-{{ site.data.binaries.mactar }}" class="dl" id="mactar">tar.gz</a></span>
         </span>


### PR DESCRIPTION
The oldest supported macOS version is 10.12 which [can run](https://bitcoincore.org/en/releases/0.21.2/) Bitcoin Core 0.21.x.

Therefore, there are no "Mac OS X" or "OS X" among supported OSes from Apple (https://en.wikipedia.org/wiki/MacOS_version_history).