### PR TITLE
Fix year in release post

### DIFF
--- a/_releases/0.20.2.md
+++ b/_releases/0.20.2.md
@@ -4,7 +4,7 @@ id: en-release-0.20.2
 name: release-0.20.2
 permalink: /en/releases/0.20.2/
 excerpt: Bitcoin Core version 0.20.2 is now available
-date: 2020-10-26
+date: 2021-10-26
 
 ## Use a YAML array for the version number to allow other parts of the
 ## site to correctly sort in "natural sort of version numbers"


### PR DESCRIPTION
Use

    git blame _releases/0.20.2.md

to check 2021 as published date for this release post.
