### PR TITLE
Update GPG4win path for easy user verification.html

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -118,7 +118,7 @@
   <h2 style="text-align: center" id="{{page.verify_download | slugify}}">{{page.verify_download}}</h2>
   {{page.verification_recommended}}
   <details>
-  {% assign GPG = "C:\Program Files\Gnu\GnuPg\gpg.exe" %}
+  {% assign GPG = "C:\Program Files (x86)\GnuPG\bin\gpg.exe" %}
     <summary><strong>{{page.windows_instructions}}</strong></summary>
     <ol>
       <li><p>{{page.download_release}}</p></li>


### PR DESCRIPTION
Updated the path to the Windows GPG installation to reflect the latest version of Gpg4win: "C:\Program Files (x86)\GnuPG\bin\gpg.exe"