### PR TITLE
Add `--ignore-missing` flag to `shasum` command on MacOS

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -19,9 +19,9 @@
 {% capture BUILDER_KEYS_TXT_URL %}{{page.builder_keys_url}}/keys.txt{% endcapture %}
 
 {% capture OBTAIN_RELEASE_KEY %}
-  {{page.obtain_release_key | 
-    replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | 
-    replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line | 
+  {{page.obtain_release_key |
+    replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url |
+    replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line |
     replace: '$(BUILDER_KEYS_TXT_URL)', BUILDER_KEYS_TXT_URL}}
 {% endcapture %}
 
@@ -186,7 +186,7 @@
 
       <li><p>{{page.verify_download_checksum}}</p>
 
-        <pre class="highlight"><code>shasum -a 256 --check SHA256SUMS</code></pre>
+        <pre class="highlight"><code>shasum -a 256 --ignore-missing --check SHA256SUMS</code></pre>
 
         <p>{{page.checksum_warning_and_ok | replace, "$(SHASUMS_OK)", page.localized_checksum_ok}} <code>{{FILE_PREFIX}}-{{site.data.binaries.macdmg}}: {{page.localized_checksum_ok}}</code></p></li>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -59,7 +59,7 @@ verify_download: "Verify your download"
 verification_recommended: >
   <p>Download verification is optional but highly recommended. Performing the
   verification steps here ensures that you have not downloaded an unexpected or
-  tampered version of Bitcoin, which may result in loss of funds.</p> 
+  tampered version of Bitcoin, which may result in loss of funds.</p>
 
   <p>Click one of the lines below to view verification instructions for that
   platform.</p>
@@ -77,7 +77,7 @@ cd_example_windows: >
   cd %UserProfile%\Downloads
 
 verify_download_checksum: "Verify that the checksum of the release file is listed in the checksums file using the following command:"
-checksum_warning_and_ok: 'In the output produced by the above command, you can safely ignore any warnings and failures, but you must ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
+checksum_warning_and_ok: 'In the output produced by the above command ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
 
 example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
 builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"


### PR DESCRIPTION
Shasum version 6 on MacOS also supports the `--ignore-missing` flag like on Linux. Allows for a cleaner user experience. 

**Question:**
Is there a some form of linting to define and take care of the whitespace stripping done on line 22 - 24? Or should those changes be reverted?

**To Do:**
The instructions for MacOS and Linux (https://bitcoincore.org/en/download/) still state: *In the output produced by the above command, you can safely ignore any warnings and failures, but you must ensure the output lists "OK" after the name of the release file you downloaded.* Think *you can safely ignore any warnings and failures* could be removed in both cases. And maybe add a warning that the output can be empty, in the case the user has no download at all in the current working directory.
