### PR TITLE
Update page.scss - Add Sticky Header/Fix Alignment

### DIFF
--- a/_sass/page.scss
+++ b/_sass/page.scss
@@ -14,6 +14,8 @@ body {
 
 .navigation-wrapper {
 	@include container;
+	position:sticky;
+	top:0;
 	padding: 0.3em 0 1em;
 	font-family: $heading-font;
 	font-weight: 700;
@@ -198,7 +200,7 @@ $button-size: 1.5rem;
 	}
 }
 .nav {
-	padding-top: 1.5em;
+	padding-top: 1.2em;
 }
 
 .nav li {


### PR DESCRIPTION
**Introduce a Sticky Header and Fix NavBar/Logo Alignment with 3 small CSS edits**

Results: Adds Sticky Header and also fixes alignment of NavBar so it aligns with the Site Logo

Steps Taken:

1. Created Sticky Header: Added `position:sticky;` and `top:0;` to .navigation-wrapper on page.scss
2. Fixed NavBar Alignment: Edited .nav on page.scss from `padding-top:1.5em;` to `padding-top:1.2em;`
3. Tested and verified locally as working