### PR TITLE
Adding pt-BR/rss

### DIFF
--- a/_posts/pt-BR/pages/2016-03-21-rss.md
+++ b/_posts/pt-BR/pages/2016-03-21-rss.md
@@ -1,0 +1,10 @@
+---
+title: RSS Feeds
+name: rss
+permalink: /pt-BR/rss/
+type: pages
+layout: page
+lang: pt-BR
+version: 1
+---
+{% include pages/rss.html %}


### PR DESCRIPTION
When translating pages into Portuguese, I get an error saying that there is no rss in Portuguese, so I'm trying to create to follow the page translations


https://github.com/bitcoin-core/bitcoincore.org/pull/905 https://github.com/bitcoin-core/bitcoincore.org/pull/906

Ref:
***
  *  internally linking to /pt-BR/rss/, which does not exist (line 197) <a href="/pt-BR/rss/">RSS <img src="/assets/images/rss-24x24.png" alt="rss feeds" width="14" height="14"></a> htmlproofer 3.14.1 | Error:  HTML-Proofer found 1 failure! make: *** [Makefile:15: test-slow] Error 1
***

Use this page to open Pull requests for changes to the Bitcoin Core project
website at [bitcoincore.org](https://bitcoincore.org).

[bitcoin.org](https://bitcoin.org) is not connected with or maintained by the
Bitcoin Core project contributors. Pull requests for changes to that website
should be opened at [the bitcoin.org
repository](https://github.com/bitcoin-dot-org/bitcoin.org/pulls).

General bitcoin questions and/or support requests are best directed to the
Bitcoin StackExchange at https://bitcoin.stackexchange.com.
