### PR TITLE
irc meetings: remove p2p meeting

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -11,11 +11,10 @@ The project holds several recurring meetings in the `#bitcoin-core-dev` IRC
 channel on Libera Chat ([webchat][bitcoin-core-dev-IRC-webchat]).  Everyone is welcome to attend.  Logs and
 automatically-generated meeting minutes may be found [here][erisian] and [here][schnelli].
 
-Current meeting schedule:
+Current meeting schedules are available on the developer wiki:
 
-- General developer meeting: Thursday 19:00 UTC (every week)
-- Wallet developer meeting: Friday 19:00 UTC (every second week)
-- P2P developer meeting: Tuesday 21:00 UTC (every second week)
+- General developer meeting: https://github.com/bitcoin-core/bitcoin-devwiki/wiki/General-IRC-meeting
+- Wallet developer meeting: https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Wallet-Current-Priorities-and-IRC-meetings
 
 Meeting times are also listed on [this Google calendar][meeting
 calendar].


### PR DESCRIPTION
This meeting is not regularly happening, and the last one was quite some time ago, remove its mention for now.