### PR TITLE
stats: increase assumed datadir size to 500GB

### DIFF
--- a/_data/stats.yml
+++ b/_data/stats.yml
@@ -1,7 +1,7 @@
 ## Size of the Bitcoin Core data directory running with default settings.
 ## Suggest rounding up by about 10% so it doesn't need to be updated
 ## too often.
-datadir_gb: "400"
+datadir_gb: "500"
 
 ## Size of the datadir with the maximum allowed pruning enabled.
 ## Suggest rounding up a little bit to give room for growth in the UTXO


### PR DESCRIPTION
See: https://github.com/bitcoin/bitcoin/blob/dce93b2dd7a96398058cd7ef0044a3d48b608cba/src/chainparams.cpp#L110.