### PR TITLE
Bitcoin Core 23.1

### DIFF
--- a/_posts/en/posts/2022-12-21-release-23.1.md
+++ b/_posts/en/posts/2022-12-21-release-23.1.md
@@ -1,0 +1,30 @@
+---
+title: Bitcoin Core 23.1 released
+name: blog-release-23.1
+id: en-blog-release-23.1
+lang: en
+type: posts
+layout: post
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+## Only true if release announcement or security annoucement. English posts only
+announcement: 1
+
+excerpt: >
+  Bitcoin Core 23.1 is now available.
+---
+Bitcoin Core version 23.1 is now available for [download][download
+page].  See the [release notes][] for more information about the many
+new features and bug fixes in this release.
+
+If you have any questions, please stop by the #bitcoin IRC chatroom
+([IRC][irc], [web][web irc]) and we’ll do our best to help you.
+
+[release notes]: /en/releases/23.1/
+[IRC]: irc://irc.libera.chat/bitcoin
+[web irc]: https://web.libera.chat/#bitcoin
+[download page]: /en/download
+
+{% include references.md %}

--- a/_releases/23.1.md
+++ b/_releases/23.1.md
@@ -1,0 +1,118 @@
+---
+title: Bitcoin Core 23.1
+id: en-release-23.1
+name: release-23.1
+permalink: /en/releases/23.1/
+excerpt: Bitcoin Core version 23.1 is now available
+date: 2022-12-21
+
+## Use a YAML array for the version number to allow other parts of the
+## site to correctly sort in "natural sort of version numbers".
+## Use the same number of elements as decimal places, e.g. "0.1.2 => [0,
+## 1, 2]" versus "1.2 => [1, 2]"
+release: [23, 1]
+
+## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
+## and View Details, or install the transmission-cli Debian/Ubuntu package
+## and run: transmission-show -m <torrent file>
+#
+## Link should be enclosed in quotes and start with: "magnet:?
+optional_magnetlink: "magnet:?xt=urn:btih:b3a5dd34839ba1f137402928809c51f9d75d9369&dn=bitcoin-core-23.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969"
+
+# Note: it is recommended to check all links to ensure they use
+#       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
+#       rather than relative urls (/bitcoin/bitcoin/doc/foo).
+---
+{% include download.html %}
+{% githubify https://github.com/bitcoin/bitcoin %}
+23.1 Release Notes
+==================
+
+Bitcoin Core version 23.1 is now available from:
+
+  <https://bitcoincore.org/bin/bitcoin-core-23.1/>
+
+This release includes new features, various bug fixes and performance
+improvements, as well as updated translations.
+
+Please report bugs using the issue tracker at GitHub:
+
+  <https://github.com/bitcoin/bitcoin/issues>
+
+To receive security and update notifications, please subscribe to:
+
+  <https://bitcoincore.org/en/list/announcements/join/>
+
+How to Upgrade
+==============
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes in some cases), then run the
+installer (on Windows) or just copy over `/Applications/Bitcoin-Qt` (on macOS)
+or `bitcoind`/`bitcoin-qt` (on Linux).
+
+Upgrading directly from a version of Bitcoin Core that has reached its EOL is
+possible, but it might take some time if the data directory needs to be migrated. Old
+wallet versions of Bitcoin Core are generally supported.
+
+Compatibility
+==============
+
+Bitcoin Core is supported and extensively tested on operating systems
+using the Linux kernel, macOS 10.15+, and Windows 7 and newer.  Bitcoin
+Core should also work on most other Unix-like systems but is not as
+frequently tested on them.  It is not recommended to use Bitcoin Core on
+unsupported systems.
+
+### P2P
+
+- #25314 p2p: always set nTime for self-advertisements
+
+### RPC and other APIs
+
+- #25220 rpc: fix incorrect warning for address type p2sh-segwit in createmultisig
+- #25237 rpc: Capture UniValue by ref for rpcdoccheck
+- #25983 Prevent data race for pathHandlers
+- #26275 Fix crash on deriveaddresses when index is 2147483647 (2^31-1)
+
+### Build system
+
+- #25201 windeploy: Renewed windows code signing certificate
+- #25788 guix: patch NSIS to remove .reloc sections from installer stubs
+- #25861 guix: use --build={arch}-guix-linux-gnu in cross toolchain
+- #25985 Revert "build: Use Homebrew's sqlite package if it is available"
+
+### GUI
+
+- #24668 build, qt: bump Qt5 version to 5.15.3
+- gui#631 Disallow encryption of watchonly wallets
+- gui#680 Fixes MacOS 13 segfault by preventing certain notifications
+
+### Tests
+
+- #24454 tests: Fix calculation of external input weights
+
+### Miscellaneous
+
+- #26321 Adjust .tx/config for new Transifex CLI
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Andrew Chow
+- brunoerg
+- Hennadii Stepanov
+- John Moffett
+- MacroFake
+- Martin Zumsande
+- Michael Ford
+- muxator
+- Pavol Rusnak
+- Sebastian Falbesoner
+- W. J. van der Laan
+
+As well as to everyone that helped with translations on
+[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+{% endgithubify %}


### PR DESCRIPTION
Add release pages for 23.1.
Same as https://github.com/bitcoin-core/bitcoincore.org/pull/869.