### PR TITLE
Re-add empty author sidebar to fix alignment

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,6 +29,7 @@
 {% endif %}
 
 <div id="main" role="main">
+  <div class="article-author-side">&nbsp;</div>
   <div id="index">
     {% assign navigation = site.data.navigation[page.lang] %}
     <h3><a href="{{ navigation.blog.url }}">Recent Posts</a></h3>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -29,6 +29,7 @@
 {% endif %}
 
 <div id="main" role="main">
+  <div class="article-author-side">&nbsp;</div>
   <article class="page">
     <h1>{{ page.title | xml_escape }}</h1>
     <div class="article-wrap">

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -29,6 +29,7 @@
 {% endif %}
 
 <div id="main" role="main">
+  <div class="article-author-side">&nbsp;</div>
   <div id="index">
     <h1>{{ page.title | xml_escape }}</h1>
     {% capture written_year %}'None'{% endcapture %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,6 +29,7 @@
 {% endif %}
 
 <div id="main" role="main">
+  <div class="article-author-side">&nbsp;</div>
   <article class="post h-entry">
     <div class="headline-wrap">
       {% if page.link %}


### PR DESCRIPTION
Prior to #863, an `article-author-side` sidebar ensured the main content was centered. This commit reintroduces the (empty) sidebar that #863 removed to fix the layout.

I have very little experience working with html/css so if there are more elegant solutions I'm open to that too, but this seems to revert to the old behaviour in a quite simple way.

Before:
![image](https://user-images.githubusercontent.com/69010457/204641428-01277e90-66f8-400d-a500-9746144d5934.png)

After:
![image](https://user-images.githubusercontent.com/69010457/204641455-2e7240df-499d-4524-b4d5-20bde66c66b6.png)
