### PR TITLE
fix typo: builders-key -> builder-keys

### DIFF
--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -90,7 +90,7 @@ obtain_release_key: >
   into your GPG key database.</p>
 
   <p>For example, given the <a href='$(BUILDER_KEYS_TXT_URL)'><code>
-  builders-key/keys.txt</code></a> line
+  builder-keys/keys.txt</code></a> line
   <code>$(EXAMPLE_BUILDERS_LINE)</code>you could load that
   key using this command:</p>
 

--- a/_posts/es/pages/2017-01-01-download.md
+++ b/_posts/es/pages/2017-01-01-download.md
@@ -93,7 +93,7 @@ obtain_release_key: >
   cargar en tu base de datos de claves GPG.</p>
 
   <p>Por ejemplo, dada la línea <a href='$(BUILDER_KEYS_TXT_URL)'><code>
-  builders-key/keys.txt</code></a>
+  builder-keys/keys.txt</code></a>
   <code>$(EXAMPLE_BUILDERS_LINE)</code> podrías cargar esa clave usando este
   comando:</p>
 


### PR DESCRIPTION
The underlying URL is not affected, only the link text is wrong

The full link is https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys/keys.txt