### PR TITLE
Fixup anchor link in japanese translation of 24.0.1

### DIFF
--- a/_posts/ja/releases/2022-12-12-release-24.0.1.md
+++ b/_posts/ja/releases/2022-12-12-release-24.0.1.md
@@ -198,7 +198,7 @@ P2Pとネットワークの変更 {#p2p-and-network-changes}
 
 - Guixビルドがアーキテクチャ間（x86_64とaarch64）で再現可能になりました。(#21194)
 
-新しい設定{#new-settings}
+新しい設定 {#new-settings}
 ------------
 
 - 新しい`mempoolfullrbf`オプションが追加され、


### PR DESCRIPTION
There was one error in the description of the anchor link.