### PR TITLE
download: update verify_checksums_file string

### DIFF
--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -103,7 +103,7 @@ choosing_builders: >
 
 release_key_obtained: "The output of the command above should say that one key was imported, updated, has new signatures, or remained unchanged."
 
-verify_checksums_file: "Verify that the checksums file is PGP signed by the release signing key:"
+verify_checksums_file: "Verify that the checksums file is PGP signed by a sufficient amount of keys you trust and have imported into your keychain:"
 
 check_gpg_output: >
   The command above will output a series of signature checks for each of the public


### PR DESCRIPTION
Remove reference to "trusted release signing key". Squashed version of #894.