### PR TITLE
Builder keys

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -24,9 +24,12 @@
 {% endcapture %}
 
 {% assign GPG_DOWNLOAD_URL = "https://www.gnupg.org/download/index.en.html#binary" %}
+{% assign GPG_VERIFY_KEYS_URL = "https://www.gnupg.org/gph/en/manual/x334.html" %}
 {% assign GPG_MACOS_DOWNLOAD_URL = "https://gpgtools.org/" %}
 {% assign GPG_WINDOWS_DOWNLOAD_URL = "https://gpg4win.org/download.html" %}
 {% assign GUIX_REPOSITORY_URL = "https://github.com/bitcoin-core/guix.sigs" %}
+{% assign GUIX_REPOSITORY_NAME = "guix.sigs" %}
+{% assign BUILDER_KEYS_DIR = "builder-keys" %}
 {% endcapture %}
 <link rel="alternate" type="application/rss+xml" href="/en/releasesrss.xml" title="Bitcoin Core releases">
 <div class="download">
@@ -207,7 +210,9 @@
 
         <p>{{page.release_key_obtained}}</p></li>
 
-      <li><p>{{page.choosing_builders | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url }}</p></li>
+      <li>{{page.choosing_builders}}
+
+        <pre class="highlight"><code>git clone {{GUIX_REPOSITORY_URL}}</code><br><code>gpg --import {{GUIX_REPOSITORY_NAME}}/{{BUILDER_KEYS_DIR}}/*</code></pre></li>
 
       <li>{{page.verify_checksums_file}}
 
@@ -218,7 +223,9 @@
           <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
         </ol>
 
-        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}</p></li>
+        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}
+           <a href="{{GPG_VERIFY_KEYS_URL}}">{{page.verify_keys}}</a>
+        </p></li>
     </ol>
   </details>
 

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -16,13 +16,11 @@
 {% capture SHORT_BUILDER_KEY %}
   {{example_builder_key | slice: 0, 4}}  {{ example_builder_key | slice: 4, 4 }}..
 .{% endcapture %}
-{% capture BUILDER_KEYS_TXT_URL %}{{page.builder_keys_url}}/keys.txt{% endcapture %}
 
 {% capture OBTAIN_RELEASE_KEY %}
   {{page.obtain_release_key | 
     replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url | 
-    replace: '$(EXAMPLE_BUILDERS_LINE)', page.example_builders_line | 
-    replace: '$(BUILDER_KEYS_TXT_URL)', BUILDER_KEYS_TXT_URL}}
+    replace: '$(EXAMPLE_BUILDER_KEY_FILE)', page.example_builder_key_file}}
 {% endcapture %}
 
 {% assign GPG_DOWNLOAD_URL = "https://www.gnupg.org/download/index.en.html#binary" %}
@@ -157,7 +155,7 @@
 
       <li>{{OBTAIN_RELEASE_KEY}}
 
-        <pre class="highlight"><code>{{GPG}}{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
+        <pre class="highlight"><code>{{GPG}} --import {{page.example_builder_key_file}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
 
@@ -205,7 +203,7 @@
 
       <li>{{OBTAIN_RELEASE_KEY}}
 
-        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
+        <pre class="highlight"><code>gpg --import {{page.example_builder_key_file}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
 
@@ -247,7 +245,7 @@
 
       <li>{{OBTAIN_RELEASE_KEY}}
 
-        <pre class="highlight"><code>gpg{{site.strings.gpg_keyserver}} --recv-keys {{example_builder_key}}</code></pre>
+        <pre class="highlight"><code>gpg --import {{page.example_builder_key_file}}</code></pre>
 
         <p>{{page.release_key_obtained}}</p></li>
 

--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -256,7 +256,9 @@
 
         <p>{{page.release_key_obtained}}</p></li>
 
-      <li><p>{{page.choosing_builders | replace: '$(BUILDER_KEYS_URL)', page.builder_keys_url }}</p></li>
+      <li>{{page.choosing_builders}}
+
+        <pre class="highlight"><code>git clone {{GUIX_REPOSITORY_URL}}</code><br><code>gpg --import {{GUIX_REPOSITORY_NAME}}/{{BUILDER_KEYS_DIR}}/*</code></pre></li>
 
       <li>{{page.verify_checksums_file}}
 
@@ -267,8 +269,9 @@
           <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
         </ol>
 
-        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}</p></li>
-
+        <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}
+           <a href="{{GPG_VERIFY_KEYS_URL}}">{{page.verify_keys}}</a>
+        </p></li>
     </ol>
   </details>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -97,10 +97,9 @@ obtain_release_key: >
 
 choosing_builders: >
   It is recommended that you choose a few individuals from this list who you find
-  trustworthy and import their keys as above, or import all the keys per the
-  instructions in the <a href="$(BUILDER_KEYS_URL)"><code>contrib/builder-key</code>
-  README</a>. You will later use their keys to check the signature attesting to the
-  validity of the checksums you use to check the binaries.
+  trustworthy and import their keys as above. You will later use their keys to
+  check the signature attesting to the validity of the checksums you use to check
+  the binaries. You can import all keys at once by cloning the repo and importing the directory:
 
 release_key_obtained: "The output of the command above should say that one key was imported, updated, has new signatures, or remained unchanged."
 
@@ -108,7 +107,7 @@ verify_checksums_file: "Verify that the checksums file is PGP signed by a suffic
 
 check_gpg_output: >
   The command above will output a series of signature checks for each of the public
-  keys that signed the checksums. Each signature will show the following text:
+  keys that signed the checksums. Each valid signature will show the following text:
 
 line_starts_with: "A line that starts with:"
 complete_line_saying: "A complete line saying:"
@@ -119,6 +118,8 @@ gpg_trust_warning: >
   you need to confirm that the signing key's fingerprint (e.g.
   <code>$(SHORT_BUILDER_KEY)</code>) listed in the second line above matches what
   you had expected for the signers public key.
+
+verify_keys: "See the GNU handbook section on key management for more details."
 
 localized_checksum_ok: "OK"
 localized_gpg_good_sig: "Good signature"

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -4,7 +4,7 @@ permalink: /en/download/
 type: pages
 layout: page
 lang: en
-version: 5
+version: 6
 
 ## These strings need to be localized.  In the listing below, the
 ## comment above each entry contains the English text.  The key before the
@@ -113,7 +113,9 @@ line_starts_with: "A line that starts with:"
 complete_line_saying: "A complete line saying:"
 
 gpg_trust_warning: >
-  The output from the verify command may contain warnings that the "key is not
+  The output from the verify command may contain warnings that a public key is not available.
+  As long as you have all the public keys of signers you trust, this warning can
+  be disregarded. There may be additional warnings that a "key is not
   certified with a trusted signature." This means that to fully verify your download,
   you need to confirm that the signing key's fingerprint (e.g.
   <code>$(SHORT_BUILDER_KEY)</code>) listed in the second line above matches what
@@ -165,13 +167,11 @@ independently_reproducing: >
   cryptographically sign and publish the checksums of the binaries they
   generate.
 verifying_and_reproducing: >
-  Verifying that several contributors you trust all signed the same
-  checksums distributed in the release checksums file will provide you
-  with additional assurances over the preceding basic verification
-  instructions.  Alternatively, reproducing a binary for yourself will
-  provide you with the highest level of assurance currently available.
-  For more information, visit the project's repository of
-
+  The preceding verification instructions will verify that several 
+  contributors you trust all signed the same checksums distributed in 
+  the release checksums file. Additionally, reproducing a binary for 
+  yourself will provide you with the highest level of assurance currently
+  available. For more information, visit the project's repository of
 guix_repository: "trusted build process signatures"
 
 key_refresh: "Refresh expired keys using:"

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -80,19 +80,20 @@ verify_download_checksum: "Verify that the checksum of the release file is liste
 checksum_warning_and_ok: 'In the output produced by the above command, you can safely ignore any warnings and failures, but you must ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
 
 example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
-builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"
+builder_keys_url: "https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys"
+example_builder_key_file: "fanquake.gpg"
 
 obtain_release_key: >
   <p>Bitcoin releases are signed by a number of individuals, each with a unique public
   key. In order to recognize the validity of signatures, you must use GPG to load these
   public keys locally. You can find many developer keys listed in the <a
-  href='$(BUILDER_KEYS_URL)'>bitcoin/bitcoin repository</a>, which you can then load
+  href='$(BUILDER_KEYS_URL)'>bitcoin-core/guix.sigs repository</a>, which you can then load
   into your GPG key database.</p>
 
-  <p>For example, given the <a href='$(BUILDER_KEYS_TXT_URL)'><code>
-  builder-keys/keys.txt</code></a> line
-  <code>$(EXAMPLE_BUILDERS_LINE)</code>you could load that
-  key using this command:</p>
+  <p>For example, you could load the key <a
+  href='$(BUILDER_KEYS_URL)/$(EXAMPLE_BUILDER_KEY_FILE)'><code>
+  builder-keys/$(EXAMPLE_BUILDER_KEY_FILE)</code></a> by downloading the file as <code>
+  $(EXAMPLE_BUILDER_KEY_FILE)</code> and using this command:</p>
 
 choosing_builders: >
   It is recommended that you choose a few individuals from this list who you find

--- a/_posts/es/pages/2017-01-01-download.md
+++ b/_posts/es/pages/2017-01-01-download.md
@@ -4,7 +4,7 @@ permalink: /es/download/
 type: pages
 layout: page
 lang: es
-version: 5
+version: 6
 translated: true
 
 ## These strings need to be localized.  In the listing below, the
@@ -83,29 +83,29 @@ checksum_warning_and_ok: 'En la salida producida por el comando superior, puedes
 
 example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
 builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"
+example_builder_key_file: "fanquake.gpg"
 
 obtain_release_key: >
-  <p>Las versiones de Bitcoin están firmadas por varias personas, cada una de ellas con
-  una clave pública única. Para reconocer la validez de las firmas, debes usar GPG para
-  cargar estas claves públicas localmente. Puedes encontrar muchas claves de
-  desarrolladores listadas en el <a
-  href='$(BUILDER_KEYS_URL)'>bitcoin/bitcoin repository</a>, las cuales puedes entonces
-  cargar en tu base de datos de claves GPG.</p>
+  <p>Las publicaciones de código son firmadas por varias personas, cada una de ellas
+  identificada por una única clave pública. Para poder validar las firmas, debes utilizar
+  GPG para cargar de forma local estas claves públicas. Encontrarás varias de las claves de
+  diversos desarroladores en <a href='$(BUILDER_KEYS_URL)'>el repositorio bitcoin-core/guix.sigs.</a>
+  Puedes utilizar esta lista para cargar las claves en tu base de datos de GPG.</p>
 
-  <p>Por ejemplo, dada la línea <a href='$(BUILDER_KEYS_TXT_URL)'><code>
-  builder-keys/keys.txt</code></a>
-  <code>$(EXAMPLE_BUILDERS_LINE)</code> podrías cargar esa clave usando este
-  comando:</p>
+  <p>Por ejemplo, puedes cargar la clave
+  <a href='$(BUILDER_KEYS_URL)/$(EXAMPLE_BUILDER_KEY_FILE)'><code>builder-keys/$(EXAMPLE_BUILDER_KEY_FILE)</code></a>
+  descargando el archivo <code>$(EXAMPLE_BUILDER_KEY_FILE)</code>
+  y utilizando el siguiente comando:</p>
 
 choosing_builders: >
-  Sería recomendable que eligieras varias personas de esta lista que estimes
-  confiables e importes sus claves según se indica arriba, o importes todas las
-  claves según las instrucciones en el documento <a
-  href="$(BUILDER_KEYS_URL)"><code>contrib/builder-key</code>
-  README</a>. Después usarás sus claves para comprobar las firmas que atestiguan la
-  validez de las checksums que usas para comprobar los programas binarios.
+  Es recomendable que elijas a varias de las personas de esta lista que consideres de
+  confianza e importes sus claves utilizando el método previamente explicado. Más
+  adelante, utilizarás sus claves para validar las firmas que atestan la validez
+  de las checksums que se proporcionan conjuntamente con los binarios del código.
+  Puedes importar todas las claves de una sola vez simplemente clonando el repositorio
+  e importando todo el directorio:
 
-release_key_obtained: "La salida del comando superior debería decir que una clave ha sido importada, actualizada, si tiene nuevas firmas, o si permanece sin cambios."
+release_key_obtained: "La respuesta del comando debería comunicarte que una clave ha sido importada, actualizada, posee nuevas firmas, o no ha sido modificada."
 
 verify_checksums_file: "Verifique que el fichero de checksums file está firmado PGP por la clave que firma la versión:"
 
@@ -118,12 +118,15 @@ line_starts_with: "Una línea que comienza por:"
 complete_line_saying: "Una línea completa que dice:"
 
 gpg_trust_warning: >
-  La salida del comando de verificación podría contener alertas de que "la clave
-  no está certificada con una firma confiable (key is not certified with a trusted
-  signature)". Esto significa que para verificar completamente la descarga, necesitas
-  confirmar que la huella de la clave firmante (p. ej.
-  <code>$(SHORT_BUILDER_KEY)</code>) listada en la segunda línea superior coincide
-  con lo que cabría esperar para la clave pública del firmante.
+  La respues del comando de verificación puede contener un aviso notificando que
+  la clave no está certificada con una firma de confianza ("key is not certified
+  with a trusted signature"). Esto significa que para poder verificar tu descarga
+  de forma completa, necesitas confirmar que la identificación de la clave de firmado
+  (e.g. <code>$(SHORT_BUILDER_KEY)</code>) listada en la segunda línea de la respuesta
+  del comando coincide con la clave pública del firmante que estabas esperando.
+  Revisa la sección de gestión de claves del manual de GNU para más detalles.
+
+verify_keys: "Consulte el manual de GNU para obtener más detalles."
 
 localized_checksum_ok: "OK"  # XXX
 localized_gpg_good_sig: "Good signature"  # XXX
@@ -174,15 +177,14 @@ independently_reproducing: >
   criptográficamente y publican las checksums de los binarios que hayan
   generado.
 verifying_and_reproducing: >
-  Verificar que varios contribuyentes en quienes confías han firmado
-  todos las mismas checksums distribuídas en el fichero de checksums de
-  la versión te proveerá de garantías adicionales de las instrucciones
-  básicas de verificación anteriores.  Alternativamente, reproducir un
-  programa binario por ti mismo te proveerá con el mayor de los niveles
-  de garantía actualmente disponibles.  Para más información, visita
-  el repositorio de
+  Las instrucciones de verificacion introducidas previamente verificaran que los
+  contribuidores en los que confias han firmado las checksums que se encuentran
+  en el archivo de checksums de la publicacion del codigo. De forma adicional,
+  generar los archivos binarios por ti mismo te proporcionara el mas alto nivel
+  de seguridad al que puedes aspirar. Para mas informacion, visita el repositorio
+  del
 
-guix_repository: "firmas del proceso de build confiable"
+guix_repository: "sistema de generacion de firmas de confianza"
 
 key_refresh: "Refresque las claves expiradas usando:"
 


### PR DESCRIPTION
Closes #945 
Closes https://github.com/bitcoin-core/bitcoincore.org/pull/957 (included)
Closes https://github.com/bitcoin-core/bitcoincore.org/pull/807 (included)
Closes https://github.com/bitcoin-core/bitcoincore.org/pull/878

download + verify procedure tested on macOS and Linux. I will go through it again on Windows tonight and add one more commit for that.