### PR TITLE
Remove external links that are no longer accessible.

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -9,7 +9,7 @@ version: 4
 ---
 The project holds several recurring meetings in the `#bitcoin-core-dev` IRC
 channel on Libera Chat ([webchat][bitcoin-core-dev-IRC-webchat]).  Everyone is welcome to attend.  Logs and
-automatically-generated meeting minutes may be found [here][erisian] and [here][schnelli].
+automatically-generated meeting minutes may be found [here][erisian].
 
 Current meeting schedules are available on the developer wiki:
 

--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -34,7 +34,6 @@ separate page][summaries].
 
 [bitcoin-core-dev-IRC-webchat]: https://web.libera.chat/#bitcoin-core-dev
 [erisian]: https://www.erisian.com.au/bitcoin-core-dev/
-[schnelli]: https://bitcoin.jonasschnelli.ch/ircmeetings/logs/bitcoin-core-dev/
 [meeting calendar]: https://calendar.google.com/calendar?cid=MTFwcXZkZ3BkOTlubGliZjliYTg2MXZ1OHNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
 [meeting calendar ical]: https://calendar.google.com/calendar/ical/11pqvdgpd99nlibf9ba861vu8s%40group.calendar.google.com/public/basic.ics
 [review club]: https://bitcoincore.reviews/


### PR DESCRIPTION
The link: https://bitcoin.jonasschnelli.ch/ is no longer accessible. I have removed it from the main branch to avoid having broken links and inaccessible information on the bitcoincore official website.