### PR TITLE
Sync security contact keys with security.md

### DIFF
--- a/_includes/dev-keys.md
+++ b/_includes/dev-keys.md
@@ -14,8 +14,8 @@
 
 | {{_includes_dev_keys-name}} | {{_includes_dev_keys-fingerprint}}         |
 |-----------------------------|--------------------------------------------|
-| Wladimir van der Laan       | <code>{% include fingerprint-split.html hex="71A3B16735405025D447E8F274810B012346C9A6" %}</code> |
 | Pieter Wuille               | <code>{% include fingerprint-split.html hex="133EAC179436F14A5CF1B794860FEB804E669320" %}</code> |
 | Michael Ford                | <code>{% include fingerprint-split.html hex="E777299FC265DD04793070EB944D35F9AC3DB76A" %}</code> |
+| Ava Chow                    | <code>{% include fingerprint-split.html hex="152812300785C96444D3334D17565732E08E5E41" %}</code> |
 
 {{_includes_dev_keys-import}}


### PR DESCRIPTION
The security contacts listed on the website differed from the SECURITY.md file in the bitcoin/bitcoin repo, they should be in sync.