### PR TITLE
Remove wallet meeting from meetings page

### DIFF
--- a/_posts/en/pages/2016-01-01-meetings.md
+++ b/_posts/en/pages/2016-01-01-meetings.md
@@ -14,7 +14,6 @@ automatically-generated meeting minutes may be found [here][erisian] and [here][
 Current meeting schedules are available on the developer wiki:
 
 - General developer meeting: https://github.com/bitcoin-core/bitcoin-devwiki/wiki/General-IRC-meeting
-- Wallet developer meeting: https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Wallet-Current-Priorities-and-IRC-meetings
 
 Meeting times are also listed on [this Google calendar][meeting
 calendar].


### PR DESCRIPTION
The wallet meeting was discontinued (IRC meeting 2023-05-11), and besides, the link here doesn't work.