### PR TITLE
ci: Use bundler 2.4.22

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ env:
 task:
   name: Bundler build
 
-  bootstrap_script: gem install bundler
+  bootstrap_script: gem install bundler -v 2.4.22
   bundler_cache:
     folder: /usr/local/bundle
     fingerprint_script:


### PR DESCRIPTION
The last version of bundle to support ruby 2.7.4 is 2.4.22. Should fix the current CI failure.