### PR TITLE
Add `--ignore-missing` flag to `shasum` command on MacOS

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -195,7 +195,7 @@
 
       <li><p>{{page.verify_download_checksum}}</p>
 
-        <pre class="highlight"><code>shasum -a 256 --check SHA256SUMS</code></pre>
+        <pre class="highlight"><code>shasum -a 256 --ignore-missing --check SHA256SUMS</code></pre>
 
         <p>{{page.checksum_warning_and_ok | replace, "$(SHASUMS_OK)", page.localized_checksum_ok}} <code>{{FILE_PREFIX}}-{{site.data.binaries.maczip}}: {{page.localized_checksum_ok}}</code></p></li>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -77,7 +77,7 @@ cd_example_windows: >
   cd %UserProfile%\Downloads
 
 verify_download_checksum: "Verify that the checksum of the release file is listed in the checksums file using the following command:"
-checksum_warning_and_ok: 'In the output produced by the above command, you can safely ignore any warnings and failures, but you must ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
+checksum_warning_and_ok: 'In the output produced by the above command ensure the output lists "$(SHASUMS_OK)" after the name of the release file you downloaded.  For example:'
 
 example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
 builder_keys_url: "https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys"


### PR DESCRIPTION
Picks up #892. This is a much more useful user experience.