### PR TITLE
download: default to ARM macOS downloads over x86_64

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -311,8 +311,7 @@ var linkwinexe = document.getElementById('downloadwinexe');
 var linkwinzip = document.getElementById('downloadwinzip');
 var hrefwin64exe = document.getElementById('win64exe').href;
 var hrefwin64zip = document.getElementById('win64zip').href;
-var hrefmaczip = document.getElementById('maczip').href;
-var hrefmactar = document.getElementById('mactar').href;
+var hrefmaczip = document.getElementById('macarmzip').href;
 var hreflin64 = document.getElementById('lin64').href;
 switch (os) {
 case 'windows64':


### PR DESCRIPTION
If a mac is detected by the browser, default to the ARM macOS download, rather than x86_64. This seems more reasonable at this point. In future, we might be able to use more advanced browser logic to detect the actual architecture dynamically. i.e https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues.