### PR TITLE
Update 2017-01-01-download.md

### DIFF
--- a/_posts/es/pages/2017-01-01-download.md
+++ b/_posts/es/pages/2017-01-01-download.md
@@ -82,7 +82,7 @@ verify_download_checksum: "Verifica que la checksum del fichero de la edición e
 checksum_warning_and_ok: 'En la salida producida por el comando superior, puedes ignorar cualquier alerta y fallo sin problema, pero debes asegurarte de que la salida lista "$(SHASUMS_OK)" después del nombre del fichero de la versión que has descargado.  Por ejemplo:'
 
 example_builders_line: "E777299FC265DD04793070EB944D35F9AC3DB76A Michael Ford (fanquake)"
-builder_keys_url: "https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys"
+builder_keys_url: "https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys"
 example_builder_key_file: "fanquake.gpg"
 
 obtain_release_key: >


### PR DESCRIPTION
In the link of https://bitcoincore.org/es/download/ where you have the different instructions to verify the links redirect to page that doesn't exist anymore.

The link of "builder_keys_url" is not `https://github.com/bitcoin/bitcoin/tree/master/contrib/builder-keys` the supposed to redirect. 


The correct value of builder_keys_url is: `https://github.com/bitcoin-core/guix.sigs/tree/main/builder-keys`

Also, the redirection of `fanquake.gpg` is `https://github.com/bitcoin-core/guix.sigs/blob/main/builder-keys/fanquake.gpg`


