### PR TITLE
release: Update 27.1 magnet url

### DIFF
--- a/_releases/27.1.md
+++ b/_releases/27.1.md
@@ -17,7 +17,7 @@ release: [27, 1]
 ## and run: transmission-show -m <torrent file>
 #
 ## Link should be enclosed in quotes and start with: "magnet:?
-optional_magnetlink: "magnet:?xt=urn:btih:39554dd8aae5688f462538a821d2227ea1b8cbb6&dn=bitcoin-core-27.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969&ws=http%3A%2F%2Fbitcoincore.org%2Fbin%2F"
+optional_magnetlink: "magnet:?xt=urn:btih:9e7fa35808fee6efc004a4d3b28e5cf9ce7770f2&dn=bitcoin-core-27.1&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969&ws=http://bitcoincore.org/bin/"
 
 # Note: it is recommended to check all links to ensure they use
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)


### PR DESCRIPTION
Since the SHA256SUMS.asc had to be reuploaded, the torrent has also changed. The magnet url should be updated to match the torrent file.