### PR TITLE
Security advisory followups

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -31,9 +31,9 @@ en:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle"
-      disclosures:
+      security-advisories:
         title: "Security Advisories"
-        url: "/en/security-advisories/"
+        url:   "/en/security-advisories/"
   contact:
     title: "Contact"
     submenu: true
@@ -79,6 +79,9 @@ zh_CN:
       eol:
         title: "生命周期"
         url:   "/zh_CN/lifecycle/"
+      security-advisories:
+        title: "Security Advisories"
+        url:   "/en/security-advisories/"
   contact:
     title: "联系"
     submenu: true
@@ -118,6 +121,9 @@ zh_TW:
       eol:
         title: "Lifecycle"
         url:   "/en/lifecycle/"
+      security-advisories:
+        title: "Security Advisories"
+        url:   "/en/security-advisories/"
   contact:
     title: "Contact"
     submenu: true
@@ -160,6 +166,9 @@ ja:
       eol:
         title: "ライフサイクル"
         url:   "/ja/lifecycle"
+      security-advisories:
+        title: "Security Advisories"
+        url:   "/en/security-advisories/"
   contact:
     title: "コンタクト"
     submenu: true
@@ -205,6 +214,9 @@ es:
       eol:
         title: "Lifecycle"  # XXX
         url:   "/en/lifecycle"  # XXX
+      security-advisories:
+        title: "Security Advisories"
+        url:   "/en/security-advisories/"
   contact:
     title: "Contact"  # XXX
     submenu: true

--- a/_layouts/feed.xml
+++ b/_layouts/feed.xml
@@ -10,7 +10,9 @@
         <uri>{{ site.url }}{{ post.url }}</uri>
     </author>
     {% assign posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
-    {% for post in posts limit:20 %}
+    {% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+    {% assign all=advisories | concat: posts | sort: "date" | reverse %}
+    {% for post in all limit:20 %}
     {% if post.author %}
     {% assign author = site.data.authors[post.author] %}
     {% else %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -36,7 +36,9 @@
     <!-- h3><a href="{{ navigation.blog.url }}">Recent Posts</a></h3 -->
       {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'posts' %}
       {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
-      {% for default_post in english_posts limit:5 %}
+      {% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+      {% assign all=advisories | concat: english_posts | sort: "date" | reverse %}
+      {% for default_post in all limit:5 %}
       {% assign post=default_post %}
       {% for tpost in translated_posts %}
         {% if tpost.name == post.name %}{% assign found=true %}{% assign post=tpost %}{% break %}{% endif %}

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -34,8 +34,10 @@
     <h1>{{ page.title | xml_escape }}</h1>
     {% capture written_year %}'None'{% endcapture %}
     {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'posts' %}
+    {% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+    {% assign all=advisories | concat: english_posts | sort: "date" | reverse %}
     {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
-    {% for default_post in english_posts %}
+    {% for default_post in all %}
       {% assign post=default_post %}
       {% for tpost in translated_posts %}
         {% if tpost.name == post.name %}{% assign found=true %}{% assign post=tpost %}{% break %}{% endif %}

--- a/_layouts/rss.xml
+++ b/_layouts/rss.xml
@@ -6,7 +6,9 @@
         <link>{{ site.url }}</link>
         <atom:link href="{{ site.url }}/{{ page.lang }}/rss.xml" rel="self" type="application/rss+xml" />
         {% assign posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
-        {% for post in posts %}
+        {% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+        {% assign all=advisories | concat: posts | sort: "date" | reverse %}
+        {% for post in all %}
         <item>
             <title>{{ post.title | strip_html }}</title>
             <description>{{ post.content | xml_escape | replace: "[[", " (" | replace: "]]", ")"}}</description>

--- a/_posts/en/pages/2024-06-26-security-advisories.md
+++ b/_posts/en/pages/2024-06-26-security-advisories.md
@@ -40,9 +40,9 @@ differentiate between 4 classes of vulnerabilities:
 
 ## Past Security Advisories
 
-{% assign disclosures=site.posts | where:"lang", 'en' | where:"type", 'disclosure' %}
-{% for default_disclosure in disclosures %}
-{% assign post=default_disclosure %}
+{% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+{% for advisory in advisories %}
+{% assign post=advisory %}
   <article>
     <h2><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title }}</a></h2>
     <p>{{ post.excerpt | markdownify | strip_html | truncate: 200 }}</p>

--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -3,7 +3,7 @@ title: CVE-2018-17144 Full Disclosure
 name: cve-2018-17144-full-disclosure
 id: en-cve-2018-17144-full-disclosure
 lang: en
-type: posts
+type: advisory
 layout: post
 
 ## If this is a new post, reset this counter to 1.

--- a/_posts/en/posts/2019-11-08-CVE-2017-18350.md
+++ b/_posts/en/posts/2019-11-08-CVE-2017-18350.md
@@ -3,7 +3,7 @@ title: CVE-2017-18350 Disclosure
 name: cve-2017-18350-disclosure
 id: en-2017-18350-disclosure
 lang: en
-type: posts
+type: advisory
 layout: post
 
 ## If this is a new post, reset this counter to 1.

--- a/_posts/ja/posts/2019-11-08-CVE-2017-18350.md
+++ b/_posts/ja/posts/2019-11-08-CVE-2017-18350.md
@@ -4,7 +4,7 @@ name: cve-2017-18350-disclosure
 id: ja-2017-18350-disclosure
 lang: ja
 permalink: /ja/2019/11/08/CVE-2017-18350/
-type: posts
+type: advisory
 layout: post
 
 ## If this is a new post, reset this counter to 1.

--- a/en/announcements.xml
+++ b/en/announcements.xml
@@ -10,7 +10,9 @@ lang: en
         <link>{{ site.url }}</link>
         <atom:link href="{{ site.url }}/{{ page.lang }}/announcements.xml" rel="self" type="application/rss+xml" />
         {% assign posts=site.posts | where:"lang", page.lang | where:"type", 'posts' | where: "announcement", 1 %}
-        {% for post in posts limit:5 %}
+        {% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+        {% assign all=advisories | concat: posts | sort: "date" | reverse %}
+        {% for post in all limit:5 %}
         <item>
             <title>{{ post.title | strip_html }}</title>
             <description>{{ post.content | xml_escape | replace: "[[", " (" | replace: "]]", ")"}}</description>


### PR DESCRIPTION
Followups to #1033.
* Ensure that both posts and advisories will be listed on the home/blog/other feeds.
* Rename some straggling instances of of disclosure to (security)-advisory.
* Add the missing menu item for translated pages (pointing to the en page for now).
  * cc azuchi, you might be interested in following up with a  translation for the japanese page?