### PR TITLE
build: add --strict_front_matter to build invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ all: build test
 
 preview:
 	bundle exec jekyll clean
-	bundle exec jekyll serve --future --drafts --unpublished --incremental
+	bundle exec jekyll serve --future --drafts --unpublished --incremental --strict_front_matter
 
 build:
 	bundle exec jekyll clean
-	bundle exec jekyll build --future --drafts --unpublished
+	bundle exec jekyll build --future --drafts --unpublished --strict_front_matter
 
 test: test-fast test-slow
 


### PR DESCRIPTION
Should help catch issues like those in #1042, which didn't cause the CI to fail.

```bash
bundle exec jekyll server --future --drafts --unpublished --incremental --strict_front_matter
...
 Incremental build: enabled
      Generating...
             Error: YAML Exception reading /bitcoincore.org/_posts/en/posts/2024-06-10-disclose-bip70-crash.md: (<unknown>): mapping values are not allowed in this context at line 2 column 18
                    ------------------------------------------------
```