### PR TITLE
27.1: fix formatting in release notes

### DIFF
--- a/_releases/27.1.md
+++ b/_releases/27.1.md
@@ -77,7 +77,7 @@ Notable changes
 - #29870 rpc: Reword SighashFromStr error message
 - #30094 rpc: move UniValue in blockToJSON
 
-### Index
+### Indexes
 
 - #29776 Fix #29767, set m_synced = true after Commit()
 


### PR DESCRIPTION
Not completely sure what the issue is, I guess we can't use the word Index, however this fixes the formatting of the release notes as currently shown on https://bitcoincore.org/en/releases/27.1/: 
![Format](https://github.com/bitcoin-core/bitcoincore.org/assets/863730/119528e7-bf5a-4c9b-b89a-b9ef90ea253d)
