### PR TITLE
Make titles/excerpts of disclosures more uniform

### DIFF
--- a/_posts/en/posts/2018-09-20-notice.md
+++ b/_posts/en/posts/2018-09-20-notice.md
@@ -1,5 +1,5 @@
 ---
-title: CVE-2018-17144 Full Disclosure
+title: Disclosure of CVE-2018-17144
 name: cve-2018-17144-full-disclosure
 id: en-cve-2018-17144-full-disclosure
 lang: en
@@ -13,9 +13,8 @@ version: 1
 announcement: 1
 
 excerpt: >
-  A full disclosure of the impact of CVE-2018-17144, a fix for which was
-  released on September 18th in Bitcoin Core versions 0.16.3 and
-  0.17.0RC4.
+  Bitcoin Core was vulnerable to a DoS and inflation attack. A fix was released on September 18th, 2018 in Bitcoin Core versions 0.16.3 and 0.17.0rc4.
+
 ---
 
 Full disclosure

--- a/_posts/en/posts/2019-11-08-CVE-2017-18350.md
+++ b/_posts/en/posts/2019-11-08-CVE-2017-18350.md
@@ -1,5 +1,5 @@
 ---
-title: CVE-2017-18350 Disclosure
+title: Disclosure of CVE-2017-18350
 name: cve-2017-18350-disclosure
 id: en-2017-18350-disclosure
 lang: en
@@ -13,8 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  Disclosure of the details of CVE-2017-18350, a fix for which was
-  released on November 6th, 2017 in Bitcoin Core version 0.15.1.
+  Nodes were potentially vulnerable to a buffer overflow by malicious SOCKS servers. A fix was released on November 6th, 2017 in Bitcoin Core version 0.15.1.
 ---
 {{page.excerpt}}
 

--- a/_posts/en/posts/2024-07-03-disclose-bip70-crash.md
+++ b/_posts/en/posts/2024-07-03-disclose-bip70-crash.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of crash due to malicious BIP72 URI (&le; version 0.19.2)
+title: Disclosure of crash using malicious BIP72 URI
 name: blog-disclose-bip70-crash
 id: en-blog-disclose-bip70-crash
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  The BIP70 implementation in Bitcoin Core could silently crash when opening a BIP72 URI.
+  The BIP70 implementation in Bitcoin-Qt could silently crash when opening a BIP72 URI. A fix was released on June 3rd, 2020 in Bitcoin Core 0.20.0.
 ---
 
 Bitcoin-Qt could crash upon opening a [BIP72](https://github.com/bitcoin/bips/blob/master/bip-0072.mediawiki) URI.

--- a/_posts/en/posts/2024-07-03-disclose-getdata-cpu.md
+++ b/_posts/en/posts/2024-07-03-disclose-getdata-cpu.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of CPU DoS due to malicious P2P message (&le; version 0.19.2)
+title: Disclosure of DoS using huge GETDATA messages
 name: blog-disclose-getdata-cpu
 id: en-blog-disclose-getdata-cpu
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  A malformed `GETDATA` message could trigger an infinite loop on the receiving node, using 100% of the CPU allocated to this thread.
+  A malformed `GETDATA` message could trigger 100% CPU usage on the receiving node. A fix was released on June 3rd, 2020 in Bitcoin Core 0.20.0.
 ---
 
 A malformed `GETDATA` message could trigger an infinite loop on the receiving node, using 100% of

--- a/_posts/en/posts/2024-07-03-disclose-header-spam.md
+++ b/_posts/en/posts/2024-07-03-disclose-header-spam.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of memory DoS using low-difficulty headers (&le; version 0.14.3)
+title: Disclosure of memory DoS using low-difficulty headers
 name: blog-disclose-header-spam-checkpoint-bypass
 id: en-blog-disclose-header-spam-checkpoint-bypass
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  After Bitcoin Core 0.12.0 and before Bitcoin Core 0.15.0 a node could be spammed with minimum difficulty headers, which could possibly be leveraged to crash it by OOM.
+  Nodes could be spammed with low-difficulty headers, which could be used to crash it. A fix was released on September 14th, 2017 in Bitcoin Core 0.15.0.
 ---
 
 After Bitcoin Core 0.12.0 and before Bitcoin Core 0.15.0 a node could be spammed with minimum

--- a/_posts/en/posts/2024-07-03-disclose-inv-buffer-blowup.md
+++ b/_posts/en/posts/2024-07-03-disclose-inv-buffer-blowup.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of memory DoS due to malicious P2P message (&le; version 0.19.2)
+title: Disclosure of memory DoS using huge INV messages
 name: blog-disclose-inv-buffer-blowup
 id: en-blog-disclose-inv-buffer-blowup
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  Public disclosure of a DoS vulnerability affecting old versions of Bitcoin Core
+  Nodes would allocate up to 50 MB of memory per attacker sending a malicious `INV` message. A fix was released on June 3rd, 2020 in Bitcoin Core 0.20.0.
 ---
 
 A node could be forced to allocate a significant amount of memory upon receiving a specially crafted

--- a/_posts/en/posts/2024-07-03-disclose-orphan-dos.md
+++ b/_posts/en/posts/2024-07-03-disclose-orphan-dos.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of CPU DoS / stalling due to malicious P2P message (&le; version 0.17.2)
+title: Disclosure of significant DoS due to orphan handling
 name: blog-disclose-orphan-dos
 id: en-blog-disclose-orphan-dos
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  A node could be stalled for hours when processing the orphans of a specially crafted unconfirmed transaction.
+  A node could be stalled for hours when receiving a specially crafted unconfirmed transaction. A fix was released on May 18th, 2019 in Bitcoin Core 0.18.0.
 ---
 
 A node could be stalled for hours when processing the orphans of a specially crafted unconfirmed

--- a/_posts/en/posts/2024-07-03-disclose-timestamp-overflow.md
+++ b/_posts/en/posts/2024-07-03-disclose-timestamp-overflow.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of netsplit due to malicious P2P messages by first 200 peers (&le; version 0.20.1)
+title: Disclosure of netsplit due to timestamp adjustment
 name: blog-disclose-timestamp-overflow
 id: en-blog-disclose-timestamp-overflow
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  Disclosure of the details of an integer overflow bug which risked causing a network split.
+  A node could be split from the network when attacked by its first 200 peers. A fix was released on January 15th, 2021 in Bitcoin Core version 0.21.0.
 ---
 
 Disclosure of the details of an integer overflow bug which risked causing a network split, a fix for

--- a/_posts/en/posts/2024-07-03-disclose-unbounded-banlist.md
+++ b/_posts/en/posts/2024-07-03-disclose-unbounded-banlist.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of CPU/memory DoS due to many malicious peers (&le; version 0.20.0)
+title: Disclosure of CVE-2020-14198
 name: blog-disclose-unbounded-banlist
 id: en-blog-disclose-unbounded-banlist
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  Bitcoin Core maintained an unlimited list of banned IP addresses and performed a quadratic operation on it. This could lead to an OOM crash and a CPU Dos.
+  Nodes could be subject to CPU and memory DoS when attacked by lots of distinct IPs. A fix was released on August 1st, 2020 in Bitcoin Core 0.20.1.
 ---
 
 Bitcoin Core maintained an unlimited list of banned IP addresses and performed a quadratic operation

--- a/_posts/en/posts/2024-07-03-disclose_already_asked_for.md
+++ b/_posts/en/posts/2024-07-03-disclose_already_asked_for.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of censoring unconfirmed transactions to a specific victim (&le; version 0.20.2)
+title: Disclosure of censorship due to transaction re-request handling
 name: blog-disclose-already-asked-for
 id: en-blog-disclose-already-asked-for
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  Public disclosure of a transaction relay censorship vulnerability affecting old versions of Bitcoin Core.
+  Nodes could be prevented from seeing specific unconfirmed transactions by a malicious peer. A fix was released on January 14th, 2021 in Bitcoin Core 0.21.0.
 ---
 
 An attacker could prevent a node from seeing a specific unconfirmed transaction.

--- a/_posts/en/posts/2024-07-03-disclose_receive_buffer_oom.md
+++ b/_posts/en/posts/2024-07-03-disclose_receive_buffer_oom.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of memory DoS due to malicious P2P message from many peers (&le; version 0.10.0)
+title: Disclosure of CVE-2015-3641
 name: blog-disclose-receive-buffer-oom
 id: en-blog-disclose-receive-buffer-oom
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  A node could be forced to allocate large buffers when receiving a message, which could be leveraged to remotely crash it by OOM.
+  Attackers sending large incomplete messages would cause high memory usage. A fix was released on April 27th, 2015 in Bitcoin Core 0.10.1.
 ---
 
 A node could be forced to allocate large buffers when receiving a message, which could be leveraged to remotely crash it by OOM.

--- a/_posts/en/posts/2024-07-03-disclose_upnp_rce.md
+++ b/_posts/en/posts/2024-07-03-disclose_upnp_rce.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of potential remote code execution due to bug in miniupnpc (&le; version 0.11.1)
+title: Disclosure of remote code execution due to bug in miniupnpc
 name: blog-disclose-upnp-rce
 id: en-blog-disclose-upnp-rce
 lang: en
@@ -13,7 +13,7 @@ version: 1
 announcement: 1
 
 excerpt: >
-  Public disclosure of a buffer overflow in miniupnpc which could have led to a remote code execution in Bitcoin Core.
+  A bug in the miniupnpc library could have led to a remote code execution in Bitcoin Core. A fix was released on October 15th, 2015 in Bitcoin Core 0.11.1.
 ---
 
 A buffer overflow enabling a significant data leak was discovered in `miniupnpc`. Combined with the then


### PR DESCRIPTION
This makes a number of changes to the titles and excerpts of the existing and new vulnerability disclosures:
* Use "Disclosure of [CVE number]" as title when a CVE is assigned.
* For vulnerabilities without known CVE put a very short description in the title.
* Drop latest version affected from the titles (it makes them too long, seeing it rendered).
* Include in the excerpts a short description of the vulnerability itself (but longer than the title), the date a fix was released, and in what version.
* Shorten all excerpts to no more than 160 characters (limit on homepage).
* Make titles/excerpts more uniform in style.