### PR TITLE
Security advisories for bugs fixed as of Bitcoin Core v22.0

### DIFF
--- a/_posts/en/posts/2024-07-31-disclose-addrman-int-overflow.md
+++ b/_posts/en/posts/2024-07-31-disclose-addrman-int-overflow.md
@@ -1,0 +1,45 @@
+---
+title: Disclosure of remote crash due to addr message spam
+name: blog-disclose-addrman-idcount-in-overflow
+id: blog-disclose-addrman-idcount-in-overflow
+lang: en
+type: advisory
+layout: post
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+## Only true if release announcement or security annoucement. English posts only
+announcement: 1
+
+excerpt: >
+  Nodes could be spammed with addr messsages, which could be used to crash them. A fix was released on September 14th, 2021 in Bitcoin Core v22.0.
+---
+
+Disclosure of the details of an integer overflow bug which causes an assertion
+crash, a fix for which was released on September 14th, 2021 in Bitcoin Core
+version v22.0.
+
+This issue is considered **High** severity.
+
+## Details
+
+`CAddrMan` has a 32-bit `nIdCount` field that is incremented on every insertion
+into addrman, and which then becomes the identifier for the new entry. By
+getting the victim to insert 2<sup>32</sup> entries (through e.g. spamming addr
+messages), this identifier overflows, which leads to an assertion crash.
+
+## Attribution
+
+Credit goes to Eugene Siegel for discovering and disclosing the vulnerability,
+and to Pieter Wuille for fixing the issue in
+https://github.com/bitcoin/bitcoin/pull/22387.
+
+## Timeline
+
+* 21-06-2021 - Initial report sent to security@bitcoincore.org by Eugene Siegel
+* 19-07-2021 - Fix is merged (https://github.com/bitcoin/bitcoin/pull/22387)
+* 13-09-2021 - v22.0 is released
+* 31-07-2024 - Public disclosure
+
+{% include references.md %}

--- a/_posts/en/posts/2024-07-31-disclose-upnp-oom.md
+++ b/_posts/en/posts/2024-07-31-disclose-upnp-oom.md
@@ -1,0 +1,52 @@
+---
+title: Disclosure of the impact of an infinite loop bug in the miniupnp dependency
+name: blog-disclose-miniupnp-bug-impact
+id: en-blog-disclose-miniupnp-bug-impact
+lang: en
+type: advisory
+layout: post
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+## Only true if release announcement or security annoucement. English posts only
+announcement: 1
+
+excerpt: >
+  Nodes could be crashed by a malicious UPnP device on the local network. A fix was released on September 14th, 2021 in Bitcoin Core v22.0.
+---
+
+Disclosure of the impact of an infinite loop bug in the miniupnp dependency on
+Bitcoin Core, a fix for which was released on September 14th, 2021 in Bitcoin
+Core version v22.0.
+
+This issue is considered **Low** severity.
+
+## Details
+
+Miniupnp, the UPnP library used by Bitcoin Core, would be waiting upon
+discovery for as long as it receives random data from a device on the network.
+In addition it would allocate memory for every new device information. An
+attacker on the local network could pretend to be a UPnP device and keep
+sending bloated M-SEARCH replies to the Bitcoin Core node until it runs out of
+memory.
+
+Only users running with the <code>-miniupnp</code> option would have been
+affected by this bug as Miniupnp is otherwise turned off by default.
+
+## Attribution
+
+Credit goes to Ronald Huveneers for reporting the infinite loop bug to the
+miniupnp project, and to Michael Ford (Fanquake) for the report to the Bitcoin
+Core project along with a PoC exploit to trigger an OOM and a pull request to
+bump the dependency (containing the fix).
+
+## Timeline
+
+* 17-09-2020 - Initial report of infinite loop bug to miniupnp by Ronald Huveneers
+* 13-10-2020 - Initial report sent to security@bitcoincore.org by Michael Ford
+* 23-03-2021 - Fix is merged (https://github.com/bitcoin/bitcoin/pull/20421)
+* 13-09-2021 - v22.0 is released
+* 31-07-2024 - Public disclosure
+
+{% include references.md %}


### PR DESCRIPTION
This publicly discloses 2 security vulnerabilities fixed in Bitcoin Core v22.0 and above.

These writeups result from a common effort to dig up and document past vulnerabilities with achow101 ajtowns fanquake dergoegge and sipa.