### PR TITLE
Remove fitVids function call

### DIFF
--- a/_includes/js/main.js
+++ b/_includes/js/main.js
@@ -45,11 +45,6 @@ document.onclick = function(e) {
 
 /*! Plugin options and other jQuery stuff */
 
-// FitVids options
-$(function() {
-	$("article").fitVids();
-});
-
 // Table of Contents toggle
 $(function() {
   $(".toc header").each(function(){


### PR DESCRIPTION
This code calls a function that does not exist, resulting in a Javascript error on every page load.

[fitVids](http://fitvidsjs.com) is a jQuery plugin that probably was part of the codebase at some point (but definitely is not now).

I don't think there are any videos on the site. I also think that there are modern CSS-based approaches to resizing videos that could be implemented if necessary.