### PR TITLE
RPC docs: fix broken links to tags >= v22.0

### DIFF
--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -24,7 +24,14 @@
     <div>
       <p>
         {% if page.btcversion != "index" %}
-          Documentation exported from <a href="https://github.com/bitcoin/bitcoin/tree/v{{page.btcversion}}">Bitcoin Core {{page.btcversion}}</a>
+          <!-- Since v22, the patch number is omitted in git tags, unless it is non-zero:
+            version  -> tag
+            0.21.0   -> v0.21.0
+            22.0.0   -> v22.0
+            24.0.1   -> v24.0.1
+          -->
+          {% assign tag_version = page.btcversion | replace: ".0.0", ".0" %}
+          Documentation exported from <a href="https://github.com/bitcoin/bitcoin/tree/v{{ tag_version }}">Bitcoin Core {{ tag_version }}</a>
         {% endif %}
       </p>
     </div>


### PR DESCRIPTION
Since v22, the patch number is omitted in git tags, unless it is non-zero.
```
  version  -> tag
  0.21.0   -> v0.21.0
  22.0.0   -> v22.0
  24.0.1   -> v24.0.1
```

This breaks the "Documentation exported from Bitcoin Core 28.0.0" link on the RPC documentation page: https://bitcoincore.org/en/doc/28.0.0/ (and other >= v22 pages)

Fix this by automatically removing the patch if both the minor and patch numbers are zero. This creates some inconsistency in that on the same page we'll refer to both "28.0.0" and "28.0", but that seems unavoidable if we don't want to break permalinks.

Alternatives considered:
1. for affected version, update the `btcversion` field in existing RPC docs and in `generate.go`, but that would change a bunch of permalinks, making them not very perma
2. for affected versions, introduce a new `git_tag` field and update `generate.go` to produce that alongside `btcversion`, but it's a lot more involved than the automatic parsing in this PR
3. add the `x.x.0` tags in `bitcoin/bitcoin` and update the release process going forward, but I think there'd be hesitancy adding new tags just for this

Fixes #1071 