### PR TITLE
Security advisories for vulnerabilities fixed in v25.0

### DIFF
--- a/_posts/en/posts/2024-10-08-disclose-blocktxn-crash.md
+++ b/_posts/en/posts/2024-10-08-disclose-blocktxn-crash.md
@@ -1,0 +1,73 @@
+---
+title: Disclosure of CVE-2024-35202
+name: blog-disclose-blocktxn-crash
+id: en-blog-disclose-blocktxn-crash
+lang: en
+type: advisory
+layout: post
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+## Only true if release announcement or security annoucement. English posts only
+announcement: 1
+
+excerpt: >
+  An attacker could remotely crash a Bitcoin Core node by triggering an
+  assertion in the blocktxn message handling logic.
+---
+
+Before Bitcoin Core v25.0, an attacker could remotely crash Bitcoin Core
+nodes by triggering an assertion in the blocktxn message handling logic.
+
+This issue is considered **High** severity.
+
+## Details
+
+When receiving a block announcement via a cmpctblock message, Bitcoin Core
+attempts to reconstruct the announced block using the transactions in its own
+mempool as well as other available transactions. If reconstruction fails due to
+missing transactions it will request them from the announcing peer via a
+getblocktxn message. In response a blocktxn message is expected, which should
+contain the requested transactions.
+
+The compact block protocol employs shortened transaction identifiers to reduce
+bandwidth. These short-ids are 6 byte in size, resulting in a small chance for
+collisions (i.e. transaction A has the same short-id as transaction B) upon
+block reconstruction. Collisions will be detected as the merkle root computed
+from the reconstructed set of transactions will not match the merkle root from
+the block announcement. Peers should not be punished for collisions as they may
+happen spuriously, therefore they are handled by falling back to requesting the
+full block.
+
+Bitcoin Core will create an instance of <code>PartiallyDownloadedBlock</code>
+whenever a new compact block is received. If missing transactions are
+requested, the instance is persisted until the corresponding blocktxn message
+is processed. Upon receiving the blocktxn message,
+<code>PartiallyDownloadedBlock::FillBlock</code> is called, attempting to
+reconstruct the full block. In the collision case described above, the full
+block is requested but the <code>PartiallyDownloadedBlock</code> instance as
+well as the other state related to the underlying block request is left
+untouched. This leaves room for a second blocktxn message for the same block to
+be processed and trigger <code>FillBlock</code> to be called again. This
+violates the assumption (documented as an <code>assert</code> statement) that
+<code>FillBlock</code> can only be called once and causes the node to crash.
+
+An attacker does not need to get lucky by triggering a collision, as the
+collision handling logic can easily be triggered by simply including
+transactions in the blocktxn message that are not committed to in the block's
+merkle root.
+
+## Attribution
+
+Credit goes to Niklas Gögge for discovering and disclosing the vulnerability,
+as well as fixing the issue in https://github.com/bitcoin/bitcoin/pull/26898.
+
+## Timeline
+
+* 2022-10-05 - Niklas Gögge reports the issue to the Bitcoin Core security mailing list.
+* 2023-01-24 - PR #26898 containing the fix is merged.
+* 2023-05-25 - Bitcoin Core 25.0 is released with the fix.
+* 2024-10-09 - Public disclosure.
+
+{% include references.md %}

--- a/_posts/en/posts/2024-10-08-disclose-large-inv-to-send.md
+++ b/_posts/en/posts/2024-10-08-disclose-large-inv-to-send.md
@@ -1,0 +1,64 @@
+---
+title: Disclosure of DoS due to inv-to-send sets growing too large
+name: blog-disclose-large-inv-to-send
+id: en-blog-disclose-large-inv-to-send
+lang: en
+type: advisory
+layout: post
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+## Only true if release announcement or security announcement. English posts only
+announcement: 1
+
+excerpt: >
+    The inv-to-send sets could grow too large to a point where the time spent sorting the sets would affect the node's ability to communicate with its peers.
+---
+
+Before Bitcoin Core v25.0, the per-peer `m_tx_inventory_to_send` sets could grow
+too large to a point where sorting these sets when constructing inventory
+messages would affect the node's ability to communicate with its peers. Network
+conditions in early May 2023 triggered this DoS and affected block and transaction
+propagation.
+
+This issue is considered **Medium** severity.
+
+## Details
+
+As part of transaction relay, Bitcoin Core maintains a per-peer
+`m_tx_inventory_to_send` set with transactions that should be announced to the
+peer. When constructing an inventory message for a peer, the set is sorted by
+transaction dependencies and feerate to prioritize high-feerate transactions and
+to avoid leaking the order the node learned about the transactions. Before
+Bitcoin Core v25.0, when constructing inventory messages, relevant (still in
+mempool, not yet announced to us by the peer, above the fee filter) transactions
+were being drained at a rate of 7 transactions per second.
+
+In early May 2023, increased network activity caused the sets to grow faster
+than they were being drained resulting in significant time spent sorting the
+sets in the P2P communication thread. Additionally, peers that only listen for
+transaction announcements but never announce any themselves (commonly referred
+to as "spy nodes"), amplified this by having huge sets (with transactions they
+already know about) that take a long time to sort. It was observed that sorting
+took up nearly the complete time spent in the P2P communication thread, which
+significantly affected block and transaction propagation as well as keeping
+connection with peers alive.
+
+This was fixed in [#27610](https://github.com/bitcoin/bitcoin/pull/27610) by 1)
+earlier removing transactions that aren't in the mempool anymore and 2) by
+dynamically increasing the set drainage rate depending on the set size.
+
+## Attribution
+
+Credit goes to Anthony Towns for working on a fix and to b10c for initially
+reporting and narrowing the problem down to the slow inv-to-send sorting.
+
+## Timeline
+
+- 2023-05-02 - Problem first observed and reported
+- 2023-05-11 - Fix is merged ([#27610](https://github.com/bitcoin/bitcoin/pull/27610))
+- 2023-05-25 - v25.0 is released
+- 2024-10-09 - Public disclosure
+
+{% include references.md %}

--- a/_posts/en/posts/2024-10-08-disclose-mutated-blocks-hindering-propagation.md
+++ b/_posts/en/posts/2024-10-08-disclose-mutated-blocks-hindering-propagation.md
@@ -1,0 +1,54 @@
+---
+title: Disclosure of hindered block propagation due to mutated blocks
+name: blog-disclose-mutated-blocks-hindering-propagation
+id: en-blog-disclose-mutated-blocks-hindering-propagation
+lang: en
+type: advisory
+layout: post
+
+## If this is a new post, reset this counter to 1.
+version: 1
+
+## Only true if release announcement or security announcement. English posts only
+announcement: 1
+
+excerpt: >
+    A peer could hinder block propagation by sending mutated blocks.
+---
+
+Before Bitcoin Core v25.0, a peer sending mutated blocks could clear the
+download state of other peers that also announced the block to us, which would
+hinder block propagation.
+
+This issue is considered **Medium** severity.
+
+## Details
+
+Bitcoin Core treats a block as mutated when, for example, the Merkle root in the
+header or the witness commitment in the coinbase transaction doesn't match the
+transactions in the block.
+
+Before Bitcoin Core v25.0, a peer could clear the block download state of
+other peers by sending an unrequested mutated block. This was a problem for, for
+example, compact block relay. After receiving a compact block and while waiting
+for a response to a `getblocktxn` request to reconstruct the full block,
+receiving the mutated block would let Bitcoin Core forget about the compact
+block reconstruction state. A `blocktxn` response arriving after the mutated
+block couldn't be used to reconstruct the block. This hindered block propagation.
+
+This was fixed in [#27608](https://github.com/bitcoin/bitcoin/pull/27608) by
+making sure that a peer can only affect its own block download state and not the
+download state of other peers.
+
+## Attribution
+
+Credit goes to Suhas Daftuar for noticing the problem and working on a fix.
+
+## Timeline
+
+- 2023-05-08 - A problem with mutated blocks is first reported in the [#bitcoin-core-dev IRC channel](https://bitcoin-irc.chaincode.com/bitcoin-core-dev/2023-05-08).
+- 2023-05-10 - Fix is merged ([#27608](https://github.com/bitcoin/bitcoin/pull/27608))
+- 2023-05-25 - v25.0 is released
+- 2024-10-09 - Public disclosure
+
+{% include references.md %}


### PR DESCRIPTION
This publicly discloses 3 security vulnerabilities fixed in Bitcoin Core v25.0 and above.