### PR TITLE
advisories: clarify low severity policy

### DIFF
--- a/_posts/en/pages/2024-06-26-security-advisories.md
+++ b/_posts/en/pages/2024-06-26-security-advisories.md
@@ -27,7 +27,7 @@ differentiate between 4 classes of vulnerabilities:
 
 * **Critical**: bugs which threaten the whole network's integrity. For instance an inflation or coin theft bug.
 
-**Low** severity bugs will be disclosed 2 weeks after a fixed version is released.
+**Low** severity bugs will be disclosed 2 weeks after a fixed version exists on the current major release branch.
   A pre-announcement will be made at the same time as the release.
 
 **Medium** and **High** severity bugs will be disclosed 2 weeks after the [last


### PR DESCRIPTION
Clarify that low severity issues will be disclosed after a fix exists in the current major release branch.

For example, if an issue is fixed in master, and then released in v29.0, if would be pre-announced, at the time of the v29.0 release, and made public 2 weeks later.

If an issue was fixed in master, it could also be backported to the current release branch, i.e 28.x, and then be in the next release of that branch, i.e v28.1. In that case, it would be pre-announced with the v28.1 release, and made public 2 weeks later.