### PR TITLE
Update security advisories with recently assigned CVE IDs

### DIFF
--- a/_posts/en/posts/2024-07-03-disclose-bip70-crash.md
+++ b/_posts/en/posts/2024-07-03-disclose-bip70-crash.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of crash using malicious BIP72 URI
+title: CVE-2024-52918 - Crash using malicious BIP72 URI
 name: blog-disclose-bip70-crash
 id: en-blog-disclose-bip70-crash
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose-getdata-cpu.md
+++ b/_posts/en/posts/2024-07-03-disclose-getdata-cpu.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of DoS using huge GETDATA messages
+title: CVE-2024-52920 - DoS using huge GETDATA messages
 name: blog-disclose-getdata-cpu
 id: en-blog-disclose-getdata-cpu
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose-header-spam.md
+++ b/_posts/en/posts/2024-07-03-disclose-header-spam.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of memory DoS using low-difficulty headers
+title: CVE-2024-52916 - Memory DoS using low-difficulty headers
 name: blog-disclose-header-spam-checkpoint-bypass
 id: en-blog-disclose-header-spam-checkpoint-bypass
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose-inv-buffer-blowup.md
+++ b/_posts/en/posts/2024-07-03-disclose-inv-buffer-blowup.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of memory DoS using huge INV messages
+title: CVE-2024-52915 - Memory DoS using huge INV messages
 name: blog-disclose-inv-buffer-blowup
 id: en-blog-disclose-inv-buffer-blowup
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose-orphan-dos.md
+++ b/_posts/en/posts/2024-07-03-disclose-orphan-dos.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of significant DoS due to orphan handling
+title: CVE-2024-52914 - Significant DoS due to orphan handling
 name: blog-disclose-orphan-dos
 id: en-blog-disclose-orphan-dos
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose-timestamp-overflow.md
+++ b/_posts/en/posts/2024-07-03-disclose-timestamp-overflow.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of netsplit due to timestamp adjustment
+title: CVE-2024-52912 - Netsplit due to timestamp adjustment
 name: blog-disclose-timestamp-overflow
 id: en-blog-disclose-timestamp-overflow
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose_already_asked_for.md
+++ b/_posts/en/posts/2024-07-03-disclose_already_asked_for.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of censorship due to transaction re-request handling
+title: CVE-2024-52913 - Censorship due to transaction re-request handling
 name: blog-disclose-already-asked-for
 id: en-blog-disclose-already-asked-for
 lang: en

--- a/_posts/en/posts/2024-07-03-disclose_upnp_rce.md
+++ b/_posts/en/posts/2024-07-03-disclose_upnp_rce.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of remote code execution due to bug in miniupnpc
+title: CVE-2015-20111 - Remote code execution due to bug in miniupnpc
 name: blog-disclose-upnp-rce
 id: en-blog-disclose-upnp-rce
 lang: en

--- a/_posts/en/posts/2024-07-31-disclose-addrman-int-overflow.md
+++ b/_posts/en/posts/2024-07-31-disclose-addrman-int-overflow.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of remote crash due to addr message spam
+title: CVE-2024-52919 - Remote crash due to addr message spam
 name: blog-disclose-addrman-idcount-in-overflow
 id: blog-disclose-addrman-idcount-in-overflow
 lang: en

--- a/_posts/en/posts/2024-07-31-disclose-upnp-oom.md
+++ b/_posts/en/posts/2024-07-31-disclose-upnp-oom.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of the impact of an infinite loop bug in the miniupnp dependency
+title: CVE-2024-52917 - Infinite loop bug in the miniupnp dependency
 name: blog-disclose-miniupnp-bug-impact
 id: en-blog-disclose-miniupnp-bug-impact
 lang: en

--- a/_posts/en/posts/2024-09-18-disclose-headers-oom.md
+++ b/_posts/en/posts/2024-09-18-disclose-headers-oom.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of memory DoS due to headers spam
+title: CVE-2019-25220 - Memory DoS due to headers spam
 name: blog-disclose-headers-oom
 id: en-blog-disclose-headers-oom
 lang: en

--- a/_posts/en/posts/2024-10-08-disclose-mutated-blocks-hindering-propagation.md
+++ b/_posts/en/posts/2024-10-08-disclose-mutated-blocks-hindering-propagation.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of hindered block propagation due to mutated blocks
+title: CVE-2024-52921 - Hindered block propagation due to mutated blocks
 name: blog-disclose-mutated-blocks-hindering-propagation
 id: en-blog-disclose-mutated-blocks-hindering-propagation
 lang: en

--- a/_posts/en/posts/2024-11-05-cb-stall-hindering-propagation.md
+++ b/_posts/en/posts/2024-11-05-cb-stall-hindering-propagation.md
@@ -1,5 +1,5 @@
 ---
-title: Disclosure of hindered block propagation due to stalling peers
+title: CVE-2024-52922 - Hindered block propagation due to stalling peers
 name: blog-disclose-stalling-peers-hindering-propagation
 id: en-blog-disclose-stalling-peers-hindering-propagation
 lang: en


### PR DESCRIPTION
Only the `inv-to-send` advisory doesn't have one because there is a misunderstanding who claims it should be `CVE-2023-33297`. I explained it is an ID which was claimed by a troll on behalf of the project and i'm now awaiting their response. I don't think it should be a blocker to publish the other 13 IDs.