### PR TITLE
update mailing list link

### DIFF
--- a/_includes/references.md
+++ b/_includes/references.md
@@ -123,10 +123,9 @@
 [issues]: https://github.com/bitcoin/bitcoin/issues
 [pulls]: https://github.com/bitcoin/bitcoin/pulls
 [BitcoinCoreDocBips]: https://github.com/bitcoin/bitcoin/blob/master/doc/bips.md
-[bitcoin-discuss]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-discuss
-[bitcoin-dev]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev
-[bitcoin-core-dev]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-core-dev
+[bitcoin-dev]: https://groups.google.com/g/bitcoindev
 [software life cycle]: /en/lifecycle
+[bitcoin core blog]: /en/blog/
 
 [laanwj-key]: https://pgp.mit.edu/pks/lookup?op=get&search=0x71A3B16735405025D447E8F274810B012346C9A6
 [jonasschnelli-key]: https://pgp.mit.edu/pks/lookup?op=get&search=0x32EE5C4C3FA15CCADB46ABE529D4BCB6416F53EC

--- a/_posts/en/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/en/pages/list/2016-03-10-announcements-join.md
@@ -9,10 +9,10 @@ version: 3
 ---
 Receive notification of important security announcements and releases for Bitcoin Core.
 
-Subscribe to the RSS feed below or add your email address to the [bitcoin-core-dev][] mailing list.
+Subscribe to the RSS feed below or check the [bitcoin core blog][] section.
+
+The announcements list is currently not available.
 
 {% include pages/list/announcement.html %}
-    
-Low traffic for announcements only.
 
 {% include references.md %}

--- a/_posts/ja/pages/list/2016-03-10-announcements-join.md
+++ b/_posts/ja/pages/list/2016-03-10-announcements-join.md
@@ -9,10 +9,10 @@ version: 3
 ---
 Bitcoin Coreの重要なセキュリティのお知らせとリリースの通知を受け取ります。
 
-以下のRSSフィードを購読するか、[bitcoin-core-dev][]メーリングリストにメールアドレスを登録してください。
+以下のRSSフィードを購読するか、[Bitcoin Coreブログ][bitcoin core blog]セクションをチェックしてください。
+
+お知らせリストは現在利用できません。
 
 {% include pages/list/announcement.html %}
-    
-お知らせのみなので送信されるメールの量はわずかです。
 
-{% include references.md %}
+[bitcoin core blog]: /ja/blog/

--- a/_posts/zh_CN/pages/2016-01-01-contribute.md
+++ b/_posts/zh_CN/pages/2016-01-01-contribute.md
@@ -24,7 +24,7 @@ version: 0
 **讨论**
 
 大多数比特币核心相关的讨论发生在 irc.freenode.net 上的 [#bitcoin-core-dev] IRC（互联网中继聊天） 频道。
-比特币协议讨论区 [bitcoin-dev][] 和一个普通比特币讨论区 [bitcoin-discuss][].
+[bitcoin-dev][] 有一个比特币协议讨论区。
 
 **为本网站做出贡献**
 


### PR DESCRIPTION
Mailing list link in: https://bitcoincore.org/en/list/announcements/join/ still points to the old linuxfoundation mailing list.

I found in the same file this other mailing lists that point to linuxfoundation, I'm not aware of them so I didn't touch, if there are new lists for them also, feel free to leave a comment and I can update all three in the same PR:
```
[bitcoin-discuss]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-discuss
[bitcoin-dev]: http://lists.linuxfoundation.org/mailman/listinfo/bitcoin-dev
[bitcoin-core-dev]: https://groups.google.com/g/bitcoindev
```