### PR TITLE
Fix code block rendering in 29.0 Release Notes

### DIFF
--- a/_releases/29.0.md
+++ b/_releases/29.0.md
@@ -164,19 +164,25 @@ replace-by-fee the standard behavior. (#30592)
 
 The build system has been migrated from Autotools to CMake:
 
-1. The minimum required CMake version is 3.22.
-2. In-source builds are not allowed. When using a subdirectory within the root source tree as a build directory, it is recommended that its name includes the substring "build".
-3. CMake variables may be used to configure the build system. **Some defaults have changed.** For example, you will now need to add `-DWITH_ZMQ=ON` to build with zmq and `-DBUILD_GUI=ON` to build `bitcoin-qt`. See [Autotools to CMake Options Mapping](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Autotools-to-CMake-Options-Mapping) for details.
-4. For single-configuration generators, the default build configuration (`CMAKE_BUILD_TYPE`) is "RelWithDebInfo". However, for the "Release" configuration, CMake defaults to the compiler optimization flag `-O3`, which has not been extensively tested with Bitcoin Core. Therefore, the build system replaces it with `-O2`.
-5. By default, the built executables and libraries are located in the `bin/` and `lib/` subdirectories of the build directory.
-6. The build system supports component‐based installation. The names of the installable components coincide with the build target names. For example:
+- The minimum required CMake version is 3.22.
+
+- In-source builds are not allowed. When using a subdirectory within the root source tree as a build directory, it is recommended that its name includes the substring "build".
+
+- CMake variables may be used to configure the build system. **Some defaults have changed.** For example, you will now need to add `-DWITH_ZMQ=ON` to build with zmq and `-DBUILD_GUI=ON` to build `bitcoin-qt`. See [Autotools to CMake Options Mapping](https://github.com/bitcoin-core/bitcoin-devwiki/wiki/Autotools-to-CMake-Options-Mapping) for details.
+
+- For single-configuration generators, the default build configuration (`CMAKE_BUILD_TYPE`) is "RelWithDebInfo". However, for the "Release" configuration, CMake defaults to the compiler optimization flag `-O3`, which has not been extensively tested with Bitcoin Core. Therefore, the build system replaces it with `-O2`.
+
+- By default, the built executables and libraries are located in the `bin/` and `lib/` subdirectories of the build directory.
+
+- The build system supports component‐based installation. The names of the installable components coincide with the build target names. For example:
+
 ```
 cmake -B build
 cmake --build build --target bitcoind
 cmake --install build --component bitcoind
 ```
 
-7. If any of the `CPPFLAGS`, `CFLAGS`, `CXXFLAGS` or `LDFLAGS` environment variables were used in your Autotools-based build process, you should instead use the corresponding CMake variables (`APPEND_CPPFLAGS`, `APPEND_CFLAGS`, `APPEND_CXXFLAGS` and `APPEND_LDFLAGS`). Alternatively, if you opt to use the dedicated `CMAKE_<...>_FLAGS` variables, you must ensure that the resulting compiler or linker invocations are as expected.
+- If any of the `CPPFLAGS`, `CFLAGS`, `CXXFLAGS` or `LDFLAGS` environment variables were used in your Autotools-based build process, you should instead use the corresponding CMake variables (`APPEND_CPPFLAGS`, `APPEND_CFLAGS`, `APPEND_CXXFLAGS` and `APPEND_LDFLAGS`). Alternatively, if you opt to use the dedicated `CMAKE_<...>_FLAGS` variables, you must ensure that the resulting compiler or linker invocations are as expected.
 
 For more detailed guidance on configuring and using CMake, please refer to the official [CMake documentation](https://cmake.org/cmake/help/latest/) and [CMake’s User Interaction Guide](https://cmake.org/cmake/help/latest/guide/user-interaction/index.html). Additionally, consult platform-specific `doc/build-*.md` build guides for instructions tailored to your operating system.
 


### PR DESCRIPTION
On the master branch @ 56264987d13d18d6a80678cb82bf676fb8a61b30, the code block is incorrectly rendered as a single line:

![image](https://github.com/user-attachments/assets/8c74bd70-790b-4206-8da4-55fe9f45e3bf)

This PR ensures it is displayed correctly over three lines:

![image](https://github.com/user-attachments/assets/94c6231e-16f9-43f9-a293-e9d576d1c721)

Numbering has been replaced with bullets, as the rendering engine otherwise restarts numbering from 1 after the code block.