### PR TITLE
29.0: Fix code block in numbered list

### DIFF
--- a/_releases/29.0.md
+++ b/_releases/29.0.md
@@ -170,11 +170,10 @@ The build system has been migrated from Autotools to CMake:
 4. For single-configuration generators, the default build configuration (`CMAKE_BUILD_TYPE`) is "RelWithDebInfo". However, for the "Release" configuration, CMake defaults to the compiler optimization flag `-O3`, which has not been extensively tested with Bitcoin Core. Therefore, the build system replaces it with `-O2`.
 5. By default, the built executables and libraries are located in the `bin/` and `lib/` subdirectories of the build directory.
 6. The build system supports component‐based installation. The names of the installable components coincide with the build target names. For example:
-```
-cmake -B build
-cmake --build build --target bitcoind
-cmake --install build --component bitcoind
-```
+
+        cmake -B build
+        cmake --build build --target bitcoind
+        cmake --install build --component bitcoind
 
 7. If any of the `CPPFLAGS`, `CFLAGS`, `CXXFLAGS` or `LDFLAGS` environment variables were used in your Autotools-based build process, you should instead use the corresponding CMake variables (`APPEND_CPPFLAGS`, `APPEND_CFLAGS`, `APPEND_CXXFLAGS` and `APPEND_LDFLAGS`). Alternatively, if you opt to use the dedicated `CMAKE_<...>_FLAGS` variables, you must ensure that the resulting compiler or linker invocations are as expected.
 


### PR DESCRIPTION
Fix the code block rendering to correctly show the three commands on separate lines.

Alternative to #1124 