### PR TITLE
Change ARM Linux default download to 64-bit

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -73,7 +73,7 @@
       <div>
         <img src="/assets/images/os/arm.png" alt="ARM Linux">
         <span>
-          <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-arm-linux-gnueabihf.tar.gz" class="dl">ARM Linux</a>
+          <a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-aarch64-linux-gnu.tar.gz" class="dl">ARM Linux</a>
           	<span><a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-aarch64-linux-gnu.tar.gz" class="dl" id="lin64arm">64 bit</a> -
             	<a href="{{ PATH_PREFIX }}/{{ FILE_PREFIX }}-arm-linux-gnueabihf.tar.gz" class="dl" id="lin32arm">32 bit</a></span>
         </span>


### PR DESCRIPTION
Change the default for ARM to the aarch64 download. 64-bit ARM is the standard nowadays for the type of computing hardware our users tend to have (Raspberri pi's and servers). While 32-bit ARM is only still used in low-power embedded systems.

Closes #1099.