### PR TITLE
blog: add redirect for disclose-cve-2024-52919 post

### DIFF
--- a/_posts/en/posts/2025-04-28-disclose-cve-2024-52919.md
+++ b/_posts/en/posts/2025-04-28-disclose-cve-2024-52919.md
@@ -5,6 +5,8 @@ id: blog-disclose-cve-2024-52919
 lang: en
 type: advisory
 layout: post
+redirect_from:
+  - /en/2025/03/31/disclose-cve-2024-52919
 
 ## If this is a new post, reset this counter to 1.
 version: 1


### PR DESCRIPTION
I changed the URL of this post, but that was after it was posted to the mailing list, this has caused some amount of confusion. Add a redirect, so if anyone hits the original link, they'll end up in the right place.

See: https://groups.google.com/g/bitcoindev/c/v2mwcWtgfxM.