### PR TITLE
releases: add posted-on date to release post

### DIFF
--- a/_includes/posted_on.html
+++ b/_includes/posted_on.html
@@ -1,0 +1,3 @@
+<p>
+	Posted: {{ page.date | date: "%B %d, %Y" }}
+</p>

--- a/_releases/27.0.md
+++ b/_releases/27.0.md
@@ -23,6 +23,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:2b2d123e5e831b245fb1dc5b8b71f89de4a90d
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 27.0 Release Notes

--- a/_releases/27.1.md
+++ b/_releases/27.1.md
@@ -23,6 +23,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:9e7fa35808fee6efc004a4d3b28e5cf9ce7770
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 27.1 Release Notes

--- a/_releases/27.2.md
+++ b/_releases/27.2.md
@@ -23,6 +23,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:f21febdf8c54d2a9b09ed54f7eebb909537fb7
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 27.2 Release Notes

--- a/_releases/28.0.md
+++ b/_releases/28.0.md
@@ -23,6 +23,7 @@ optional_magnetlink: magnet:?xt=urn:btih:e18e92024fc9d4026cf8cdef174f03c24080fd1
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 28.0 Release Notes

--- a/_releases/28.1.md
+++ b/_releases/28.1.md
@@ -23,6 +23,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:60837ded9c7e11b2a44f2ae7bc8e6fe3a3d7ee
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 28.1 Release Notes

--- a/_releases/28.2.md
+++ b/_releases/28.2.md
@@ -23,6 +23,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:7afc299da40a45400e560d535324c7147fc47a
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 28.2 Release Notes

--- a/_releases/29.0.md
+++ b/_releases/29.0.md
@@ -23,6 +23,7 @@ optional_magnetlink: "magnet:?xt=urn:btih:c2ebe360dc7e85d9850196ea57712c8ddffbcd
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)
 #       rather than relative urls (/bitcoin/bitcoin/doc/foo).
 ---
+{% include posted_on.html %}
 {% include download.html %}
 {% githubify https://github.com/bitcoin/bitcoin %}
 29.0 Release Notes


### PR DESCRIPTION
Displays the date of the post below the title. 
Added to the most recent releases (could do all).
Related to #1159.

<img width="609" height="348" alt="29 0" src="https://github.com/user-attachments/assets/a6bb0f2f-4f58-46f6-bde3-16efdcc7ff7c" />