### PR TITLE
fix(layout): broken mobile margins on release page

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -109,8 +109,15 @@
       <a href="/en/releases">{{ page.versionhistory }}</a>
     </p>
     <p class="downloadkeys">
-      {% if page.version > 2 %}<i>{{page.key_refresh}}</i><br><code>gpg{{site.strings.gpg_keyserver}} --refresh-keys</code>{% endif %}
-    </p>
+  {% if page.version > 2 %}
+    <i>{{ page.key_refresh }}</i><br>
+  {% endif %}
+</p>
+{% if page.version > 2 %}
+  <pre class="highlight code-pad" style="white-space: normal; word-break: break-word; overflow-wrap: anywhere; padding: 0.5rem;">
+    <code>gpg{{site.strings.gpg_keyserver}} --refresh-keys</code>
+  </pre>
+{% endif %}
   </div>
 
 </div>
@@ -168,8 +175,13 @@
         <pre class="highlight"><code>{{GPG}} --verify SHA256SUMS.asc</code></pre></li>
 
       <li><p>{{page.check_gpg_output}}</p>
-        <ol><li><p>{{page.line_starts_with}} <code>gpg: {{page.localized_gpg_good_sig}}</code></p></li>
-          <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
+        <ol>
+          <li><p>{{page.line_starts_with}}</p>
+            <pre class="highlight"><code>gpg: {{page.localized_gpg_good_sig}}</code></pre>
+          </li>
+          <li><p>{{page.complete_line_saying}}</p>
+            <pre class="highlight"><code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></pre>
+          </li>
         </ol>
 
         <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}</p></li>
@@ -218,8 +230,13 @@
         <pre class="highlight"><code>gpg --verify SHA256SUMS.asc</code></pre></li>
 
       <li><p>{{page.check_gpg_output}}</p>
-        <ol><li><p>{{page.line_starts_with}} <code>gpg: {{page.localized_gpg_good_sig}}</code></p></li>
-          <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
+        <ol>
+          <li><p>{{page.line_starts_with}}</p>
+            <pre class="highlight"><code>gpg: {{page.localized_gpg_good_sig}}</code></pre>
+          </li>
+          <li><p>{{page.complete_line_saying}}</p>
+            <pre class="highlight"><code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></pre>
+          </li>
         </ol>
 
         <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}
@@ -264,8 +281,13 @@
         <pre class="highlight"><code>gpg --verify SHA256SUMS.asc</code></pre></li>
 
       <li><p>{{page.check_gpg_output}}</p>
-        <ol><li><p>{{page.line_starts_with}} <code>gpg: {{page.localized_gpg_good_sig}}</code></p></li>
-          <li><p>{{page.complete_line_saying}} <code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></p></li>
+        <ol>
+          <li><p>{{page.line_starts_with}}</p>
+            <pre class="highlight"><code>gpg: {{page.localized_gpg_good_sig}}</code></pre>
+          </li>
+          <li><p>{{page.complete_line_saying}}</p>
+            <pre class="highlight"><code>{{page.localized_gpg_primary_fingerprint}} {{SIGNING_KEY_FINGERPRINT_EXPLODED}}</code></pre>
+          </li>
         </ol>
 
         <p>{{page.gpg_trust_warning | replace: '$(SHORT_BUILDER_KEY)', SHORT_BUILDER_KEY }}


### PR DESCRIPTION
## Description

On mobile screen sizes, inline codes inside of `downloadkeys` and each of the OS verification instructions are overflowing and breaking the right page margin causing the entire page's width to increase on mobile screen sizes and become scrollable; this also breaks the header and footer. The OS instructions currently break the page margin only when `details` is opened to reveal its content.

Rather than edit global behaviors for inline code to wrap down or become scrollable on overflow, the simplest solution is to just replace them with fenced code blocks; most of the other code blocks there are already that type anyway so it appears more consistent. The inline code for `downloadkeys` when replaced with a fenced code block apparently would not become scrollable despite applying different several techniques including with inline styling, so ultimately I opted to make that particular code block just wrap down.

**This fix will:**
- replace overflowing inline code in `details` with scrollable fenced code blocks.
- replace gpg inline code with fenced code block for stylistic consistency.
- replace `downloadkeys` inline code with a fenced code block that wraps down (since horizontal scroll proved unreliable).

**No global styling changes are made**

> Even though on smaller screens the `downloadkeys` code snippet wraps down onto a second line, it still copy-pastes as a single string, the effect is purely visual.

Tested the fix with Chrome and Firefox on desktop and mobile app versions; the page now behaves as expected.

**Before - `downloadkeys` - 400px screen size**
![download-BEFORE-top](https://github.com/user-attachments/assets/fb0bb83a-349e-4df2-b38a-a4c7d8fe0224)

**After - `downloadkeys` - 400px screen size**
![download-AFTER-top](https://github.com/user-attachments/assets/3cc72d14-5ecc-451c-819b-b369a624d02a)

**Before - Instructions**
![download-BEFORE-instructions](https://github.com/user-attachments/assets/8497f7b1-a054-4aa2-87e9-6e4abd020245)

**After - Instructions**
![download-AFTER-instructions](https://github.com/user-attachments/assets/bbc2f5d5-27d3-425d-b205-e07d8d492cad)
