### PR TITLE
Clarify pre announcements for security advisories

### DIFF
--- a/_posts/en/pages/2024-06-26-security-advisories.md
+++ b/_posts/en/pages/2024-06-26-security-advisories.md
@@ -89,11 +89,10 @@ Examples:
 
 ---
 
-**Low** severity bugs will be disclosed 2 weeks after a fixed version exists on the current major release branch.
-
-**Medium** and **High** severity bugs will be disclosed 2 weeks after the [last
-  affected release goes EOL](/en/lifecycle/). This is a year after a fixed version was first
-  released.
+**Low** severity vulnerabilities will be disclosed 2 weeks after the release of a major version
+containing the fix. **Medium** and **High** severity vulnerabilities will be disclosed 2 weeks after
+the last affected release goes [End of Life](/en/lifecycle/) (approximately a year after a major
+version containing the fix was first released).
 
 A pre-announcement will be made two weeks prior to releasing the details of a vulnerability. This
 pre-announcement will coincide with the release of a new major version and contain the number of


### PR DESCRIPTION
Be explicit about the content of our pre-announcements. Take the opportunity to cleanup the paragraph on timelines.

Here is the rendered version:
<img width="1049" height="240" alt="image" src="https://github.com/user-attachments/assets/6fb5ec36-83b5-4420-a6e4-f21ac3e42f1e" />
