### PR TITLE
Add AssumeUTXO snapshot

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -5,7 +5,10 @@
      http://opensource.org/licenses/MIT. -->
 {% assign VERSION_SORTED_RELEASES = site.releases | sort: 'release' | reverse %}
 {% capture CURRENT_RELEASE %}{% for subver in VERSION_SORTED_RELEASES[0].release %}{{subver}}{% unless forloop.last %}.{% endunless %}{% endfor %}{% endcapture %}
+{% capture FULL_VERSION %}{% for subver in VERSION_SORTED_RELEASES[0].btcversion %}{{subver}}{% unless forloop.last %}.{% endunless %}{% endfor %}{% endcapture %}
 {% assign magnet = VERSION_SORTED_RELEASES[0].optional_magnetlink %}
+{% assign snapshot_magnet = VERSION_SORTED_RELEASES[0].snapshot_magnet %}
+{% assign UTXO_SNAPSHOT_HEIGHT = VERSION_SORTED_RELEASES[0].snapshot_height %}
 {% capture PATH_PREFIX %}/bin/bitcoin-core-{{CURRENT_RELEASE}}{% endcapture %}
 {% capture FILE_PREFIX %}bitcoin-{{CURRENT_RELEASE}}{% endcapture %}
 {% assign builder_line_arr = page.example_builders_line | split: ' ' %}
@@ -295,6 +298,16 @@
 
   <p>{{page.verifying_and_reproducing}} <a href="{{GUIX_REPOSITORY_URL}}">{{page.guix_repository}}</a>.</p>
 {% endif %}{% comment %}END VERSION > 1 CONTENT{% endcomment %}
+
+  <h2 style="text-align: center">{{page.assume_utxo}}</h2>
+
+  <p>{{page.assume_utxo_steps | replace: '$(FULL_VERSION)', FULL_VERSION | replace: '$(UTXO_SNAPSHOT_HEIGHT)', UTXO_SNAPSHOT_HEIGHT }}</p>
+
+  <ul>
+    <li>
+      Torrent magnet: <a href="{{ snapshot_magnet | replace: '&', '\&amp;'}}" class="magnetlink" data-proofer-ignore></a><br>
+    </li>
+  </ul>
 
 <hr>
 

--- a/_posts/en/pages/2017-01-01-download.md
+++ b/_posts/en/pages/2017-01-01-download.md
@@ -176,6 +176,10 @@ guix_repository: "trusted build process signatures"
 
 key_refresh: "Refresh expired keys using:"
 
+assume_utxo: "AssumeUTXO Snapshot"
+assume_utxo_steps: >
+  The following UTXO snapshot can be used to quickly sync from block $(UTXO_SNAPSHOT_HEIGHT) to the tip. Use the <a href='https://bitcoincore.org/en/doc/$(FULL_VERSION)/rpc/blockchain/loadtxoutset/'>loadtxoutset</a> RPC to load it.
+
 ---
 
 {% include templates/download.html %}

--- a/_releases/30.0.md
+++ b/_releases/30.0.md
@@ -12,13 +12,21 @@ date: 2025-10-10
 ## 1, 2]" versus "1.2 => [1, 2]"
 release: [30, 0]
 
+## Full version for links to RPC docs
+btcversion: 30.0.0
+
 ## Optional magnet link.  To get it, open the torrent in a good BitTorrent client
 ## and View Details, or install the transmission-cli Debian/Ubuntu package
 ## and run: transmission-show -m <torrent file>
 #
 ## Link should be enclosed in quotes and start with: "magnet:?
-optional_magnetlink: "magnet:?xt=urn:btih:503f19ccf3347fb0045a18ac5c90b7b3ec33264a&dn=bitcoin-core-30.0&xl=5100393877&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969&ws=http://bitcoincore.org/bin/
-"
+optional_magnetlink: "magnet:?xt=urn:btih:503f19ccf3347fb0045a18ac5c90b7b3ec33264a&dn=bitcoin-core-30.0&xl=5100393877&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969&ws=http://bitcoincore.org/bin/"
+
+## Height of the most recent AssumeUTXO snapshot
+snapshot_height: 910_000
+
+## Torrent for the most recent AssumeUTXO snapshot
+snapshot_magnet: "magnet:?xt=urn:btih:7019437a2b1530624b100c0795cfc5f90b8322ca&dn=utxo-910000.dat&tr=udp%3A%2F%2Ftracker.openbittorrent.com%3A80&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.bitcoin.sprovoost.nl%3A6969"
 
 # Note: it is recommended to check all links to ensure they use
 #       absolute urls (https://github.com/bitcoin/bitcoin/doc/foo)


### PR DESCRIPTION
This adds a magnet link and brief instructions to the bottom of the Download page.

> # AssumeUTXO Snapshot
> The following UTXO snapshot can be used to quickly sync from block 910000 to the tip. Use the loadtxoutset RPC to load it.
> • Torrent magnet: 🧲

It's just a magnet link right now, but I can add a "Download torrent" link if we commit to hosting the `.torrent` file.

Fixes #1130 