### PR TITLE
Fix overlapping text in multi-line post title

### DIFF
--- a/_sass/mixins.scss
+++ b/_sass/mixins.scss
@@ -57,7 +57,7 @@
 @mixin font-size($size) {
   font-size: 0px + $size;
   font-size: 0rem + $size / $doc-font-size;
-  line-height: 0 + round($doc-line-height / $size*10000) / 10000;
+  line-height: max(1.2, $doc-line-height / $size);
   margin-bottom: 0px + $doc-line-height;
   margin-bottom: 0rem + ($doc-line-height / $doc-font-size);
 }
@@ -80,7 +80,7 @@
 @mixin font($size) {
   font-size: 0px + $size;
   font-size: 0rem + $size / $doc-font-size;
-  line-height: 0 + round($doc-line-height / $size*10000) / 10000;
+  line-height: max(1.2, $doc-line-height / $size);
 }
 
 /*


### PR DESCRIPTION
When a title spans two lines, the characters on the upper and lower lines overlap, making it difficult to read. To address this, we add line-height to the CSS to create some spacing.

English:
<img width="668" height="167" alt="image" src="https://github.com/user-attachments/assets/9801a871-6bad-46be-bea0-5a99fc4b733c" />

Japanese:
<img width="668" height="167" alt="image" src="https://github.com/user-attachments/assets/403f44da-a068-4664-a9cf-3aae8f0ed097" />

In English, lowercase letters are still somewhat readable, but uppercase letters or other languages become hard to read.

Below is the result after adding line-height to the CSS.

English:
<img width="668" height="192" alt="image" src="https://github.com/user-attachments/assets/e79749cb-5b6c-4fbc-808b-b160d4c6a7dc" />

Japanese:
<img width="668" height="192" alt="image" src="https://github.com/user-attachments/assets/a30f8035-9768-4f07-ad03-75ced9463012" />

