### PR TITLE
Add release artifacts documentation page

### DIFF
--- a/_posts/en/pages/2026-02-10-release-artifacts.md
+++ b/_posts/en/pages/2026-02-10-release-artifacts.md
@@ -12,7 +12,7 @@ Bitcoin Core release files are hosted at [https://bitcoincore.org/bin/](https://
 
 ## Build Suffixes
 
-- **Standard Binaries** (`.tar.gz`, `.zip`, `-setup.exe`): Production-ready, signed binaries for general use.
+- **Standard Binaries** (`.tar.gz`, `.zip`, `-setup.exe`): Production-ready binaries for general use.
 - **`-debug`**: Includes symbols for backtrace generation. Larger file size and reduced performance.
 - **`-unsigned`**: Raw Guix build outputs. Used to audit reproducibility against signed releases.
 - **`-codesigning`**: Intermediate artifacts for macOS/Windows signing ceremonies. Not for end-users.
@@ -22,7 +22,7 @@ Bitcoin Core release files are hosted at [https://bitcoincore.org/bin/](https://
 
 | File | Description |
 |------|-------------|
-| `SHA256SUMS` | Manifest of all release file hashes. |
+| `SHA256SUMS` |  Hashes of all release artifacts. |
 | `SHA256SUMS.asc` | Detached GPG signatures from trusted signers. |
 | `SHA256SUMS.ots` | OpenTimestamps proof. |
 

--- a/_posts/en/pages/2026-02-10-release-artifacts.md
+++ b/_posts/en/pages/2026-02-10-release-artifacts.md
@@ -1,0 +1,29 @@
+---
+title: Release Artifacts
+name: release-artifacts
+type: pages
+layout: page
+lang: en
+permalink: /en/release-artifacts/
+version: 1
+---
+
+Bitcoin Core release files are hosted at [https://bitcoincore.org/bin/](https://bitcoincore.org/bin/) and distributed via torrent.
+
+## Build Suffixes
+
+- **Standard Binaries** (`.tar.gz`, `.zip`, `-setup.exe`): Production-ready, signed binaries for general use.
+- **`-debug`**: Includes symbols for backtrace generation. Larger file size and reduced performance.
+- **`-unsigned`**: Raw Guix build outputs. Used to audit reproducibility against signed releases.
+- **`-codesigning`**: Intermediate artifacts for macOS/Windows signing ceremonies. Not for end-users.
+- **Source**: `bitcoin-<version>.tar.gz` (no platform string). For manual compilation.
+
+## Verification Files
+
+| File | Description |
+|------|-------------|
+| `SHA256SUMS` | Manifest of all release file hashes. |
+| `SHA256SUMS.asc` | Detached GPG signatures from trusted signers. |
+| `SHA256SUMS.ots` | OpenTimestamps proof. |
+
+For step-by-step verification instructions, see the [download page](/en/download/).

--- a/_posts/en/pages/2026-02-10-release-artifacts.md
+++ b/_posts/en/pages/2026-02-10-release-artifacts.md
@@ -13,7 +13,7 @@ Bitcoin Core release files are hosted at [https://bitcoincore.org/bin/](https://
 ## Build Suffixes
 
 - **Standard Binaries** (`.tar.gz`, `.zip`, `-setup.exe`): Production-ready binaries for general use.
-- **`-debug`**: Includes symbols for backtrace generation. Larger file size and reduced performance.
+- **`-debug`**: Debug symbols split from the standard binaries, for use in backtrace generation.
 - **`-unsigned`**: Raw Guix build outputs. Used to audit reproducibility against signed releases.
 - **`-codesigning`**: Intermediate artifacts for macOS/Windows signing ceremonies. Not for end-users.
 - **Source**: `bitcoin-<version>.tar.gz` (no platform string). For manual compilation.


### PR DESCRIPTION
Add a page explaining the different file types distributed on the Bitcoin Core download page and in release torrents.

Closes #1220
