### PR TITLE
test: Ignore $(package) when checking for liquid templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ test-fast:
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
 	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
 	## Ensure that no template strings leak through liquid rendering
-	! find _site/ -name '*.html' | xargs grep '\$$(.*)'
+	! find _site/ -name '*.html' | xargs grep -P '\$$\((?!package).+?\)'

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ test-slow:
 
 test-fast:
 	## Check for broken Markdown reference-style links that are displayed in text unchanged, e.g. [broken][broken link]
-	! find _site/ -name '*.html' | xargs grep ']\[' | grep -v skip-test | grep .
+	! find _site/ -name '*.html' -exec grep ']\[' {} \; | grep -v skip-test | grep .
 	## Ensure that no template strings leak through liquid rendering
-	! find _site/ -name '*.html' | xargs grep -P '\$$\((?!package).+?\)'
+	! find _site/ -name '*.html' -exec grep -P '\$$\((?!package).+?\)' {} \; | grep .


### PR DESCRIPTION
$(package) is not used in any liquid template strings, but does appear in the title of a PR. Ignore this string so that CI does not fail on a false positive on these strings.

Fixes the current CI failures.