### PR TITLE
doc: fix broken Transifex URLs across release notes and config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 
 title: Bitcoin Core
 url: https://bitcoincore.org
-transifex_url: https://www.transifex.com/bitcoincore/bitcoincoreorg
+transifex_url: https://explore.transifex.com/bitcoin/bitcoin/
 
 # Jekyll configuration
 

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,6 @@
 
 title: Bitcoin Core
 url: https://bitcoincore.org
-transifex_url: https://explore.transifex.com/bitcoin/bitcoin/
 
 # Jekyll configuration
 

--- a/_posts/es/releases/2021-09-29-release-0.21.2.md
+++ b/_posts/es/releases/2021-09-29-release-0.21.2.md
@@ -141,5 +141,5 @@ Gracias a todos los que han contribuído directamente a esta edición:
 - W. J. van der Laan
 
 Así como a todos aquellos que han ayudado con las traducciones en
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_posts/ja/releases/2017-09-01-release-0.15.0.md
+++ b/_posts/ja/releases/2017-09-01-release-0.15.0.md
@@ -867,6 +867,6 @@ Coin Age Priorityの削除 {#removal-of-coin-age-priority}
 - Warren Togami
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 
 {% endgithubify %}

--- a/_posts/ja/releases/2017-10-02-release-0.15.0.1.md
+++ b/_posts/ja/releases/2017-10-02-release-0.15.0.1.md
@@ -90,6 +90,6 @@ GUI起動時にクラッシュする問題
 - Jonas Schnelli
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 
 {% endgithubify %}

--- a/_posts/ja/releases/2017-11-11-release-0.15.1.md
+++ b/_posts/ja/releases/2017-11-11-release-0.15.1.md
@@ -268,6 +268,6 @@ GUIの設定は`-resetguisettings`引数が使われた際、設定が消去さ�
 - Tomas van der Wansem
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 
 {% endgithubify %}

--- a/_posts/ja/releases/2018-02-26-release-0.16.0.md
+++ b/_posts/ja/releases/2018-02-26-release-0.16.0.md
@@ -734,5 +734,5 @@ RPCの変更
 - Willy Ko
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2018-06-15-release-0.16.1.md
+++ b/_posts/ja/releases/2018-06-15-release-0.16.1.md
@@ -166,5 +166,5 @@ Bitcoin Coreは他のほとんどのUnixライクなシステムで動作する�
 - Tamas Blummer
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2018-07-29-release-0.16.2.md
+++ b/_posts/ja/releases/2018-07-29-release-0.16.2.md
@@ -139,5 +139,5 @@ Bitcoin Coreは他のほとんどのUnixライクなシステムで動作する�
 - Braydon Fuller
 - Himanshu Mehta
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2018-09-18-release-0.16.3.md
+++ b/_posts/ja/releases/2018-09-18-release-0.16.3.md
@@ -114,5 +114,5 @@ Bitcoin Coreのバージョン0.14.0から0.16.2において、マイナーに�
 
 - beardnboobies
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2018-10-03-release-0.17.0.md
+++ b/_posts/ja/releases/2018-10-03-release-0.17.0.md
@@ -1103,5 +1103,5 @@ Credits
 
 - awemany (for CVE-2018-17144, previously credited as "anonymous reporter")
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2018-12-25-release-0.17.1.md
+++ b/_posts/ja/releases/2018-12-25-release-0.17.1.md
@@ -190,5 +190,5 @@ bitcoinが`-deprecatedrpc=accounts`の設定で構成されている場合、lab
 - Walter
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2019-05-02-release-0.18.0.md
+++ b/_posts/ja/releases/2019-05-02-release-0.18.0.md
@@ -1190,5 +1190,5 @@ RPC
 - Wladimir J. van der Laan
 - Zain Iqbal Allarakhia
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2019-08-09-release-0.18.1.md
+++ b/_posts/ja/releases/2019-08-09-release-0.18.1.md
@@ -157,5 +157,5 @@ Qt 5.9.xを使ってビルドされていますが、それが10.10未満のmacO
 - tecnovert
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2019-11-24-release-0.19.0.1.md
+++ b/_posts/ja/releases/2019-11-24-release-0.19.0.1.md
@@ -1084,5 +1084,5 @@ RPC
 - Wladimir J. van der Laan
 - zenosage
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2020-03-09-release-0.19.1.md
+++ b/_posts/ja/releases/2020-03-09-release-0.19.1.md
@@ -147,5 +147,5 @@ Bitcoin Core 0.17.0以降、10.10より前のmacOSバージョンはサポート
 - Russell Yanofsky
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/projects/p/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2020-06-03-release-0.20.0.md
+++ b/_posts/ja/releases/2020-06-03-release-0.20.0.md
@@ -973,5 +973,5 @@ GUIの変更 {#gui-changes}
 - Zakk
 - Zero
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2020-08-01-release-0.20.1.md
+++ b/_posts/ja/releases/2020-08-01-release-0.20.1.md
@@ -184,5 +184,5 @@ witness utxoの両方を含むようになりました。witness utxoは、そ�
 - Samuel Dobson
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2021-01-14-release-0.21.0.md
+++ b/_posts/ja/releases/2021-01-14-release-0.21.0.md
@@ -1324,5 +1324,5 @@ RPC
 - wiz
 - Wladimir J. van der Laan
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2021-05-01-release-0.21.1.md
+++ b/_posts/ja/releases/2021-05-01-release-0.21.1.md
@@ -214,5 +214,5 @@ Taprootの詳細については、以下のリソースを参照ください:
 - Vasil Dimov
 - W. J. van der Laan
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2021-09-13-release-22.0.md
+++ b/_posts/ja/releases/2021-09-13-release-22.0.md
@@ -1193,5 +1193,5 @@ RPC
 - Yuval Kogman
 - Zero
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2021-09-29-release-0.21.2.md
+++ b/_posts/ja/releases/2021-09-29-release-0.21.2.md
@@ -132,5 +132,5 @@ Bitcoin Core 0.20.0以降、10.12より前のmacOSはサポートされなくな
 - Rafael Sadowski
 - W. J. van der Laan
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくれたみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2022-04-25-release-23.0.md
+++ b/_posts/ja/releases/2022-04-25-release-23.0.md
@@ -384,5 +384,5 @@ RPC {#rpc}
 - zealsham
 - Zero-1729
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2022-12-12-release-24.0.1.md
+++ b/_posts/ja/releases/2022-12-12-release-24.0.1.md
@@ -391,5 +391,5 @@ RPC
 - William Casarin
 - Yancy Ribbens
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2023-05-18-release-23.2.md
+++ b/_posts/ja/releases/2023-05-18-release-23.2.md
@@ -97,5 +97,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - Michael Ford
 - Suhas Daftuar
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2023-05-18-release-24.1.md
+++ b/_posts/ja/releases/2023-05-18-release-24.1.md
@@ -124,5 +124,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - Thomas Nguyen
 - Vasil Dimov
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2023-05-26-release-25.0.md
+++ b/_posts/ja/releases/2023-05-26-release-25.0.md
@@ -344,5 +344,5 @@ RPC
 - yancy
 - Yusuf Sahin HAMZA
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2023-12-06-release-26.0.md
+++ b/_posts/ja/releases/2023-12-06-release-26.0.md
@@ -357,6 +357,6 @@ GUIの変更 {#gui-changes}
 - willcl-ark
 - Yusuf Sahin HAMZA
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 
 {% endgithubify %}

--- a/_posts/ja/releases/2024-04-02-release-26.1.md
+++ b/_posts/ja/releases/2024-04-02-release-26.1.md
@@ -130,5 +130,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - stickies-v
 - UdjinM6
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2024-04-08-release-25.2.md
+++ b/_posts/ja/releases/2024-04-08-release-25.2.md
@@ -99,5 +99,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - dergoegge
 - Greg Sanders
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2024-04-16-release-27.0.md
+++ b/_posts/ja/releases/2024-04-16-release-27.0.md
@@ -240,5 +240,5 @@ Init
 - willcl-ark
 
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2024-06-17-release-27.1.md
+++ b/_posts/ja/releases/2024-06-17-release-27.1.md
@@ -139,5 +139,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - Sjors Provoost
 - willcl-ark
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2024-07-09-release-26.2.md
+++ b/_posts/ja/releases/2024-07-09-release-26.2.md
@@ -120,5 +120,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - nanlour
 - willcl-ark
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2024-10-02-release-28.0.md
+++ b/_posts/ja/releases/2024-10-02-release-28.0.md
@@ -378,5 +378,5 @@ Chainstate
 - virtu
 - willcl-ark
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2024-11-04-release-27.2.md
+++ b/_posts/ja/releases/2024-11-04-release-27.2.md
@@ -117,5 +117,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - Vasil Dimov
 - willcl-ark
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2025-01-09-release-28.1.md
+++ b/_posts/ja/releases/2025-01-09-release-28.1.md
@@ -134,5 +134,5 @@ Bitcoin Coreは他のほとんどのUNIXライクなシステムでも動作す�
 - Marnix
 - Sebastian Falbesoner
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/ja/releases/2025-04-14-release-29.0.md
+++ b/_posts/ja/releases/2025-04-14-release-29.0.md
@@ -304,5 +304,5 @@ CMakeの設定と使用に関する詳細なガイダンスについては、公
 - willcl-ark
 - yancy
 
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)での翻訳を手伝ってくださったみなさんもありがとうございます。
 {% endgithubify %}

--- a/_posts/zh_CN/pages/2016-01-15-lifecycle.md
+++ b/_posts/zh_CN/pages/2016-01-15-lifecycle.md
@@ -30,4 +30,4 @@ version: 1
 
 _TBA: 将被公布_
 
-[bitcoin-transifex-link]: https://www.transifex.com/bitcoin/bitcoin/
+[bitcoin-transifex-link]: https://explore.transifex.com/bitcoin/bitcoin/

--- a/_posts/zh_CN/releases/2016-02-23-release-0.12.0.md
+++ b/_posts/zh_CN/releases/2016-02-23-release-0.12.0.md
@@ -729,4 +729,4 @@ Changelog
 - Zak Wilcox
 - zathras-crypto
 
-同时也向所有在[Transifex](https://www.transifex.com/projects/p/bitcoin/)上协助进行翻译的人员致以真诚的感谢。义务翻译.
+同时也向所有在[Transifex](https://explore.transifex.com/bitcoin/bitcoin/)上协助进行翻译的人员致以真诚的感谢。义务翻译.

--- a/_posts/zh_CN/releases/2016-10-27-release-0.13.1.md
+++ b/_posts/zh_CN/releases/2016-10-27-release-0.13.1.md
@@ -324,4 +324,4 @@ Credits（感谢）
 - whythat
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).

--- a/_releases/0.11.0.md
+++ b/_releases/0.11.0.md
@@ -523,6 +523,6 @@ And all those who contributed additional code review and/or security research:
 
 - Sergio Demian Lerner
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.11.1.md
+++ b/_releases/0.11.1.md
@@ -181,6 +181,6 @@ And those who contributed additional code review and/or security research:
 - timothy on IRC for reporting the issue
 - Vulnerability in miniupnp discovered by Aleksandar Nikolic of Cisco Talos
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.11.2.md
+++ b/_releases/0.11.2.md
@@ -227,6 +227,6 @@ Thanks to everyone who directly contributed to this release:
 
 And those who contributed additional code review and/or security research.
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.12.0.md
+++ b/_releases/0.12.0.md
@@ -728,6 +728,6 @@ Thanks to everyone who directly contributed to this release:
 - Zak Wilcox
 - zathras-crypto
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.12.1.md
+++ b/_releases/0.12.1.md
@@ -206,6 +206,6 @@ Thanks to everyone who directly contributed to this release:
 - Suhas Daftuar
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.13.0.md
+++ b/_releases/0.13.0.md
@@ -893,6 +893,6 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - Yuri Zhykin
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.13.1.md
+++ b/_releases/0.13.1.md
@@ -421,6 +421,6 @@ Thanks to everyone who directly contributed to this release:
 - whythat
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.13.2.md
+++ b/_releases/0.13.2.md
@@ -165,6 +165,6 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - wodry
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.14.0.md
+++ b/_releases/0.14.0.md
@@ -888,6 +888,6 @@ Thanks to everyone who directly contributed to this release:
 - wodry
 - Zak Wilcox
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.14.1.md
+++ b/_releases/0.14.1.md
@@ -158,6 +158,6 @@ Thanks to everyone who directly contributed to this release:
 - Suhas Daftuar
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.14.2.md
+++ b/_releases/0.14.2.md
@@ -119,6 +119,6 @@ Thanks to everyone who directly contributed to this release:
 - Shigeya Suzuki
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.15.0.1.md
+++ b/_releases/0.15.0.1.md
@@ -107,6 +107,6 @@ Thanks to everyone who directly contributed to this release:
 - Jonas Schnelli
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.15.0.md
+++ b/_releases/0.15.0.md
@@ -894,6 +894,6 @@ Thanks to everyone who directly contributed to this release:
 - Warren Togami
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.15.1.md
+++ b/_releases/0.15.1.md
@@ -293,6 +293,6 @@ Thanks to everyone who directly contributed to this release:
 - Tomas van der Wansem
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/0.16.0.md
+++ b/_releases/0.16.0.md
@@ -747,5 +747,5 @@ Thanks to everyone who directly contributed to this release:
 - Willy Ko
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.16.1.md
+++ b/_releases/0.16.1.md
@@ -169,5 +169,5 @@ Thanks to everyone who directly contributed to this release:
 - Tamas Blummer
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.16.2.md
+++ b/_releases/0.16.2.md
@@ -140,5 +140,5 @@ And to those that reported security issues:
 - Braydon Fuller
 - Himanshu Mehta
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.16.3.md
+++ b/_releases/0.16.3.md
@@ -114,5 +114,5 @@ And to those that reported security issues:
 
 - beardnboobies
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.17.0.md
+++ b/_releases/0.17.0.md
@@ -1130,5 +1130,5 @@ And to those that reported security issues:
 
 - awemany (for CVE-2018-17144, previously credited as "anonymous reporter")
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.17.1.md
+++ b/_releases/0.17.1.md
@@ -195,5 +195,5 @@ Thanks to everyone who directly contributed to this release:
 - Walter
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.18.0.md
+++ b/_releases/0.18.0.md
@@ -1248,5 +1248,5 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - Zain Iqbal Allarakhia
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.18.1.md
+++ b/_releases/0.18.1.md
@@ -159,5 +159,5 @@ Thanks to everyone who directly contributed to this release:
 - tecnovert
 - Wladimir J. van der Laan
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/projects/p/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.19.0.1.md
+++ b/_releases/0.19.0.1.md
@@ -1116,5 +1116,5 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 - zenosage
 
-As well as everyone that helped translating on [Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+As well as everyone that helped translating on [Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.19.1.md
+++ b/_releases/0.19.1.md
@@ -146,5 +146,5 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.20.0.md
+++ b/_releases/0.20.0.md
@@ -1013,5 +1013,5 @@ Thanks to everyone who directly contributed to this release:
 - Zero
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.20.1.md
+++ b/_releases/0.20.1.md
@@ -192,5 +192,5 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.20.2.md
+++ b/_releases/0.20.2.md
@@ -190,5 +190,5 @@ Thanks to everyone who directly contributed to this release:
 - Suhas Daftuar
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.21.0.md
+++ b/_releases/0.21.0.md
@@ -1358,5 +1358,5 @@ Thanks to everyone who directly contributed to this release:
 - Wladimir J. van der Laan
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.21.1.md
+++ b/_releases/0.21.1.md
@@ -225,5 +225,5 @@ Thanks to everyone who directly contributed to this release:
 - W. J. van der Laan
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/0.21.2.md
+++ b/_releases/0.21.2.md
@@ -133,5 +133,5 @@ Thanks to everyone who directly contributed to this release:
 
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/22.0.md
+++ b/_releases/22.0.md
@@ -1187,5 +1187,5 @@ Thanks to everyone who directly contributed to this release:
 - Zero
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/22.1.md
+++ b/_releases/22.1.md
@@ -152,5 +152,5 @@ Thanks to everyone who directly contributed to this release:
 - W. J. van der Laan
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/23.0.md
+++ b/_releases/23.0.md
@@ -397,5 +397,5 @@ Thanks to everyone who directly contributed to this release:
 - Zero-1729
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/23.1.md
+++ b/_releases/23.1.md
@@ -114,5 +114,5 @@ Thanks to everyone who directly contributed to this release:
 - W. J. van der Laan
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/23.2.md
+++ b/_releases/23.2.md
@@ -96,5 +96,5 @@ Thanks to everyone who directly contributed to this release:
 - Suhas Daftuar
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/24.0.1.md
+++ b/_releases/24.0.1.md
@@ -415,5 +415,5 @@ Thanks to everyone who directly contributed to this release:
 - Yancy Ribbens
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/24.1.md
+++ b/_releases/24.1.md
@@ -123,5 +123,5 @@ Thanks to everyone who directly contributed to this release:
 - Vasil Dimov
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/24.2.md
+++ b/_releases/24.2.md
@@ -100,5 +100,5 @@ Thanks to everyone who directly contributed to this release:
 - Pieter Wuille
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/25.0.md
+++ b/_releases/25.0.md
@@ -364,5 +364,5 @@ Thanks to everyone who directly contributed to this release:
 - Yusuf Sahin HAMZA
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/25.1.md
+++ b/_releases/25.1.md
@@ -132,5 +132,5 @@ Thanks to everyone who directly contributed to this release:
 - Will Clark
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/25.2.md
+++ b/_releases/25.2.md
@@ -98,5 +98,5 @@ Thanks to everyone who directly contributed to this release:
 - Greg Sanders
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/26.0.md
+++ b/_releases/26.0.md
@@ -381,6 +381,6 @@ Thanks to everyone who directly contributed to this release:
 - Yusuf Sahin HAMZA
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 
 {% endgithubify %}

--- a/_releases/26.1.md
+++ b/_releases/26.1.md
@@ -129,5 +129,5 @@ Thanks to everyone who directly contributed to this release:
 - UdjinM6
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/26.2.md
+++ b/_releases/26.2.md
@@ -118,5 +118,5 @@ Thanks to everyone who directly contributed to this release:
 - willcl-ark
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/27.0.md
+++ b/_releases/27.0.md
@@ -244,5 +244,5 @@ Thanks to everyone who directly contributed to this release:
 
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/27.1.md
+++ b/_releases/27.1.md
@@ -138,5 +138,5 @@ Thanks to everyone who directly contributed to this release:
 - willcl-ark
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/27.2.md
+++ b/_releases/27.2.md
@@ -116,5 +116,5 @@ Thanks to everyone who directly contributed to this release:
 - willcl-ark
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/28.0.md
+++ b/_releases/28.0.md
@@ -398,5 +398,5 @@ Thanks to everyone who directly contributed to this release:
 - willcl-ark
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/28.1.md
+++ b/_releases/28.1.md
@@ -134,5 +134,5 @@ Thanks to everyone who directly contributed to this release:
 - Sebastian Falbesoner
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/28.2.md
+++ b/_releases/28.2.md
@@ -110,5 +110,5 @@ Thanks to everyone who directly contributed to this release:
 - Sjors Provoost
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}

--- a/_releases/29.0.md
+++ b/_releases/29.0.md
@@ -293,5 +293,5 @@ Thanks to everyone who directly contributed to this release:
 - yancy
 
 As well as to everyone that helped with translations on
-[Transifex](https://www.transifex.com/bitcoin/bitcoin/).
+[Transifex](https://explore.transifex.com/bitcoin/bitcoin/).
 {% endgithubify %}


### PR DESCRIPTION
All `transifex.com` links in release notes and `_config.yml` currently return 404. Transifex migrated to `explore.transifex.com`.

This PR updates all affected files:
- `www.transifex.com/projects/p/bitcoin/` → `explore.transifex.com/bitcoin/bitcoin/`
- `www.transifex.com/bitcoin/bitcoin/` → `explore.transifex.com/bitcoin/bitcoin/`
- `www.transifex.com/bitcoincore/bitcoincoreorg` → `explore.transifex.com/bitcoin/bitcoin/`

Rebased version of #1155, which has had merge conflicts since June 2025. Credit to azuchi for identifying the issue.

Verified: old URLs return HTTP 404, new URL returns HTTP 200.