### PR TITLE
ci: Don't use a container for verify-commits task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,6 @@ jobs:
   verify-commits:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    container:
-      image: debian:latest
     steps:
       - uses: actions/checkout@v6
         with:
@@ -61,8 +59,8 @@ jobs:
 
       - name: Install packages
         run: |
-          apt-get update
-          apt-get install -y \
+          sudo apt-get update
+          sudo apt-get install -y \
             git \
             gnupg
 


### PR DESCRIPTION
Apparently using a container with a specific image causes the `.git` directory to disappear. `verify-commits.sh` can run on ubuntu so the container can be dropped to resolve that issue. Also switching to ubuntu requires `sudo`ing `apt-get`.

A run of this task is available at https://github.com/achow101/bitcoincore.org/actions/runs/24218968381/job/70705928687, although that has an additional change to have it run on a non-master branch.