### PR TITLE
ci: check maintenance table updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,12 @@ env:
   NOKOGIRI_USE_SYSTEM_LIBRARIES: true # speeds up installation of html-proofer
   RUBYOPT: "-KU -E utf-8:utf-8"
 jobs:
+  check-maintenance-table:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: ./contrib/check-maintenance-table.sh
+
   bundler:
     runs-on: ubuntu-latest
     container:

--- a/contrib/check-maintenance-table.sh
+++ b/contrib/check-maintenance-table.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Copyright (c) The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#
+# Checks to ensure the maintenance table is up-to-date with release posts.
+
+latest=$(
+  printf '%s\n' _releases/*.md |
+    sed -nE 's#^_releases/([0-9]+)\.0\.md$#\1#p' |
+    sort -n |
+    tail -n 1
+)
+
+[ -n "$latest" ] || exit 0
+
+if ! grep -qE "^\|[[:space:]]*${latest}\.x[[:space:]]*\|[[:space:]]*[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]*\|" \
+  _includes/posts/maintenance-table.md
+then
+  echo "error: _includes/posts/maintenance-table.md is missing a dated row for ${latest}.x but ${latest}.0 has shipped" >&2
+  exit 1
+fi


### PR DESCRIPTION
A very rudimentary check to verify that the maintenance table is updated when a new major release is done (see e.g. #1239 ). Does not validate any details to keep the script simple, just that the latest major release has a date associated with it.

The minimal checks are intentional, to avoid CI getting in the way when the release process is a bit non-standard.

Can be tested locally by modifying the `maintenance-table.md` and running `./contrib/check-maintenance-table.sh`.
