### PR TITLE
Fix header alternate link to use url instead of permalink

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,7 @@
 {% include open-graph.html %}
 
 {% assign posts=site.posts |where:"name", page.name %}
-{% for hrefpost in posts %}<link rel="alternate" hreflang="{{ hrefpost.lang }}" href="{{ site.url }}{{ hrefpost.permalink }}" />{% endfor %}
+{% for hrefpost in posts %}<link rel="alternate" hreflang="{{ hrefpost.lang }}" href="{{ site.url }}{{ hrefpost.url }}" />{% endfor %}
 {% if page.canonical != null %}<link rel="canonical" href="{{ page.canonical }}">{% else %}<link rel="canonical" href="{{ site.url }}{{ page.url }}">{% endif %}
 <link href="{{ site.url }}/{{ page.lang }}/feed.xml" type="application/atom+xml" rel="alternate" title="{{ site.title | xml_escape }} Blog XML Feed">
 <link href="{{ site.url }}/{{ page.lang }}/rss.xml" type="application/rss+xml" rel="alternate" title="{{ site.title | xml_escape }} Blog RSS Feed">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -19,7 +19,9 @@
 {% include open-graph.html %}
 
 {% assign posts=site.posts |where:"name", page.name %}
-{% for hrefpost in posts %}<link rel="alternate" hreflang="{{ hrefpost.lang }}" href="{{ site.url }}{{ hrefpost.url }}" />{% endfor %}
+{%- for hrefpost in posts %}
+<link rel="alternate" hreflang="{{ hrefpost.lang }}" href="{{ site.url }}{{ hrefpost.url }}" />
+{%- endfor %}
 {% if page.canonical != null %}<link rel="canonical" href="{{ page.canonical }}">{% else %}<link rel="canonical" href="{{ site.url }}{{ page.url }}">{% endif %}
 <link href="{{ site.url }}/{{ page.lang }}/feed.xml" type="application/atom+xml" rel="alternate" title="{{ site.title | xml_escape }} Blog XML Feed">
 <link href="{{ site.url }}/{{ page.lang }}/rss.xml" type="application/rss+xml" rel="alternate" title="{{ site.title | xml_escape }} Blog RSS Feed">


### PR DESCRIPTION
`permalink` in english posts has a value of the literal string `/en/:year/:month/:day/:title/`. As `permalink` is undocumented and appears to contain the placeholder rather than the real permalink, use `url` instead which is documented and has the correct link.