### PR TITLE
Reduce extraneous whitespace in the generated html

### DIFF
--- a/_includes/meetings.html
+++ b/_includes/meetings.html
@@ -1,20 +1,24 @@
 <ul class="meeting">
-  {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'meetings' | sort_by:'date' %}
-  {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'meetings' %}
-  {% for default_post in english_posts %}
-    {% assign post=default_post %}
-    {% capture year %}{{post.date | date: '%Y' }}{% endcapture %}
-    {% if forloop.first == true %}<li><b>{{year}}</b><ul>{% assign old_year = year %}{% endif %}
-    {% if year != old_year %}</ul></li><li><b>{{year}}</b><ul>{% assign old_year = year %}{% endif %}
-    {% for t_post in translated_posts %}
-      {% if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
-    {% endfor %}
+  {%- assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'meetings' | sort_by:'date' %}
+  {%- assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'meetings' %}
+  {%- for default_post in english_posts %}
+    {%- assign post=default_post %}
+    {%- capture year %}{{post.date | date: '%Y' }}{% endcapture %}
+    {%- if forloop.first == true %}
+    <li><b>{{year}}</b><ul>{% assign old_year = year %}
+    {%- endif %}
+    {%- if year != old_year %}
+    </ul></li><li><b>{{year}}</b><ul>{% assign old_year = year %}
+    {%- endif %}
+    {%- for t_post in translated_posts %}
+      {%- if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
+    {%- endfor %}
   <li>
     <a href="{{ post.url }}">
       {{ post.title | replace: '<br/>', '' }}
     </a>
     <div class="desc">{{ post.desc }}</div>
   </li>
-  {% endfor %}
+  {%- endfor %}
   </ul></li>
 </ul>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,81 +1,76 @@
 <div class="navigation-wrapper">
-	<div class="site-name">
-        {% assign homelink = site.data.navigation[page.lang]['home'] %}
-		<a href="{{ homelink.url }}"><img src="/assets/images/bitcoin_core_logo_colored_reversed.png" alt="bitcoin core logo"></a>
-	</div><!-- /.site-name -->
-	<div class="top-navigation">
-		<nav role="navigation" id="site-nav" class="nav">
-		    <ul>
-		        {% for link in site.data.navigation[page.lang] %}
-                    {% if link[0] != 'home' and link[1].submenu != true and link[1].disabled != true %}
-                      <li><a href="{{ link[1].url }}">{{ link[1].title }}</a></li>
-                    {% elsif link[1].submenu == true and link[1].disabled != true %}
-                      <li>{% if link[1].url %}<a href="{{ link[1].url }}">{{ link[1].title }}</a>{% else %}<a href="javascript:;">{{ link[1].title }}</a>{% endif %}
-                          <ul>
-                          {% for sublink in link[1].tree %}
-
-                              {% if sublink[0] != 'home' and sublink[1].submenu != true and sublink[1].disabled != true %}
-                              <li><a href="{{ sublink[1].url }}">{{ sublink[1].title }}</a></li>
-                              {% elsif sublink[1].submenu == true and sublink[1].disabled != true %}
-                              <li>{% if sublink[1].url %}<a href="{{ sublink[1].url }}">{{ sublink[1].title }}</a>{% else %}<a href="javascript:;">{{ sublink[1].title }}</a>{% endif %}
-                                  <ul>
-                                      {% for sublink2 in sublink[1].tree %}
-                                      <li><a href="{{ sublink2[1].url }}">{{ sublink2[1].title }}</a></li>
-                                      {% endfor %}
-                                  </ul>
-                              </li>
-                              {% endif %}
-
-                          {% endfor %}
-                          {% if link[0] == 'dev' %}
+    <div class="site-name">
+        {%- assign homelink = site.data.navigation[page.lang]['home'] %}
+        <a href="{{ homelink.url }}"><img src="/assets/images/bitcoin_core_logo_colored_reversed.png" alt="bitcoin core logo"></a>
+    </div><!-- /.site-name -->
+    <div class="top-navigation">
+        <nav role="navigation" id="site-nav" class="nav">
+            <ul>
+                {%- for link in site.data.navigation[page.lang] %}
+                    {%- if link[0] != 'home' and link[1].submenu != true and link[1].disabled != true %}
+                    <li><a href="{{ link[1].url }}">{{ link[1].title }}</a></li>
+                    {%- elsif link[1].submenu == true and link[1].disabled != true %}
+                    <li>
+                        {%- if link[1].url %}
+                        <a href="{{ link[1].url }}">{{ link[1].title }}</a>{%- else %}<a href="javascript:;">{{ link[1].title }}</a>{%- endif %}
+                            <ul>
+                            {%- for sublink in link[1].tree %}
+                                {%- if sublink[0] != 'home' and sublink[1].submenu != true and sublink[1].disabled != true %}
+                                <li><a href="{{ sublink[1].url }}">{{ sublink[1].title }}</a></li>
+                                {%- elsif sublink[1].submenu == true and sublink[1].disabled != true %}
+                                <li>{%- if sublink[1].url %}<a href="{{ sublink[1].url }}">{{ sublink[1].title }}</a>{%- else %}<a href="javascript:;">{{ sublink[1].title }}</a>{%- endif %}
+                                    <ul>
+                                        {%- for sublink2 in sublink[1].tree %}
+                                        <li><a href="{{ sublink2[1].url }}">{{ sublink2[1].title }}</a></li>
+                                        {%- endfor %}
+                                    </ul>
+                                </li>
+                                {%- endif %}
+                            {%- endfor %}
+                            {%- if link[0] == 'dev' %}
                             <li>
-                              {% for article in site.doc %}
-                                {% if article.btcversion == "index" %}
-                                  <a href="{{article.url}}">RPC Docs</a>
-                                {% endif %}
-                              {% endfor %}
-                              {% assign groups = site.doc | group_by:"btcversion" | sort_by: "btcversion" | reverse %}
-                              <ul>
-                                {% for group in groups %}
-                                  {% if group.name != "index" %}
-                                    {% for article in group.items %}
-                                      {% if article.name == "index" %}
-                                        <li><a href="{{article.url}}">{{group.name}}</a></li>
-                                      {% endif %}
-                                    {% endfor %}
-                                  {% endif %}
-                                {% endfor %}
-                              </ul>
+                                {%- for article in site.doc %}
+                                    {%- if article.btcversion == "index" %}
+                                        <a href="{{article.url}}">RPC Docs</a>
+                                    {%- endif %}
+                                {%- endfor %}
+                                {%- assign groups = site.doc | group_by:"btcversion" | sort_by: "btcversion" | reverse %}
+                                <ul>
+                                {%- for group in groups %}
+                                    {%- if group.name != "index" %}
+                                        {%- for article in group.items %}
+                                            {%- if article.name == "index" %}
+                                                <li><a href="{{article.url}}">{{group.name}}</a></li>
+                                            {%- endif %}
+                                        {%- endfor %}
+                                    {%- endif %}
+                                {%- endfor %}
+                                </ul>
                             </li>
-                          {% endif %}
-                          </ul>
-                      </li>
-                    {% endif %}
-                {% endfor %}
-                {% assign posts=site.posts | where:"name", page.name | sort: 'path' %}
-                {% assign releases=site.releases | where:"name", page.name | sort: 'path' %}
+                            {%- endif %}
+                        </ul>
+                    </li>
+                    {%- endif %}
+                {%- endfor %}
+                {%- assign posts=site.posts | where:"name", page.name | sort: 'path' %}
+                {%- assign releases=site.releases | where:"name", page.name | sort: 'path' %}
 
                 <li id="langselect" class="lang">
                     <select onchange="window.location=this.value;">
                         <option value="{{ post.url }}">{{ site.data.languages[page.lang] }}</option>
-                        {% for post in posts %}
-                        {% if post.lang != page.lang %}<option value="{{ post.url }}">{{ site.data.languages[post.lang] }}</option>{% endif %}
-                        {% endfor %}
-                        {% for release in releases %}
-                        {% if release.lang != page.lang %}<option value="{{ release.url }}">{{ site.data.languages[release.lang] }}</option>{% endif %}
-                        {% endfor %}
+                        {%- for post in posts %}
+                        {%- if post.lang != page.lang %}
+                        <option value="{{ post.url }}">{{ site.data.languages[post.lang] }}</option>
+                        {%- endif %}
+                        {%- endfor %}
+                        {%- for release in releases %}
+                        {%- if release.lang != page.lang %}
+                        <option value="{{ release.url }}">{{ site.data.languages[release.lang] }}</option>
+                        {%- endif %}
+                        {%- endfor %}
                     </select>
                 </li>
-                <!--<li class="lang">-->
-                    <!--<li><a>{{ site.data.languages[page.lang] }}</a>-->
-                    <!--{% assign posts=site.posts | where:"name", page.name | sort: 'path' %}      -->
-                    <!--{% for post in posts %}-->
-                    <!--{% if post.lang != page.lang %}<a href="{{ post.url }}" class="{{ post.lang }}">{{ language }}</a>{% endif %}-->
-                    <!--<a href="{{ post.url }}" class="{{ post.lang }}">{{ site.data.languages[post.lang] }}</a>-->
-                    <!--<a href="{{ post.url }}" class="{{ post.lang }}">{{ site.data.languages[post.lang] }}</a>-->
-                    <!--{% endfor %}-->
-                <!--</li>-->
-		    </ul>
-		</nav>
-	</div><!-- /.top-navigation -->
+            </ul>
+        </nav>
+    </div><!-- /.top-navigation -->
 </div><!-- /.navigation-wrapper -->

--- a/_includes/related.html
+++ b/_includes/related.html
@@ -1,14 +1,14 @@
-{% assign related_posts = site.related_posts | where:"lang", page.lang | where:"type", 'posts' %}
-{% if related_posts.size > 0 %}
+{%- assign related_posts = site.related_posts | where:"lang", page.lang | where:"type", 'posts' %}
+{%- if related_posts.size > 0 %}
 <div class="related-articles">
-    {% assign translations = site.data.translations[page.lang] %}
-    {% assign navigation = site.data.navigation[page.lang] %}
+    {%- assign translations = site.data.translations[page.lang] %}
+    {%- assign navigation = site.data.navigation[page.lang] %}
     <h4>{{ translations.related }} <small class="pull-right">(<a href="{{ navigation.blog.url }}">{{ translations.viewallposts }}</a>)</small></h4>
     <ul>
-        {% for post in related_posts limit:3 %}
+        {%- for post in related_posts limit:3 %}
         <li><a href="{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></li>
-        {% endfor %}
+        {%- endfor %}
     </ul>
     <hr />
 </div><!-- /.related-articles -->
-{% endif %}
+{%- endif %}

--- a/_includes/releases.html
+++ b/_includes/releases.html
@@ -1,16 +1,16 @@
 <ul class="releases">
-  {% assign english_posts = site.releases | sort: 'release' | reverse %}
-  {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'releases' %}
-  {% for default_post in english_posts %}
-    {% assign post=default_post %}
-    {% for t_post in translated_posts %}
-      {% if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
-    {% endfor %}
+  {%- assign english_posts = site.releases | sort: 'release' | reverse %}
+  {%- assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'releases' %}
+  {%- for default_post in english_posts %}
+    {%- assign post=default_post %}
+    {%- for t_post in translated_posts %}
+      {%- if t_post.name == post.name %}{% assign post=t_post %}{% break %}{% endif %}
+    {%- endfor %}
   <li>
     <a href="{{ post.url }}">
       {{ post.title | replace: '<br/>', '' }}
     </a>
     <div class="desc">{{ post.desc }}</div>
   </li>
-  {% endfor %}
+  {%- endfor %}
 </ul>

--- a/_layouts/doc.html
+++ b/_layouts/doc.html
@@ -1,15 +1,15 @@
 <!doctype html>
 {% include browser_magic.html %}
 <head>
-{% if page.name != "index" and page.name != "rpcindex" %}
-  {% assign custom_title = page.name | append: " (" | append: page.btcversion | append: " RPC)" %}
-{% else %}
-  {% if page.btcversion != "index" %}
-    {% assign custom_title = "Bitcoin Core " | append: page.btcversion | append: " RPC" %}
-  {% else %}
-    {% assign custom_title = "Bitcoin Core RPC" %}
-  {% endif %}
-{% endif %}
+{%- if page.name != "index" and page.name != "rpcindex" %}
+  {%- assign custom_title = page.name | append: " (" | append: page.btcversion | append: " RPC)" %}
+{%- else %}
+  {%- if page.btcversion != "index" %}
+    {%- assign custom_title = "Bitcoin Core " | append: page.btcversion | append: " RPC" %}
+  {%- else %}
+    {%- assign custom_title = "Bitcoin Core RPC" %}
+  {%- endif %}
+{%- endif %}
 {% include head.html %}
 </head>
 
@@ -39,12 +39,12 @@
   <article class="page">
     <h1>{{ custom_title | xml_escape }}</h1>
     <div class="article-wrap">
-      {% if page.btcversion != "index" %}
-        {% assign groups = site.doc | where:"btcversion", page.btcversion | group_by:"btcgroup" | sort: "name" %}
+      {%- if page.btcversion != "index" %}
+        {%- assign groups = site.doc | where:"btcversion", page.btcversion | group_by:"btcgroup" | sort: "name" %}
         <section class="toc">
         <input id="searchbar" type="text" value="" placeholder="Search ..."/>
-        {% for group in groups %}
-          {% if group.name != "index" %}
+        {%- for group in groups %}
+          {%- if group.name != "index" %}
             <header>
               <h3 class="toc-header">
                 <i class="fa fa-book"></i>
@@ -52,40 +52,40 @@
               </h3>
               <div class="toc-drawer js-hide-on-start">
                 <ul>
-                  {% for article in group.items %}
+                  {%- for article in group.items %}
                     <li class="leaf-article"><a href="{{article.url}}">{{article.name}}</a></li>
-                  {% endfor %}
+                  {%- endfor %}
                 </ul>
               </div>
             </header>
-          {% endif %}
-        {% endfor %}
+          {%- endif %}
+        {%- endfor %}
         </section>
-      {% endif %}
+      {%- endif %}
 
-      {% if page.name != "index" and page.name != "rpcindex" %}
+      {%- if page.name != "index" and page.name != "rpcindex" %}
 <span class="doc">
 {% highlight text %}{{ content }}{% endhighlight %}
 </span>
-      {% else %}
-        {% if page.btcversion != "index" %}
+      {%- else %}
+        {%- if page.btcversion != "index" %}
           Select a command group in the menu.
-        {% else %}
+        {%- else %}
           Following docs are available:
-          {% assign groups = site.doc | sort: "btcversion" | reverse | group_by:"btcversion" %}
+          {%- assign groups = site.doc | sort: "btcversion" | reverse | group_by:"btcversion" %}
           <ul>
-            {% for group in groups %}
-              {% if group.name != "index" %}
-                {% for article in group.items %}
-                  {% if article.name == "index" %}
+            {%- for group in groups %}
+              {%- if group.name != "index" %}
+                {%- for article in group.items %}
+                  {%- if article.name == "index" %}
                     <li><a href="{{article.url}}">{{group.name}}</a></li>
-                  {% endif %}
-                {% endfor %}
-              {% endif %}
-            {% endfor %}
+                  {%- endif %}
+                {%- endfor %}
+              {%- endif %}
+            {%- endfor %}
           </ul>
-        {% endif %}
-      {% endif %}
+        {%- endif %}
+      {%- endif %}
     </div><!-- /.article-wrap -->
   </article>
 </div><!-- /#index -->

--- a/_layouts/post-index.html
+++ b/_layouts/post-index.html
@@ -13,51 +13,51 @@
 {% if page.image.feature %}
   <div class="image-wrap">
   <img src=
-    {% if page.image.feature contains 'http' %}
+    {%- if page.image.feature contains 'http' %}
       "{{ page.image.feature }}"
-    {% else %}
+    {%- else %}
       "/assets/images/{{ page.image.feature }}"
-    {% endif %}
+    {%- endif %}
     alt="{% if page.image.alt %}{{ page.image.alt }}{% else %}{{ page.title | xml_escape }}{% endif %} feature image">
-  {% if page.image.byline %}
+  {%- if page.image.byline %}
     <span class="image-credit">{{ page.image.byline }}</span>
-  {% endif %}
-  {% if page.image.credit %}
+  {%- endif %}
+  {%- if page.image.credit %}
     <span class="image-credit">Photo Credit: <a href="{{ page.image.creditlink }}">{{ page.image.credit }}</a></span>
-  {% endif %}
+  {%- endif %}
   </div><!-- /.image-wrap -->
-{% endif %}
+{%- endif %}
 
 <div id="main" role="main">
   <div class="article-author-side">&nbsp;</div>
   <div id="index">
     <h1>{{ page.title | xml_escape }}</h1>
-    {% capture written_year %}'None'{% endcapture %}
-    {% assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'posts' %}
-    {% assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
-    {% assign all=advisories | concat: english_posts | sort: "date" | reverse %}
-    {% assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
-    {% assign translated_advisories=site.posts | where:"lang", page.lang | where:"type", 'advisory' %}
-    {% assign translated_all=translated_advisories | concat: translated_posts | sort: "date" | reverse %}
-    {% for default_post in all %}
-      {% assign post=default_post %}
-      {% for tpost in translated_all %}
-        {% if tpost.name == post.name %}{% assign found=true %}{% assign post=tpost %}{% break %}{% endif %}
-      {% endfor %}
-      {% capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
-      {% if year != written_year %}
+    {%- capture written_year %}'None'{% endcapture %}
+    {%- assign english_posts=site.posts | where:"lang", 'en' | where:"type", 'posts' %}
+    {%- assign advisories=site.posts | where:"lang", 'en' | where:"type", 'advisory' %}
+    {%- assign all=advisories | concat: english_posts | sort: "date" | reverse %}
+    {%- assign translated_posts=site.posts | where:"lang", page.lang | where:"type", 'posts' %}
+    {%- assign translated_advisories=site.posts | where:"lang", page.lang | where:"type", 'advisory' %}
+    {%- assign translated_all=translated_advisories | concat: translated_posts | sort: "date" | reverse %}
+    {%- for default_post in all %}
+      {%- assign post=default_post %}
+      {%- for tpost in translated_all %}
+        {%- if tpost.name == post.name %}{% assign found=true %}{% assign post=tpost %}{% break %}{% endif %}
+      {%- endfor %}
+      {%- capture year %}{{ post.date | date: '%Y' }}{% endcapture %}
+      {%- if year != written_year %}
         <h3 class="year">{{ year }}</h3>
-        {% capture written_year %}{{ year }}{% endcapture %}
-      {% endif %}
+        {%- capture written_year %}{{ year }}{% endcapture %}
+      {%- endif %}
       <article>
-        {% if post.link %}
+        {%- if post.link %}
           <h2 class="link-post"><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title | xml_escape }}</a> <a href="{{ post.link }}" target="_blank" title="{{ post.title | xml_escape }}"><i class="fa fa-link"></i></a></h2>
-        {% else %}
+        {%- else %}
           <h2><a href="{{ post.url }}" title="{{ post.title | xml_escape }}">{{ post.title }}</a></h2>
           <p>{{ post.excerpt | markdownify | strip_html | truncate: 160 }}</p>
-        {% endif %}
+        {%- endif %}
       </article>
-    {% endfor %}
+    {%- endfor %}
   </div><!-- /#index -->
 </div><!-- /#main -->
 

--- a/assets/elements/sitemaps.xml
+++ b/assets/elements/sitemaps.xml
@@ -5,20 +5,20 @@ permalink: /sitemap.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
-{% for collection in site.collections %}
-  {% assign en_posts = collection.docs | where: "lang", "en" %}
-  {% for post in en_posts %}
-    {% if post.id contains "404" or post.sitemap_exlude == true %}{% else %}
+{%- for collection in site.collections %}
+  {%- assign en_posts = collection.docs | where: "lang", "en" %}
+  {%- for post in en_posts %}
+    {%- if post.id contains "404" or post.sitemap_exlude == true %}{% else %}
       <url>
         <loc>{{ site.url }}{{ post.url }}</loc>
-        {% assign langs=site.posts | where:"name", post.name %}{% for version in langs %}
+        {%- assign langs=site.posts | where:"name", post.name %}{% for version in langs %}
           {% if version.lang != 'en' %}<xhtml:link rel="alternate" hreflang="{{ version.lang }}" href="{{ site.url }}{{ version.url }}" />{% endif %}
-        {% endfor %}
+        {%- endfor %}
         <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
-        {% if page.changefreq != null %}<changefreq>{{ page.changefreq }}</changefreq>{% endif %}
-        {% if page.priority != null %}<priority>{{ page.priority }}</priority>{% endif %}
+        {%- if page.changefreq != null %}<changefreq>{{ page.changefreq }}</changefreq>{% endif %}
+        {%- if page.priority != null %}<priority>{{ page.priority }}</priority>{% endif %}
       </url>
-    {% endif %}
-  {% endfor %}
-{% endfor %}
+    {%- endif %}
+  {%- endfor %}
+{%- endfor %}
 </urlset>


### PR DESCRIPTION
Currently the generated html of the website contains thousands of lines of just whitespace. This results in us sending hundreds kilobytes of whitespace per page load, and also makes it quite difficult to review the built website.

The root cause of this whitespace is jekyll's template tags which do things but have no html output. The standard tags (`{%` and `%}`) do not consume whitespace characters, so any line in an include or layout and no html will result in a line with only whitespace characters. However, jekyll does have template tags that do consume whitespace: `{%-` consumes all whitespace before the tag, while `-%}` consumes whitespace that comes after. For the most part, we can replace any `{%` with `{%-` to get rid of the whitespace, with only a few places where lines need to be moved around so that some lines do not accidentally get squashed into the line before.

This PR targets the biggest offenders of empty line generation: the navigation bar, the IRC meetings list, the blog post index, the RPC docs list, related posts list, and the sitemap. All of these layouts and includes feature loops that iterate many files and do filtering and processing, hence they produce a lot of whitespace.

The first commit contains only changes for the navigation bar as this include had some indentation weirdness going on (mixed tabs and spaces). I normalized the indentation to be 4 spaces, removed a commented out section, and changed the tags.

The second commit does the other includes and layouts as these did not have major changes like the navbar include.

Overall, this change reduces the size of pages like the blog index (`/en/blog/index.html`) from 503 KB to 41 KB. The total size of the generated site is reduced from 1.2 GB to 94 MB.