### PR TITLE
Add Brazilian Portuguese (pt_BR) translation for the about page

### DIFF
--- a/_data/languages.yml
+++ b/_data/languages.yml
@@ -3,3 +3,4 @@ zh_CN: 简体中文
 zh_TW: 繁體中文
 ja: 日本語
 es: Español
+pt_BR: Português (Brasil)

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -247,8 +247,8 @@ pt_BR:
     title: "Versões"  # XXX
     url:   "/en/releases/"  # XXX
   security-advisories:
-    title: "Security Advisories"
-    url:   "/en/security-advisories/"
+    title: "Avisos de segurança"  # XXX
+    url:   "/en/security-advisories/"  # XXX
   dev:
     title: "Desenvolvimento"  # XXX
     submenu: true
@@ -263,18 +263,18 @@ pt_BR:
         title: "reuniões"  # XXX
         url:   "/en/meetings/"  # XXX
       eol:
-        title: "Lifecycle"  # XXX
+        title: "Ciclo de vida"  # XXX
         url:   "/en/lifecycle"  # XXX
   contact:
     title: "Contato"  # XXX
     submenu: true
     tree:
       contact_us:
-        title: "Contact Us"  # XXX
+        title: "Fale conosco"  # XXX
         url: "/en/contact/"  # XXX
       announcements:
-        title: "Announcements"  # XXX
+        title: "Comunicados"  # XXX
         url: "/en/list/announcements/join/"  # XXX
       twitter_impersonation:
-        title: "X impersonation"  # XXX
+        title: "Perfis falsos no X"  # XXX
         url: "/en/twitter-impersonation"  # XXX

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -230,3 +230,51 @@ es:
       twitter_impersonation:
         title: "X impersonation"  # XXX
         url: "/en/twitter-impersonation"  # XXX
+pt_BR:
+  home:
+    title: "Bitcoin Core"
+    url:   "/pt_BR/"
+  about:
+    title: "Sobre"
+    url:   "/pt_BR/about/"
+  download:
+    title: "Download"  # XXX
+    url: "/en/download"  # XXX
+  blog:
+    title: "Blog"  # XXX
+    url:   "/en/blog/"  # XXX
+  releases:
+    title: "Versões"  # XXX
+    url:   "/en/releases/"  # XXX
+  security-advisories:
+    title: "Security Advisories"
+    url:   "/en/security-advisories/"
+  dev:
+    title: "Desenvolvimento"  # XXX
+    submenu: true
+    tree:
+      contribute:
+        title: "contribuir"  # XXX
+        url:   "/en/contribute/"  # XXX
+      contribute-code:
+        title: "contributing code"  # XXX
+        url:   "/en/faq/contributing-code/"  # XXX
+      meetings:
+        title: "reuniões"  # XXX
+        url:   "/en/meetings/"  # XXX
+      eol:
+        title: "Lifecycle"  # XXX
+        url:   "/en/lifecycle"  # XXX
+  contact:
+    title: "Contato"  # XXX
+    submenu: true
+    tree:
+      contact_us:
+        title: "Contact Us"  # XXX
+        url: "/en/contact/"  # XXX
+      announcements:
+        title: "Announcements"  # XXX
+        url: "/en/list/announcements/join/"  # XXX
+      twitter_impersonation:
+        title: "X impersonation"  # XXX
+        url: "/en/twitter-impersonation"  # XXX

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -257,7 +257,7 @@ pt_BR:
         title: "contribuir"  # XXX
         url:   "/en/contribute/"  # XXX
       contribute-code:
-        title: "contributing code"  # XXX
+        title: "contribuir com código"  # XXX
         url:   "/en/faq/contributing-code/"  # XXX
       meetings:
         title: "reuniões"  # XXX

--- a/_data/translations.yml
+++ b/_data/translations.yml
@@ -67,3 +67,17 @@ es:
   rss_feed: "Fuente RSS del Blog de Bitcoin Core"
   rss_meetings_feed: "Feed de reuniones"
   rss_blog_feed: "Feed de entradas del blog"
+
+pt_BR:
+  created: "Publicado em"
+  author: "por"
+  description: "Site do Bitcoin Core"
+  footer: "Projeto Bitcoin Core"
+  related: "Recomendado"
+  viewallposts: "Ver todas as publicações"
+  not_translated: "Nota: esta página não foi traduzida"
+  tocoverview: "Visão geral"
+  translation_outdated: "Esta tradução pode estar desatualizada. Por favor, compare com a versão em inglês."
+  rss_feed: "Feed RSS do Blog do Bitcoin Core"
+  rss_meetings_feed: "Feed de reuniões"
+  rss_blog_feed: "Feed de publicações do blog"

--- a/_posts/pt_BR/pages/2016-01-01-about.md
+++ b/_posts/pt_BR/pages/2016-01-01-about.md
@@ -25,7 +25,7 @@ Há muitos outros que contribuem com pesquisa, revisão por pares, testes, docum
 
 ### Mantenedores
 
-Os mantenedores do projeto têm acesso de commit e são responsáveis por incorporar os patches dos contribuidores. Eles exercem um papel de curadoria, integrando os patches que a equipe concorda que devem ser integrados. Também atuam como uma verificação final para garantir que os patches sejam seguros e alinhados aos objetivos do projeto. O papel dos mantenedores decorre do consenso entre os contribuidores do projeto.
+Os mantenedores do projeto têm acesso de commit e são responsáveis por incorporar os patches dos contribuidores. Eles exercem um papel de manutenção, integrando os patches que a equipe concorda que devem ser integrados. Também atuam como uma verificação final para garantir que os patches sejam seguros e alinhados aos objetivos do projeto. O papel dos mantenedores decorre do consenso entre os contribuidores do projeto.
 
 ### Contribuidores
 

--- a/_posts/pt_BR/pages/2016-01-01-about.md
+++ b/_posts/pt_BR/pages/2016-01-01-about.md
@@ -1,0 +1,40 @@
+---
+title: Sobre
+name: about
+permalink: /pt_BR/about/
+type: pages
+layout: page
+lang: pt_BR
+version: 3
+#redirect_from:
+#  - /zh_TW/about/
+#  - /en/team/
+---
+
+## Sobre nós
+
+O Bitcoin Core é um projeto de [código aberto](https://opensource.org/) que mantém e publica o software cliente do Bitcoin chamado "Bitcoin Core".
+
+Ele é um descendente direto do software cliente original do Bitcoin publicado por Satoshi Nakamoto após a divulgação do famoso [whitepaper do Bitcoin](/bitcoin.pdf).
+
+O [Bitcoin Core](https://github.com/bitcoin/bitcoin) consiste tanto no software de "nó completo" (full node) para validar integralmente a blockchain quanto em uma carteira bitcoin. O projeto também mantém atualmente softwares relacionados, como a biblioteca de criptografia [libsecp256k1](https://github.com/bitcoin-core/secp256k1) e outros disponíveis no [GitHub](https://github.com/bitcoin-core).
+
+Qualquer pessoa pode [contribuir com o Bitcoin Core](/en/contribute/).  <!-- XXX /pt_BR/contribute quando disponível XXX -->
+
+## Equipe
+
+O projeto Bitcoin Core tem uma grande comunidade de desenvolvedores de código aberto, com muitos contribuidores ocasionais ao código.
+Há muitos outros que contribuem com pesquisa, revisão por pares, testes, documentação e tradução.
+
+### Mantenedores
+
+Os mantenedores do projeto têm acesso de commit e são responsáveis por integrar os patches dos contribuidores. Eles exercem um papel de curadoria, integrando os patches que a equipe concorda que devem ser integrados. Também atuam como uma verificação final para garantir que os patches sejam seguros e alinhados aos objetivos do projeto. O papel dos mantenedores decorre do acordo entre os contribuidores do projeto.
+
+### Contribuidores
+
+Qualquer pessoa é livre para propor alterações de código e para testar, revisar e comentar Pull Requests abertos.
+Qualquer pessoa que contribua com código, revisão, testes, tradução ou documentação ao projeto Bitcoin Core é considerada um contribuidor.
+As notas de versão de cada lançamento do software Bitcoin Core contêm uma seção de créditos para reconhecer todos aqueles que contribuíram com o projeto durante o ciclo de lançamento anterior.
+Uma lista dos contribuidores de código pode ser encontrada no [Github][github-contributors].
+
+{% include references.md %}

--- a/_posts/pt_BR/pages/2016-01-01-about.md
+++ b/_posts/pt_BR/pages/2016-01-01-about.md
@@ -25,7 +25,7 @@ Há muitos outros que contribuem com pesquisa, revisão por pares, testes, docum
 
 ### Mantenedores
 
-Os mantenedores do projeto têm acesso de commit e são responsáveis por integrar os patches dos contribuidores. Eles exercem um papel de curadoria, integrando os patches que a equipe concorda que devem ser integrados. Também atuam como uma verificação final para garantir que os patches sejam seguros e alinhados aos objetivos do projeto. O papel dos mantenedores decorre do acordo entre os contribuidores do projeto.
+Os mantenedores do projeto têm acesso de commit e são responsáveis por incorporar os patches dos contribuidores. Eles exercem um papel de curadoria, integrando os patches que a equipe concorda que devem ser integrados. Também atuam como uma verificação final para garantir que os patches sejam seguros e alinhados aos objetivos do projeto. O papel dos mantenedores decorre do consenso entre os contribuidores do projeto.
 
 ### Contribuidores
 

--- a/_posts/pt_BR/pages/2016-01-01-about.md
+++ b/_posts/pt_BR/pages/2016-01-01-about.md
@@ -6,9 +6,6 @@ type: pages
 layout: page
 lang: pt_BR
 version: 3
-#redirect_from:
-#  - /zh_TW/about/
-#  - /en/team/
 ---
 
 ## Sobre nós

--- a/_posts/pt_BR/pages/2016-01-01-index.md
+++ b/_posts/pt_BR/pages/2016-01-01-index.md
@@ -1,0 +1,13 @@
+---
+layout: home
+type: pages
+lang: pt_BR
+title: Bitcoin
+name: index
+permalink: /pt_BR/
+version: 2
+tags: [bitcoin, bitcoin core]
+translated: true
+---
+
+Bitcoin

--- a/_posts/pt_BR/pages/2016-03-21-rss.md
+++ b/_posts/pt_BR/pages/2016-03-21-rss.md
@@ -1,0 +1,10 @@
+---
+title: RSS Feeds
+name: rss
+permalink: /pt_BR/rss/
+type: pages
+layout: page
+lang: pt_BR
+version: 1
+---
+{% include pages/rss.html %}

--- a/assets/feeds/feed-pt_BR.xml
+++ b/assets/feeds/feed-pt_BR.xml
@@ -1,0 +1,6 @@
+---
+layout: feed
+sitemap: false
+lang: pt_BR
+permalink: /pt_BR/feed.xml
+---

--- a/assets/meeting_rss/rss-pt_BR.xml
+++ b/assets/meeting_rss/rss-pt_BR.xml
@@ -1,0 +1,7 @@
+---
+layout: meetingrss
+type: rss
+sitemap: false
+lang: pt_BR
+permalink: /pt_BR/meetingrss.xml
+---

--- a/assets/rss/rss-pt_BR.xml
+++ b/assets/rss/rss-pt_BR.xml
@@ -1,0 +1,7 @@
+---
+layout: rss
+type: rss
+sitemap: false
+lang: pt_BR
+permalink: /pt_BR/rss.xml
+---


### PR DESCRIPTION
This adds Brazilian Portuguese (pt_BR) as a new language, starting with the about page.

Changes:
- languages.yml: add pt_BR entry
- translations.yml: add pt_BR UI strings
- navigation.yml: add pt_BR menu; untranslated entries point to /en/ following the existing es/ja pattern
- _posts/pt_BR/pages/2016-01-01-about.md: translated about page

This is intended as the first step of an incremental pt_BR effort. I plan to follow up with additional static pages (contribute, contact, meetings, lifecycle) one at a time. Feedback on the translation and structure is welcome.