### PR TITLE
Add Brazilian Portuguese (pt_BR) translation for the contribute page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -254,8 +254,8 @@ pt_BR:
     submenu: true
     tree:
       contribute:
-        title: "contribuir"  # XXX
-        url:   "/en/contribute/"  # XXX
+        title: "contribuir"
+        url:   "/pt_BR/contribute/"
       contribute-code:
         title: "contribuir com código"  # XXX
         url:   "/en/faq/contributing-code/"  # XXX

--- a/_posts/pt_BR/pages/2016-01-01-about.md
+++ b/_posts/pt_BR/pages/2016-01-01-about.md
@@ -16,7 +16,7 @@ Ele é um descendente direto do software cliente original do Bitcoin publicado p
 
 O [Bitcoin Core](https://github.com/bitcoin/bitcoin) consiste tanto no software de "nó completo" (full node) para validar integralmente a blockchain quanto em uma carteira bitcoin. O projeto também mantém atualmente softwares relacionados, como a biblioteca de criptografia [libsecp256k1](https://github.com/bitcoin-core/secp256k1) e outros disponíveis no [GitHub](https://github.com/bitcoin-core).
 
-Qualquer pessoa pode [contribuir com o Bitcoin Core](/en/contribute/).  <!-- XXX /pt_BR/contribute quando disponível XXX -->
+Qualquer pessoa pode [contribuir com o Bitcoin Core](/pt_BR/contribute/).
 
 ## Equipe
 

--- a/_posts/pt_BR/pages/2016-01-01-contribute.md
+++ b/_posts/pt_BR/pages/2016-01-01-contribute.md
@@ -1,0 +1,43 @@
+---
+title: Como posso contribuir?
+name: contribute
+id: pt_BR-contribute
+permalink: /pt_BR/contribute/
+type: pages
+layout: page
+lang: pt_BR
+version: 5
+---
+
+Contribuições para o projeto são sempre bem-vindas!
+Nosso repositório principal de código-fonte está [hospedado no GitHub](https://github.com/bitcoin/bitcoin/) e você pode ajudar de várias maneiras:
+
+  - Melhorar nossa documentação (veja o [README.md][README.md] e a [pasta doc][doc])
+  - [Traduções][translation_process.md]
+  - Testar o código e as versões lançadas
+  - Participar das listas de e-mail
+  - Melhorar nossas interfaces (UIs)
+  - Programar (corrigir issues abertas ou implementar novos recursos)
+
+Sinta-se à vontade para reportar [issues][issues] e abrir [pull requests][pulls], mas por favor consulte as [diretrizes de contribuição](/en/faq/contributing-code) para entender nosso fluxo de trabalho.
+
+**Discussão**
+
+A maior parte das discussões relacionadas ao Bitcoin Core acontece nos seguintes canais IRC em irc.libera.chat:
+
+- [#bitcoin-core-dev] - Discussão principal
+- [#bitcoin-core-builds] - Discussão sobre o sistema de build e os lançamentos
+- [#bitcoin-core-gui] - Discussão sobre a interface gráfica do usuário
+
+Há também uma lista de e-mail para discussão sobre o protocolo Bitcoin [bitcoin-dev][].
+
+**Contribua com este site**
+
+Você também pode traduzir ou contribuir com este [site][website-contrib].
+
+[README.md]: https://github.com/bitcoin/bitcoin/blob/master/README.md
+[doc]: https://github.com/bitcoin/bitcoin/tree/master/doc
+[translation_process.md]: https://github.com/bitcoin/bitcoin/blob/master/doc/translation_process.md
+[website-contrib]: https://github.com/bitcoin-core/bitcoincore.org/blob/master/CONTRIBUTING.md
+
+{% include references.md %}


### PR DESCRIPTION
Follow-up to #1260, adding the second page of the incremental pt_BR translation effort.

Changes:
- Translate `_posts/pt_BR/pages/2016-01-01-contribute.md`
- Update `navigation.yml` to point the pt_BR contribute entry to `/pt_BR/contribute/` and remove its XXX markers
- Update the About page so the contribute link no longer points to the `/en/` placeholder

Next pages planned (one at a time): contact, meetings, lifecycle.