### PR TITLE
Add Brazilian Portuguese (pt_BR) translation for the contact page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -270,8 +270,8 @@ pt_BR:
     submenu: true
     tree:
       contact_us:
-        title: "Fale conosco"  # XXX
-        url: "/en/contact/"  # XXX
+        title: "Fale conosco"
+        url: "/pt_BR/contact/"
       announcements:
         title: "Comunicados"  # XXX
         url: "/en/list/announcements/join/"  # XXX

--- a/_posts/pt_BR/pages/2016-03-12-contact.md
+++ b/_posts/pt_BR/pages/2016-03-12-contact.md
@@ -1,0 +1,35 @@
+---
+title: Fale conosco
+name: contact
+permalink: /pt_BR/contact/
+type: pages
+layout: page
+lang: pt_BR
+version: 2
+---
+
+<center>
+<hr>
+<i style="font-weight: bold;font-size: 184%;">O Bitcoin Core <span style="color:red">não</span> oferece <wbr>suporte técnico.
+</i>
+<i style="font-weight: regular;font-size: medium;"><br>O suporte da comunidade pode ser encontrado em <a style="color:black;font-weight: bold;" href="https://bitcoin.stackexchange.com/">bitcoin.stackexchange.com</a></i>
+<hr>
+</center>
+
+<span style="color:black">X: <a href="https://x.com/bitcoincoreorg/">@bitcoincoreorg</a></span>
+
+Você pode reportar bugs em nosso software usando o <i class="fa fa-fw fa-github"></i> [rastreador de issues][issues].
+
+Você pode encontrar os desenvolvedores do Bitcoin Core no [IRC][#bitcoin-core-dev].
+
+## Chaves GPG
+
+As chaves a seguir podem ser usadas para comunicar informações sensíveis aos
+desenvolvedores:
+{% include dev-keys.md %}
+Para reportar problemas neste site, por favor, use o rastreador de issues do [site][website-issues].
+<i style="font-weight:regular; font-size: medium;"><br><a style="color:black" href="https://en.wikipedia.org/wiki/Responsible_disclosure">RESPONSIBLE DISCLOSURE</a></i>
+<br>
+Para reportar problemas de segurança: <i class="fa fa-fw fa-envelope"></i> security<span style="display:none"></span>@bitcoincore.org (<i style="color:red">não é para suporte</i>).
+<hr>
+{% include references.md %}


### PR DESCRIPTION
Third page of the incremental pt_BR translation effort (#1260, #1271).

Changes:
- Translate _posts/pt_BR/pages/2016-03-12-contact.md
- Update navigation.yml to point the pt_BR contact entry to /pt_BR/contact/ and remove its XXX placeholders

Note: the security contact email markup (including the anti-spam span) and all styling are preserved byte-for-byte from the English page; only the surrounding text is translated. "Responsible disclosure" is kept in English as an established security term.

Next pages: meetings, lifecycle.