### PR TITLE
Add Brazilian Portuguese (pt_BR) translation for the meetings page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -260,8 +260,8 @@ pt_BR:
         title: "contribuir com código"  # XXX
         url:   "/en/faq/contributing-code/"  # XXX
       meetings:
-        title: "reuniões"  # XXX
-        url:   "/en/meetings/"  # XXX
+        title: "reuniões"
+        url:   "/pt_BR/meetings/"
       eol:
         title: "Ciclo de vida"  # XXX
         url:   "/en/lifecycle"  # XXX

--- a/_posts/pt_BR/pages/2016-01-01-meetings.md
+++ b/_posts/pt_BR/pages/2016-01-01-meetings.md
@@ -1,0 +1,35 @@
+---
+type: pages
+layout: page
+lang: pt_BR
+title: Reuniões IRC
+name: meetings
+permalink: /pt_BR/meetings/
+version: 4
+---
+O projeto realiza várias reuniões recorrentes no canal IRC `#bitcoin-core-dev`
+no Libera Chat ([webchat][bitcoin-core-dev-IRC-webchat]). Todos são bem-vindos a participar. Os logs e
+as atas de reunião geradas automaticamente podem ser encontrados [aqui][erisian] e [aqui][schnelli].
+
+Os horários atuais das reuniões estão disponíveis na wiki dos desenvolvedores:
+
+- Reunião geral de desenvolvedores: https://github.com/bitcoin-core/bitcoin-devwiki/wiki/General-IRC-meeting
+
+[Aqui em formato iCal][meeting calendar ical] para adicionar o calendário ao seu aplicativo de calendário.
+
+Se você tiver alguma dúvida sobre a data ou o horário de uma próxima reunião,
+por favor, pergunte no canal IRC.
+
+Qualquer pessoa interessada em contribuir com o Bitcoin Core também é
+incentivada a participar das reuniões semanais do Bitcoin Core PR Review Club,
+que acontecem em outra sala de chat. Veja [o site do Review Club][review club] para mais detalhes.
+
+Os resumos das reuniões antigas de 2015 a 2018 agora estão disponíveis em [uma
+página separada][summaries].
+
+[bitcoin-core-dev-IRC-webchat]: https://web.libera.chat/#bitcoin-core-dev
+[erisian]: https://www.erisian.com.au/bitcoin-core-dev/
+[schnelli]: https://bitcoin.jonasschnelli.ch/ircmeetings/logs/bitcoin-core-dev/
+[meeting calendar ical]: /assets/ics/irc-meeting.ics
+[review club]: https://bitcoincore.reviews/
+[summaries]: /en/meeting-summaries/


### PR DESCRIPTION
Fourth page of the incremental pt_BR translation effort (#1260, #1271, #1272).

Changes:
- Translate _posts/pt_BR/pages/2016-01-01-meetings.md
- Update navigation.yml to point the pt_BR meetings entry to /pt_BR/meetings/ and remove its XXX placeholders

Note: translated from the current English page (version 4), including the developer-wiki schedule link, both log links (erisian and schnelli) and the local ical file. The [summaries] reference keeps pointing to /en/meeting-summaries/ until that page is translated.

Next page: lifecycle.