### PR TITLE
download: Pass checksum file explicitly to GPG

### DIFF
--- a/_includes/templates/download.html
+++ b/_includes/templates/download.html
@@ -165,7 +165,7 @@
 
       <li>{{page.verify_checksums_file}}
 
-        <pre class="highlight"><code>{{GPG}} --verify SHA256SUMS.asc</code></pre></li>
+        <pre class="highlight"><code>{{GPG}} --verify SHA256SUMS.asc SHA256SUMS</code></pre></li>
 
       <li><p>{{page.check_gpg_output}}</p>
         <ol><li><p>{{page.line_starts_with}} <code>gpg: {{page.localized_gpg_good_sig}}</code></p></li>
@@ -215,7 +215,7 @@
 
       <li>{{page.verify_checksums_file}}
 
-        <pre class="highlight"><code>gpg --verify SHA256SUMS.asc</code></pre></li>
+        <pre class="highlight"><code>gpg --verify SHA256SUMS.asc SHA256SUMS</code></pre></li>
 
       <li><p>{{page.check_gpg_output}}</p>
         <ol><li><p>{{page.line_starts_with}} <code>gpg: {{page.localized_gpg_good_sig}}</code></p></li>
@@ -261,7 +261,7 @@
 
       <li>{{page.verify_checksums_file}}
 
-        <pre class="highlight"><code>gpg --verify SHA256SUMS.asc</code></pre></li>
+        <pre class="highlight"><code>gpg --verify SHA256SUMS.asc SHA256SUMS</code></pre></li>
 
       <li><p>{{page.check_gpg_output}}</p>
         <ol><li><p>{{page.line_starts_with}} <code>gpg: {{page.localized_gpg_good_sig}}</code></p></li>


### PR DESCRIPTION
The gpg man page strongly discourages relying on GPG's historical behavior of finding a detached signature's data file by stripping the signature filename's suffix.

Pass SHA256SUMS explicitly when verifying SHA256SUMS.asc, as recommended by the man page.

Only tested on linux with
```
❯ gpg --version
gpg (GnuPG) 2.4.9
```
but it should apply to distributions of the GnuPG gpg command on all supported operating systems. https://www.gnupg.org/documentation/manuals/gnupg/Operational-GPG-Commands.html